### PR TITLE
Allow tagging of collections-publisher documents

### DIFF
--- a/config/tagging-apps.yml
+++ b/config/tagging-apps.yml
@@ -7,7 +7,7 @@ a-migrated-app: content-tagger # for testing puposes
 businesssupportfinder: content-tagger
 calculators: content-tagger
 calendars: content-tagger
-collections-publisher: collections-publisher
+collections-publisher: content-tagger
 contacts: panopticon
 contacts-admin:
 design-principles:


### PR DESCRIPTION
`collections-publisher` publishes topics and mainstream browse pages. This commit allows those pages to be tagged.

This allows users, for example, to add link topics to other topics, and add organisations to topics. There are no plans to do this, but we want as few special cases as possible. It would be therefore be good to
treat the pages managed by collections-publisher as just a normal piece of content on GOV.UK.

After this is merged, collections-publisher should also be added to the list in https://github.com/alphagov/rummager/pull/555.

Trello: https://trello.com/c/GRt7NSbL