### PR TITLE
Adds policy-publisher

### DIFF
--- a/config/tagging-apps.yml
+++ b/config/tagging-apps.yml
@@ -21,7 +21,7 @@ info-frontend:
 licencefinder: content-tagger
 manuals-frontend:
 performanceplatform-big-screen-view:
-policy-publisher:
+policy-publisher: content-tagger
 publisher: publisher
 rummager:
 service-manual-publisher:


### PR DESCRIPTION
Part of https://trello.com/c/BQDQ824W/468-use-publishing-api-v2-for-policy-publisher