### PR TITLE
Allow setting of parent tag

### DIFF
--- a/app/forms/tagging_update_form.rb
+++ b/app/forms/tagging_update_form.rb
@@ -1,7 +1,7 @@
 class TaggingUpdateForm
   include ActiveModel::Model
   attr_accessor :content_item, :content_id, :previous_version
-  attr_reader :topics, :organisations, :mainstream_browse_pages
+  attr_reader :topics, :organisations, :mainstream_browse_pages, :parent
 
   # Return a new LinkUpdate object with topics, mainstream_browse_pages,
   # organisations and content_item set.
@@ -14,6 +14,7 @@ class TaggingUpdateForm
       topics: link_set.links['topics'],
       organisations: link_set.links['organisations'],
       mainstream_browse_pages: link_set.links['mainstream_browse_pages'],
+      parent: link_set.links['parent'],
     )
   end
 
@@ -28,6 +29,7 @@ class TaggingUpdateForm
         topics: topics,
         mainstream_browse_pages: mainstream_browse_pages,
         organisations: organisations,
+        parent: parent,
       },
       previous_version: previous_version.to_i,
     )
@@ -47,5 +49,9 @@ class TaggingUpdateForm
 
   def mainstream_browse_pages=(mainstream_browse_page_ids)
     @mainstream_browse_pages = Array(mainstream_browse_page_ids).select(&:present?)
+  end
+
+  def parent=(parent_id)
+    @parent = Array(parent_id).select(&:present?)
   end
 end

--- a/app/services/allowed_tags_for.rb
+++ b/app/services/allowed_tags_for.rb
@@ -3,7 +3,7 @@ class AllowedTagsFor
 
   def self.allowed_tag_types(content_item)
     if content_item.publishing_app.in?(MIGRATED_APPS)
-      %w(topics organisations mainstream_browse_pages)
+      %w(topics organisations mainstream_browse_pages parent)
     else
       []
     end

--- a/app/views/content/_form_for_parent.html.erb
+++ b/app/views/content/_form_for_parent.html.erb
@@ -1,0 +1,6 @@
+<h3>Parent</h3>
+
+<%= f.select :parent,
+    options_for_select(TagFetcher.new.tags_of_type('topic'), @tagging_update.parent),
+    { include_blank: true },
+    { multiple: false, class: "select2", data: { placeholder: "Choose a parent (topic)..." } } %>

--- a/spec/features/tagging_content_spec.rb
+++ b/spec/features/tagging_content_spec.rb
@@ -117,6 +117,7 @@ RSpec.describe "Tagging content" do
         topics: ["ID-OF-FIRST-TAG", "ID-OF-ALREADY-TAGGED"],
         mainstream_browse_pages: [],
         organisations: [],
+        parent: [],
       },
       previous_version: 54_321,
     }


### PR DESCRIPTION
This PR adds `parent` to the tags content can be tagged to. It is a replacement for the "primary section" tag used in panopticon.

The copy for this will be added in a later PR.

https://trello.com/c/XwVC0IM8