### PR TITLE
Get content-item basepath from url, not a form field

### DIFF
--- a/app/controllers/lookup_controller.rb
+++ b/app/controllers/lookup_controller.rb
@@ -4,7 +4,7 @@ class LookupController < ApplicationController
   end
 
   def find_by_slug
-    content_lookup = ContentLookupForm.new(params[:content_lookup_form])
+    content_lookup = ContentLookupForm.new(lookup_params)
 
     if content_lookup.valid?
       redirect_to content_path(content_lookup.content_id)
@@ -12,5 +12,11 @@ class LookupController < ApplicationController
       @lookup = content_lookup
       render 'new'
     end
+  end
+
+private
+
+  def lookup_params
+    params[:content_lookup_form] || { base_path: "/#{params[:slug]}" }
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
 
   controller :lookup do
     get '/lookup', action: :new, as: :taggings
+    get '/lookup/:slug', action: :find_by_slug
     post '/lookup', action: :find_by_slug, as: :find_by_slug
   end
 

--- a/spec/features/tagging_content_spec.rb
+++ b/spec/features/tagging_content_spec.rb
@@ -30,6 +30,12 @@ RSpec.describe "Tagging content" do
     then_i_see_my_form_with_a_not_found_error
   end
 
+  scenario "User inputs a correct basepath directly in the URL" do
+    given_there_is_a_content_item_with_tags
+    when_i_type_its_basepath_in_the_url_directly
+    then_i_am_on_the_page_for_the_item
+  end
+
   before do
     setup_tags_for_select_boxes
   end
@@ -38,6 +44,10 @@ RSpec.describe "Tagging content" do
 
   def when_i_visit_the_homepage
     visit root_path
+  end
+
+  def when_i_type_its_basepath_in_the_url_directly
+    visit "/lookup/my-content-item"
   end
 
   def and_i_am_on_the_page_for_the_item
@@ -85,6 +95,7 @@ RSpec.describe "Tagging content" do
   def then_i_am_on_the_page_for_an_item
     expect(page).to have_content 'This Is A Content Item'
   end
+  alias_method :then_i_am_on_the_page_for_the_item, :then_i_am_on_the_page_for_an_item
 
   def then_i_see_my_form_with_a_not_found_error
     expect(page).to have_content 'No page found with this path'


### PR DESCRIPTION
Save some users from having to enter a basepath via the form submission, and allow them to enter the basepath in the URL, eg `content-tagger.gov.uk/lookup/some/basepath`
