### PR TITLE
Improve alpha taxonomy import handling of pipe-separated values

### DIFF
--- a/lib/alpha_taxonomy/import_file.rb
+++ b/lib/alpha_taxonomy/import_file.rb
@@ -93,9 +93,10 @@ module AlphaTaxonomy
     end
 
     # We expect taxonomy_labels to be a pipe-separated list.
-    # Return an array of whitespace-stripped taxon titles.
+    # Return an array of whitespace-stripped taxon titles, removing any blank
+    # strings in the process.
     def stripped_array_of(taxon_titles)
-      taxon_titles.split('|').map(&:strip)
+      taxon_titles.split('|').map(&:strip).reject(&:blank?)
     end
   end
 end

--- a/spec/lib/alpha_taxonomy/import_file_spec.rb
+++ b/spec/lib/alpha_taxonomy/import_file_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe AlphaTaxonomy::ImportFile do
     it "parses and writes the required data to a file" do
       stub_downloaded_sheet_data([
         "Foo-Taxon\t" + "/foo-content-item-path",
-        "Bar (Br)| Baz (Bz)\t" + "/bar-or-baz-content-item-path",
+        "Bar (Br)| Baz (Bz) | \t" + "/bar-or-baz-content-item-path",
         "n/a - not applicable\t" + "/n/a-content-item-path",
       ])
 


### PR DESCRIPTION
Handles the case where the value after a pipe is blank, resulting in
empty strings when deriving an array of taxon titles.