### PR TITLE
Fix kind of content available for 'parent'

### DIFF
--- a/app/views/content/_form_for_parent.html.erb
+++ b/app/views/content/_form_for_parent.html.erb
@@ -1,6 +1,6 @@
 <h3>Parent</h3>
 
 <%= f.select :parent,
-    options_for_select(TagFetcher.new.tags_of_type('topic'), @tagging_update.parent),
+    options_for_select(TagFetcher.new.tags_of_type('mainstream_browse_page'), @tagging_update.parent),
     { include_blank: true },
     { multiple: false, class: "select2", data: { placeholder: "Choose a parent (topic)..." } } %>


### PR DESCRIPTION
The "parent" tag is the primary mainstream browse pages, so the select box should be populated with those, not the topics.

https://trello.com/c/XwVC0IM8