### PR TITLE
Allow tagging to alpha taxonomy

### DIFF
--- a/app/forms/tagging_update_form.rb
+++ b/app/forms/tagging_update_form.rb
@@ -1,7 +1,7 @@
 class TaggingUpdateForm
   include ActiveModel::Model
   attr_accessor :content_item, :content_id, :previous_version
-  attr_reader :topics, :organisations, :mainstream_browse_pages, :parent
+  attr_reader :topics, :organisations, :mainstream_browse_pages, :parent, :alpha_taxons
 
   # Return a new LinkUpdate object with topics, mainstream_browse_pages,
   # organisations and content_item set.
@@ -15,6 +15,7 @@ class TaggingUpdateForm
       organisations: link_set.links['organisations'],
       mainstream_browse_pages: link_set.links['mainstream_browse_pages'],
       parent: link_set.links['parent'],
+      alpha_taxons: link_set.links['alpha_taxons'],
     )
   end
 
@@ -30,6 +31,7 @@ class TaggingUpdateForm
         mainstream_browse_pages: mainstream_browse_pages,
         organisations: organisations,
         parent: parent,
+        alpha_taxons: alpha_taxons,
       },
       previous_version: previous_version.to_i,
     )
@@ -49,5 +51,9 @@ class TaggingUpdateForm
 
   def parent=(parent_id)
     @parent = Array(parent_id).select(&:present?)
+  end
+
+  def alpha_taxons=(taxon_id)
+    @alpha_taxons = Array(taxon_id).select(&:present?)
   end
 end

--- a/app/forms/tagging_update_form.rb
+++ b/app/forms/tagging_update_form.rb
@@ -35,10 +35,6 @@ class TaggingUpdateForm
     )
   end
 
-  def allowed_tag_types
-    AllowedTagsFor.allowed_tag_types(content_item)
-  end
-
   def topics=(topic_ids)
     @topics = Array(topic_ids).select(&:present?)
   end

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -1,4 +1,6 @@
 class ContentItem
+  TAG_TYPES = %w(mainstream_browse_pages parent topics organisations)
+
   attr_reader :content_id, :title, :format, :base_path, :publishing_app
 
   def initialize(data)
@@ -17,6 +19,10 @@ class ContentItem
 
   def link_set
     @link_set ||= LinkSet.find(content_id)
+  end
+
+  def tagging_allowed?
+    app_responsible_for_tagging == "content-tagger"
   end
 
   def app_responsible_for_tagging

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -1,5 +1,5 @@
 class ContentItem
-  TAG_TYPES = %w(mainstream_browse_pages parent topics organisations)
+  TAG_TYPES = %w(mainstream_browse_pages parent topics organisations alpha_taxons)
 
   attr_reader :content_id, :title, :format, :base_path, :publishing_app
 

--- a/app/services/allowed_tags_for.rb
+++ b/app/services/allowed_tags_for.rb
@@ -1,9 +1,0 @@
-class AllowedTagsFor
-  def self.allowed_tag_types(content_item)
-    if content_item.app_responsible_for_tagging == "content-tagger"
-      %w(mainstream_browse_pages parent topics organisations)
-    else
-      []
-    end
-  end
-end

--- a/app/views/content/_form_for_alpha_taxons.html.erb
+++ b/app/views/content/_form_for_alpha_taxons.html.erb
@@ -1,0 +1,10 @@
+<h3>Alpha taxonomy</h3>
+
+<%= f.select :alpha_taxons,
+    options_for_select(TagFetcher.new.tags_of_type('taxon'), @tagging_update.alpha_taxons),
+    {},
+    { multiple: true, class: "select2", data: { placeholder: "Choose alpha taxons..." } } %>
+
+<p class='explain'>
+  The alpha taxonomy is currently being developed by the Finding Things team.
+</p>

--- a/app/views/content/_tagging_form.html.erb
+++ b/app/views/content/_tagging_form.html.erb
@@ -2,7 +2,7 @@
   <%= f.hidden_field :content_id %>
   <%= f.hidden_field :previous_version %>
 
-  <% @tagging_update.allowed_tag_types.each do |tag_type| %>
+  <% ContentItem::TAG_TYPES.each do |tag_type| %>
     <div class='tag-section'>
       <%= render "form_for_#{tag_type}", f: f %>
     </div>

--- a/app/views/content/show.html.erb
+++ b/app/views/content/show.html.erb
@@ -6,7 +6,7 @@
 
 <hr/>
 
-<% if @tagging_update.allowed_tag_types.any? %>
+<% if @content_item.tagging_allowed? %>
   <%= render 'tagging_form' %>
 <% else %>
   <%= render 'not_migrated_yet' %>

--- a/spec/features/tagging_content_spec.rb
+++ b/spec/features/tagging_content_spec.rb
@@ -150,6 +150,7 @@ RSpec.describe "Tagging content" do
         mainstream_browse_pages: [],
         organisations: [],
         parent: [],
+        alpha_taxons: [],
       },
       previous_version: 54_321,
     }
@@ -171,13 +172,9 @@ RSpec.describe "Tagging content" do
       }
     ]
 
-    stub_request(:get, "#{PUBLISHING_API}/v2/content?content_format=topic&fields%5B%5D=content_id&fields%5B%5D=title&fields%5B%5D=details")
-      .to_return(body: content.to_json)
-
-    stub_request(:get, "#{PUBLISHING_API}/v2/content?content_format=organisation&fields%5B%5D=content_id&fields%5B%5D=title&fields%5B%5D=details")
-      .to_return(body: content.to_json)
-
-    stub_request(:get, "#{PUBLISHING_API}/v2/content?content_format=mainstream_browse_page&fields%5B%5D=content_id&fields%5B%5D=title&fields%5B%5D=details")
-      .to_return(body: content.to_json)
+    %w(topic organisation mainstream_browse_page taxon).each do |content_format|
+      stub_request(:get, "#{PUBLISHING_API}/v2/content?content_format=#{content_format}&fields%5B%5D=content_id&fields%5B%5D=title&fields%5B%5D=details")
+        .to_return(body: content.to_json)
+    end
   end
 end


### PR DESCRIPTION
Alpha taxons are being developed by Finding Things IAs. Currently the only way to tag to this link type is via the bulk importer. This change allows us to tag to the alpha taxonomy manually.

![screen shot 2016-02-12 at 10 45 22](https://cloud.githubusercontent.com/assets/233676/13004840/bc9cadc0-d175-11e5-90d2-7b752fc11e2c.png)
