### PR TITLE
Rename initializer for admin template

### DIFF
--- a/config/initializers/govuk_admin_template.rb
+++ b/config/initializers/govuk_admin_template.rb
@@ -1,5 +1,1 @@
-GovukAdminTemplate.configure do |c|
-  c.app_title = "Content Tagger"
-  c.show_signout = true
-  c.show_flash = true
-end
+# This file is overwritten on deploy.

--- a/config/initializers/govuk_admin_template_config.rb
+++ b/config/initializers/govuk_admin_template_config.rb
@@ -1,0 +1,5 @@
+GovukAdminTemplate.configure do |c|
+  c.app_title = "Content Tagger"
+  c.show_signout = true
+  c.show_flash = true
+end


### PR DESCRIPTION
The file `config/initializers/govuk_admin_template.rb` is overwritten on deploy so display the environment indicators. In our case, it was overwriting our own initializer, causing the flash, app title and
logout-button to disappear.