### PR TITLE
Add initializer for GDS-SSO

### DIFF
--- a/config/initializers/gds_sso.rb
+++ b/config/initializers/gds_sso.rb
@@ -1,0 +1,6 @@
+GDS::SSO.config do |config|
+  config.user_model   = 'User'
+  config.oauth_id     = ENV['OAUTH_ID']
+  config.oauth_secret = ENV['OAUTH_SECRET']
+  config.oauth_root_url = Plek.find('signon')
+end


### PR DESCRIPTION
SSO doesn't work currently, because we've not set these variables and they don't have sensible defaults.

