### PR TITLE
Add functionality to bulk assign content items to taxons

### DIFF
--- a/lib/alpha_taxonomy/import_file.rb
+++ b/lib/alpha_taxonomy/import_file.rb
@@ -47,9 +47,7 @@ module AlphaTaxonomy
   private
 
     def check_import_file_is_present
-      unless File.exist? self.class.location
-        raise MissingImportFileError, "Run #populate to create import file"
-      end
+      raise MissingImportFileError, "Run #populate to create import file" unless File.exist? self.class.location
     end
 
     def write_headers

--- a/lib/alpha_taxonomy/import_file.rb
+++ b/lib/alpha_taxonomy/import_file.rb
@@ -8,7 +8,7 @@ module AlphaTaxonomy
     self.location = begin
       return ENV["TAXON_IMPORT_FILE"] if ENV["TAXON_IMPORT_FILE"]
       FileUtils.mkdir_p Rails.root + "lib/data/"
-      "#{Rails.root}" + "/lib/data/alpha_taxonomy_import.csv"
+      "#{Rails.root}" + "/lib/data/alpha_taxonomy_import.tsv"
     end
 
     def initialize(logger: Logger.new(STDOUT))
@@ -34,15 +34,15 @@ module AlphaTaxonomy
   private
 
     def write_headers
-      @file.write("taxon_title\tlink\n")
+      @file.write("taxon_title\tbase_path\n")
     end
 
     def write(taxonomy_data)
       relevant_columns_in(taxonomy_data).each do |row|
         mapped_to = row[0]
-        link = row[1]
+        base_path = row[1]
 
-        if mapped_to.blank? || link.blank?
+        if mapped_to.blank? || base_path.blank?
           raise BlankMappingFieldError, "Missing value in downloaded taxonomy spreadsheet"
         end
 
@@ -51,7 +51,7 @@ module AlphaTaxonomy
         else
           taxon_titles = stripped_array_of(mapped_to)
           taxon_titles.each do |taxon_title|
-            @file.write("#{taxon_title}\t#{link}\n")
+            @file.write("#{taxon_title}\t#{base_path}\n")
           end
         end
       end

--- a/lib/alpha_taxonomy/taxon_linker.rb
+++ b/lib/alpha_taxonomy/taxon_linker.rb
@@ -1,0 +1,23 @@
+require "csv"
+
+module AlphaTaxonomy
+  class TaxonLinker
+    def run!
+      ImportFile.new.grouped_mappings.each do |base_path, taxon_titles|
+        taxon_content_ids = taxon_titles.map do |taxon_title|
+          taxon_base_path = TaxonPresenter.new(title: taxon_title).base_path
+          taxon_content_item = Services.content_store.content_item!(taxon_base_path)
+          taxon_content_item["content_id"]
+        end
+        target_content_item = Services.content_store.content_item!(base_path)
+
+        Services.publishing_api.put_links(
+          target_content_item["content_id"],
+          links: {
+            alpha_taxons: taxon_content_ids
+          }
+        )
+      end
+    end
+  end
+end

--- a/lib/alpha_taxonomy/taxon_linker.rb
+++ b/lib/alpha_taxonomy/taxon_linker.rb
@@ -2,22 +2,60 @@ require "csv"
 
 module AlphaTaxonomy
   class TaxonLinker
-    def run!
-      ImportFile.new.grouped_mappings.each do |base_path, taxon_titles|
-        taxon_content_ids = taxon_titles.map do |taxon_title|
-          taxon_base_path = TaxonPresenter.new(title: taxon_title).base_path
-          taxon_content_item = Services.content_store.content_item!(taxon_base_path)
-          taxon_content_item["content_id"]
-        end
-        target_content_item = Services.content_store.content_item!(base_path)
+    class TaxonNotInContentStoreError < StandardError; end
 
+    def initialize(logger: Logger.new(STDOUT))
+      @log = logger
+      @errors = []
+    end
+
+    def run!
+      grouped_mappings = ImportFile.new.grouped_mappings
+
+      grouped_mappings.each do |base_path, taxon_titles|
+        taxon_content_ids = find_content_ids_for(taxon_titles)
+        target_content_item_id = fetch_content_item_id_with(base_path)
+
+        next unless target_content_item_id.present?
         Services.publishing_api.put_links(
-          target_content_item["content_id"],
+          target_content_item_id,
           links: {
             alpha_taxons: taxon_content_ids
           }
         )
       end
+
+      @errors.each { |err| @log.error err } if @errors.present?
+    end
+
+  private
+
+    def report_error(error_message)
+      @errors << error_message
+    end
+
+    def all_taxons
+      @all_taxons ||= Services.publishing_api.get_content_items(
+        content_format: 'taxon', fields: %i(title base_path content_id)
+      ).sort_by { |taxon| taxon["title"] }
+    end
+
+    def find_content_ids_for(taxon_titles)
+      taxon_titles.map do |taxon_title|
+        taxon_content_item = all_taxons.find { |taxon| taxon["title"] == taxon_title }
+        if taxon_content_item
+          taxon_content_item["content_id"]
+        else
+          raise TaxonNotInContentStoreError, "Use TaxonCreator#run! to ensure all taxons have been created"
+        end
+      end
+    end
+
+    def fetch_content_item_id_with(base_path)
+      lookup = ContentLookupForm.new(base_path: base_path)
+      return lookup.content_id if lookup.valid?
+      report_error(lookup.errors[:base_path])
+      nil
     end
   end
 end

--- a/spec/lib/alpha_taxonomy/import_file_spec.rb
+++ b/spec/lib/alpha_taxonomy/import_file_spec.rb
@@ -1,30 +1,33 @@
 require "rails_helper"
 
 RSpec.describe AlphaTaxonomy::ImportFile do
+  let(:test_tsv_file_path) { Rails.root + "tmp/import_file_spec.tsv" }
+  let(:sheet_downloader) { AlphaTaxonomy::SheetDownloader.new }
+
+  before do
+    allow(AlphaTaxonomy::ImportFile).to receive(:location).and_return(test_tsv_file_path)
+    allow(AlphaTaxonomy::SheetDownloader).to receive(:new).and_return(sheet_downloader)
+  end
+
+  after do
+    File.delete(test_tsv_file_path) if File.exist?(test_tsv_file_path)
+  end
+
+  def stub_downloaded_sheet_data(tsv_rows)
+    # Create a string of tsv data from an array of rows, resulting in
+    # tab-seperated values with newlines delimiting each row.
+    headers = ["mapped to\tlink"]
+    sheet_data = (headers + tsv_rows).join("\n") + "\n"
+    allow(sheet_downloader).to receive(:each_sheet).and_yield(sheet_data)
+  end
+
   describe "#populate" do
-    let(:test_tsv_file_path) { Rails.root + "tmp/import_file_spec.tsv" }
-    let(:sheet_downloader) { AlphaTaxonomy::SheetDownloader.new }
-
-    before do
-      allow(AlphaTaxonomy::ImportFile).to receive(:location).and_return(test_tsv_file_path)
-      allow(AlphaTaxonomy::SheetDownloader).to receive(:new).and_return(sheet_downloader)
-    end
-
-    after do
-      File.delete(test_tsv_file_path) if File.exist?(test_tsv_file_path)
-    end
-
-    def stub_sheet_data(tsv_rows)
-      sheet_data = (["mapped to\tlink"] + tsv_rows).join("\n") + "\n"
-      allow(sheet_downloader).to receive(:each_sheet).and_yield(sheet_data)
-    end
-
     def expected_tsv_content(tsv_rows)
       (["taxon_title\tbase_path"] + tsv_rows).join("\n") + "\n"
     end
 
     it "parses and writes the required data to a file" do
-      stub_sheet_data([
+      stub_downloaded_sheet_data([
         "Foo-Taxon\t" + "/foo-content-item-path",
         "Bar (Br)| Baz (Bz)\t" + "/bar-or-baz-content-item-path",
         "n/a - not applicable\t" + "/n/a-content-item-path",
@@ -43,7 +46,7 @@ RSpec.describe AlphaTaxonomy::ImportFile do
     end
 
     it "reports an error and removes the file if the required values aren't present" do
-      stub_sheet_data([ "\t" + "the-foo-slug", ])
+      stub_downloaded_sheet_data(["\t" + "the-foo-slug"])
 
       log_output = StringIO.new
       AlphaTaxonomy::ImportFile.new(logger: Logger.new(log_output)).populate
@@ -66,6 +69,37 @@ RSpec.describe AlphaTaxonomy::ImportFile do
       log_output.rewind
       expect(log_output.read).to match(/Column names in downloaded taxonomy data did not match expected values/)
       expect(File.exist?(test_tsv_file_path)).to be false
+    end
+  end
+
+  describe "#grouped_mappings" do
+    context "if the import file is present" do
+      before do
+        stub_downloaded_sheet_data([
+          "Foo-Taxon\t" + "/foo-content-item-path",
+          "Bar (Br)| Baz (Bz)\t" + "/bar-or-baz-content-item-path",
+        ])
+        AlphaTaxonomy::ImportFile.new.populate
+      end
+
+      it "returns lists of taxons grouped by base_path" do
+        expect(AlphaTaxonomy::ImportFile.new.grouped_mappings).to eq(
+          {
+            "/foo-content-item-path" => ["Foo-Taxon"],
+            "/bar-or-baz-content-item-path"=> ["Bar (Br)", "Baz (Bz)"]
+          }
+        )
+      end
+    end
+
+    context "if the import file is missing" do
+      it "raises an error" do
+        allow(AlphaTaxonomy::ImportFile).to receive(:location).and_return("/some-crazy-non-existing-path")
+
+        expect { AlphaTaxonomy::ImportFile.new.grouped_mappings }.to raise_error(
+          AlphaTaxonomy::ImportFile::MissingImportFileError
+        )
+      end
     end
   end
 end

--- a/spec/lib/alpha_taxonomy/import_file_spec.rb
+++ b/spec/lib/alpha_taxonomy/import_file_spec.rb
@@ -84,10 +84,8 @@ RSpec.describe AlphaTaxonomy::ImportFile do
 
       it "returns lists of taxons grouped by base_path" do
         expect(AlphaTaxonomy::ImportFile.new.grouped_mappings).to eq(
-          {
-            "/foo-content-item-path" => ["Foo-Taxon"],
-            "/bar-or-baz-content-item-path"=> ["Bar (Br)", "Baz (Bz)"]
-          }
+          "/foo-content-item-path" => ["Foo-Taxon"],
+          "/bar-or-baz-content-item-path" => ["Bar (Br)", "Baz (Bz)"]
         )
       end
     end

--- a/spec/lib/alpha_taxonomy/import_file_spec.rb
+++ b/spec/lib/alpha_taxonomy/import_file_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe AlphaTaxonomy::ImportFile do
-  let(:test_tsv_file_path) { Rails.root + "tmp/import_file_spec.tsv" }
+  let(:test_tsv_file_path) { "/tmp/import_file_spec.tsv" }
   let(:sheet_downloader) { AlphaTaxonomy::SheetDownloader.new }
 
   before do

--- a/spec/lib/alpha_taxonomy/import_file_spec.rb
+++ b/spec/lib/alpha_taxonomy/import_file_spec.rb
@@ -13,26 +13,44 @@ RSpec.describe AlphaTaxonomy::ImportFile do
     after do
       File.delete(test_tsv_file_path) if File.exist?(test_tsv_file_path)
     end
+
+    def stub_sheet_data(tsv_rows)
+      sheet_data = (["mapped to\tlink"] + tsv_rows).join("\n") + "\n"
+      allow(sheet_downloader).to receive(:each_sheet).and_yield(sheet_data)
+    end
+
+    def expected_tsv_content(tsv_rows)
+      (["taxon_title\tbase_path"] + tsv_rows).join("\n") + "\n"
     end
 
     it "parses and writes the required data to a file" do
-      test_tsv_data = [
-        "mapped to\t" + "link",
-        "Foo-Taxon\t" + "the-foo-link",
-        "Bar (Br)| Baz (Bz)\t" + "the-bar-or-baz-link",
-        "n/a - not applicable\t" + "the-n/a-link",
-      ].join("\n")
-      allow(sheet_downloader).to receive(:each_sheet).and_yield(test_tsv_data)
+      stub_sheet_data([
+        "Foo-Taxon\t" + "/foo-content-item-path",
+        "Bar (Br)| Baz (Bz)\t" + "/bar-or-baz-content-item-path",
+        "n/a - not applicable\t" + "/n/a-content-item-path",
+      ])
 
       AlphaTaxonomy::ImportFile.new.populate
 
       populated_file = File.open(test_tsv_file_path)
-      expect(populated_file.read.split("\n")).to eq([
-        "taxon_title\tlink",
-        "Foo-Taxon\tthe-foo-link",
-        "Bar (Br)\tthe-bar-or-baz-link",
-        "Baz (Bz)\tthe-bar-or-baz-link"
-      ])
+      expect(populated_file.read).to eq(
+        expected_tsv_content([
+          "Foo-Taxon\t/foo-content-item-path",
+          "Bar (Br)\t/bar-or-baz-content-item-path",
+          "Baz (Bz)\t/bar-or-baz-content-item-path"
+        ])
+      )
+    end
+
+    it "reports an error and removes the file if the required values aren't present" do
+      stub_sheet_data([ "\t" + "the-foo-slug", ])
+
+      log_output = StringIO.new
+      AlphaTaxonomy::ImportFile.new(logger: Logger.new(log_output)).populate
+
+      log_output.rewind
+      expect(log_output.read).to match(/Missing value in downloaded taxonomy spreadsheet/)
+      expect(File.exist?(test_tsv_file_path)).to be false
     end
 
     it "reports an error and removes the file if the expected columns aren't present" do
@@ -47,21 +65,6 @@ RSpec.describe AlphaTaxonomy::ImportFile do
 
       log_output.rewind
       expect(log_output.read).to match(/Column names in downloaded taxonomy data did not match expected values/)
-      expect(File.exist?(test_tsv_file_path)).to be false
-    end
-
-    it "reports an error and removes the file if the required values aren't present" do
-      test_tsv_data = [
-        "mapped to\t" + "link",
-        "\t" + "the-foo-slug",
-      ].join("\n")
-      allow(sheet_downloader).to receive(:each_sheet).and_yield(test_tsv_data)
-
-      log_output = StringIO.new
-      AlphaTaxonomy::ImportFile.new(logger: Logger.new(log_output)).populate
-
-      log_output.rewind
-      expect(log_output.read).to match(/Missing value in downloaded taxonomy spreadsheet/)
       expect(File.exist?(test_tsv_file_path)).to be false
     end
   end

--- a/spec/lib/alpha_taxonomy/import_file_spec.rb
+++ b/spec/lib/alpha_taxonomy/import_file_spec.rb
@@ -1,17 +1,18 @@
 require "rails_helper"
 
 RSpec.describe AlphaTaxonomy::ImportFile do
-  describe ".populate" do
-    let(:test_output_path) { Rails.root + "tmp/import_file_spec.csv" }
+  describe "#populate" do
+    let(:test_tsv_file_path) { Rails.root + "tmp/import_file_spec.tsv" }
     let(:sheet_downloader) { AlphaTaxonomy::SheetDownloader.new }
 
     before do
-      allow(AlphaTaxonomy::ImportFile).to receive(:location).and_return(test_output_path)
+      allow(AlphaTaxonomy::ImportFile).to receive(:location).and_return(test_tsv_file_path)
       allow(AlphaTaxonomy::SheetDownloader).to receive(:new).and_return(sheet_downloader)
     end
 
     after do
-      File.delete(test_output_path) if File.exist?(test_output_path)
+      File.delete(test_tsv_file_path) if File.exist?(test_tsv_file_path)
+    end
     end
 
     it "parses and writes the required data to a file" do
@@ -25,7 +26,7 @@ RSpec.describe AlphaTaxonomy::ImportFile do
 
       AlphaTaxonomy::ImportFile.new.populate
 
-      populated_file = File.open(test_output_path)
+      populated_file = File.open(test_tsv_file_path)
       expect(populated_file.read.split("\n")).to eq([
         "taxon_title\tlink",
         "Foo-Taxon\tthe-foo-link",
@@ -46,7 +47,7 @@ RSpec.describe AlphaTaxonomy::ImportFile do
 
       log_output.rewind
       expect(log_output.read).to match(/Column names in downloaded taxonomy data did not match expected values/)
-      expect(File.exist?(test_output_path)).to be false
+      expect(File.exist?(test_tsv_file_path)).to be false
     end
 
     it "reports an error and removes the file if the required values aren't present" do
@@ -61,7 +62,7 @@ RSpec.describe AlphaTaxonomy::ImportFile do
 
       log_output.rewind
       expect(log_output.read).to match(/Missing value in downloaded taxonomy spreadsheet/)
-      expect(File.exist?(test_output_path)).to be false
+      expect(File.exist?(test_tsv_file_path)).to be false
     end
   end
 end

--- a/spec/lib/alpha_taxonomy/taxon_linker_spec.rb
+++ b/spec/lib/alpha_taxonomy/taxon_linker_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+RSpec.describe AlphaTaxonomy::TaxonLinker do
+  describe "#run!" do
+    def stub_taxon_fetch(title:, content_id:)
+      allow(Services.content_store).to receive(:content_item!).with(
+        AlphaTaxonomy::TaxonPresenter.new(title: title).base_path
+      ).and_return("content_id" => content_id)
+    end
+
+    def stub_content_item_fetch(base_path:, content_id:)
+      allow(Services.content_store).to receive(:content_item!).with(
+        base_path
+      ).and_return("content_id" => content_id)
+    end
+
+    it "creates taxon links based on the grouped mappings" do
+      import_file = AlphaTaxonomy::ImportFile.new
+      allow(import_file).to receive(:grouped_mappings).and_return(
+        "/a-foo-content-item" => ["Foo Taxon"],
+        "/a-foo-bar-content-item" => ["Foo Taxon", "Bar Taxon"]
+      )
+      allow(AlphaTaxonomy::ImportFile).to receive(:new).and_return(import_file)
+
+      stub_taxon_fetch(title: "Foo Taxon", content_id: "foo-taxon-uuid")
+      stub_taxon_fetch(title: "Bar Taxon", content_id: "bar-taxon-uuid")
+      stub_content_item_fetch(base_path: "/a-foo-content-item", content_id: "foo-item-uuid")
+      stub_content_item_fetch(base_path: "/a-foo-bar-content-item", content_id: "foo-bar-item-uuid")
+
+      expect(Services.publishing_api).to receive(:put_links).with(
+        "foo-item-uuid",
+        links: { alpha_taxons: ["foo-taxon-uuid"] }
+      ).once
+      expect(Services.publishing_api).to receive(:put_links).with(
+        "foo-bar-item-uuid",
+        links: { alpha_taxons: ["foo-taxon-uuid", "bar-taxon-uuid"] }
+      ).once
+
+      AlphaTaxonomy::TaxonLinker.new.run!
+    end
+  end
+end

--- a/spec/lib/alpha_taxonomy/taxon_linker_spec.rb
+++ b/spec/lib/alpha_taxonomy/taxon_linker_spec.rb
@@ -2,30 +2,35 @@ require "rails_helper"
 
 RSpec.describe AlphaTaxonomy::TaxonLinker do
   describe "#run!" do
-    def stub_taxon_fetch(title:, content_id:)
-      allow(Services.content_store).to receive(:content_item!).with(
-        AlphaTaxonomy::TaxonPresenter.new(title: title).base_path
-      ).and_return("content_id" => content_id)
+    def stub_taxons_fetch(returned_taxon_collection)
+      allow(Services.publishing_api).to receive(:get_content_items).with(
+        content_format: 'taxon', fields: %i(title base_path content_id)
+      ).and_return(returned_taxon_collection.map(&:stringify_keys))
     end
 
-    def stub_content_item_fetch(base_path:, content_id:)
-      allow(Services.content_store).to receive(:content_item!).with(
-        base_path
-      ).and_return("content_id" => content_id)
+    def stub_content_item_lookup(base_path:, content_id:)
+      lookup = double(valid?: true)
+      allow(lookup).to receive(:content_id).and_return(content_id)
+      allow(ContentLookupForm).to receive(:new).with(base_path: base_path).and_return(lookup)
+    end
+
+    def stub_import_file_mappings(returned_mappings)
+      import_file = AlphaTaxonomy::ImportFile.new
+      allow(import_file).to receive(:grouped_mappings).and_return(returned_mappings)
+      allow(AlphaTaxonomy::ImportFile).to receive(:new).and_return(import_file)
     end
 
     it "creates taxon links based on the grouped mappings" do
-      import_file = AlphaTaxonomy::ImportFile.new
-      allow(import_file).to receive(:grouped_mappings).and_return(
+      stub_import_file_mappings(
         "/a-foo-content-item" => ["Foo Taxon"],
         "/a-foo-bar-content-item" => ["Foo Taxon", "Bar Taxon"]
       )
-      allow(AlphaTaxonomy::ImportFile).to receive(:new).and_return(import_file)
-
-      stub_taxon_fetch(title: "Foo Taxon", content_id: "foo-taxon-uuid")
-      stub_taxon_fetch(title: "Bar Taxon", content_id: "bar-taxon-uuid")
-      stub_content_item_fetch(base_path: "/a-foo-content-item", content_id: "foo-item-uuid")
-      stub_content_item_fetch(base_path: "/a-foo-bar-content-item", content_id: "foo-bar-item-uuid")
+      stub_taxons_fetch([
+        { title: "Foo Taxon", content_id: "foo-taxon-uuid" },
+        { title: "Bar Taxon", content_id: "bar-taxon-uuid" },
+      ])
+      stub_content_item_lookup(base_path: "/a-foo-content-item", content_id: "foo-item-uuid")
+      stub_content_item_lookup(base_path: "/a-foo-bar-content-item", content_id: "foo-bar-item-uuid")
 
       expect(Services.publishing_api).to receive(:put_links).with(
         "foo-item-uuid",
@@ -37,6 +42,40 @@ RSpec.describe AlphaTaxonomy::TaxonLinker do
       ).once
 
       AlphaTaxonomy::TaxonLinker.new.run!
+    end
+
+    context "when the grouped mappings contain a taxon not present in the content store" do
+      it "raises an error" do
+        stub_import_file_mappings("/a-foo-content-item" => ["Foo Taxon"])
+        stub_taxons_fetch([{ title: "Other taxon", content_id: "irrelevant" }])
+
+        expect { AlphaTaxonomy::TaxonLinker.new.run! }.to raise_error(
+          AlphaTaxonomy::TaxonLinker::TaxonNotInContentStoreError
+        )
+      end
+    end
+
+    context "when the target content_item is not found by the lookup" do
+      before do
+        stub_import_file_mappings("/a-foo-content-item" => ["Foo Taxon"], "/invalid-content-item" => ["Foo Taxon"])
+        stub_taxons_fetch([{ title: "Foo Taxon", content_id: "foo-taxon-uuid" }])
+        stub_content_item_lookup(base_path: "/a-foo-content-item", content_id: "foo-item-uuid")
+
+        invalid_lookup = double(valid?: false, errors: { base_path: "something went wrong" })
+        allow(ContentLookupForm).to receive(:new).with(base_path: "/invalid-content-item").and_return(invalid_lookup)
+      end
+
+      it "does not create a link and reports the error" do
+        expect(Services.publishing_api).to receive(:put_links).with(
+          "foo-item-uuid",
+          links: { alpha_taxons: ["foo-taxon-uuid"] }
+        ).once
+
+        log_output = StringIO.new
+        AlphaTaxonomy::TaxonLinker.new(logger: Logger.new(log_output)).run!
+        log_output.rewind
+        expect(log_output.read).to match(/something went wrong/)
+      end
     end
   end
 end


### PR DESCRIPTION
This is required as part of the functionality to bulk assign content
items to taxons, based on the alpha taxonomy data that is currently
being produced by Information Architects in the Finding Things team.

This change adds a method which inspects the locally-downloaded taxonomy
data and groups list of taxons to each base path. Part of this change
includes moving the actual file creation to the #populate method rather
than doing this on initialize. Any client of the ImportFile class will
have to ensure the file is created via #populate before calling anything
else.

Trello: https://trello.com/c/bsZAwZ35