### PR TITLE
Use `template0` to create database

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -24,6 +24,7 @@ default: &default
 development:
   <<: *default
   database: content_tagger_development
+  template: template0
 
   # The specified database role being used to connect to postgres.
   # To create additional roles in postgres see `$ createuser --help`.
@@ -58,6 +59,7 @@ development:
 test:
   <<: *default
   database: content_tagger_test
+  template: template0
 
 # As with config/secrets.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is


### PR DESCRIPTION
Using `template0` will create the correct type of database.