### PR TITLE
Enable hmrc-manuals-api for tagging

### DIFF
--- a/config/tagging-apps.yml
+++ b/config/tagging-apps.yml
@@ -16,7 +16,7 @@ external-link-tracker:
 feedback:
 frontend:
 govuk_content_api:
-hmrc-manuals-api:
+hmrc-manuals-api: content-tagger
 info-frontend:
 licencefinder: content-tagger
 manuals-frontend:


### PR DESCRIPTION
We are currently migrating it to the new tagging architecture, and need
to have tagging in content-tagger enabled before dropping the existing
tagging mechanism.