### PR TITLE
Add Google drive sheet identifiers for Driving taxonomy data

### DIFF
--- a/lib/alpha_taxonomy/import_file.rb
+++ b/lib/alpha_taxonomy/import_file.rb
@@ -66,7 +66,7 @@ module AlphaTaxonomy
         if mapped_to[0..2] == "n/a"
           next
         else
-          taxon_titles = stripped_array_of(mapped_to)
+          taxon_titles = derive_taxon_array_from(mapped_to)
           taxon_titles.each do |taxon_title|
             @file.write("#{taxon_title}\t#{base_path}\n")
           end
@@ -92,11 +92,11 @@ module AlphaTaxonomy
       @log.error "#{exception.backtrace.join("\n")}"
     end
 
-    # We expect taxonomy_labels to be a pipe-separated list.
-    # Return an array of whitespace-stripped taxon titles, removing any blank
-    # strings in the process.
-    def stripped_array_of(taxon_titles)
-      taxon_titles.split('|').map(&:strip).reject(&:blank?)
+    # We expect to receive a pipe-separated list.
+    # Return an array of whitespace-stripped, downcased taxon titles, removing
+    # any blank strings in the process.
+    def derive_taxon_array_from(taxon_titles)
+      taxon_titles.split('|').map(&:strip).reject(&:blank?).map(&:downcase)
     end
   end
 end

--- a/lib/alpha_taxonomy/sheet_downloader.rb
+++ b/lib/alpha_taxonomy/sheet_downloader.rb
@@ -13,6 +13,7 @@ module AlphaTaxonomy
     self.sheets = [
       { name: "early_years", key: "1zjRy7XKrcroscX4cEqc4gM9Eq0DuVWEm_5wATsolRJY", gid: "1025053831" },
       { name: "curriculum_content_mapping", key: "1rViQioxz5iu3hGYFldNOJift0PqjX0fYd8LZz07ljd4", gid: "678558707" },
+      { name: "driving", key: "19GhkAQ9VEmsiPeoHbrz9Q-nTnbtLxC2kkD6szoGGam0", gid: "1102496302" },
     ]
 
     def initialize(logger: Logger.new(STDOUT))

--- a/spec/lib/alpha_taxonomy/import_file_spec.rb
+++ b/spec/lib/alpha_taxonomy/import_file_spec.rb
@@ -41,9 +41,9 @@ RSpec.describe AlphaTaxonomy::ImportFile do
       populated_file = File.open(test_tsv_file_path)
       expect(populated_file.read).to eq(
         expected_tsv_content([
-          "Foo-Taxon\t/foo-content-item-path",
-          "Bar (Br)\t/bar-or-baz-content-item-path",
-          "Baz (Bz)\t/bar-or-baz-content-item-path"
+          "foo-taxon\t/foo-content-item-path",
+          "bar (br)\t/bar-or-baz-content-item-path",
+          "baz (bz)\t/bar-or-baz-content-item-path"
         ])
       )
     end
@@ -79,16 +79,16 @@ RSpec.describe AlphaTaxonomy::ImportFile do
     context "if the import file is present" do
       before do
         stub_downloaded_sheet_data([
-          "Foo-Taxon\t" + "/foo-content-item-path",
-          "Bar (Br)| Baz (Bz)\t" + "/bar-or-baz-content-item-path",
+          "foo-taxon\t" + "/foo-content-item-path",
+          "bar (br)| baz (bz)\t" + "/bar-or-baz-content-item-path",
         ])
         AlphaTaxonomy::ImportFile.new.populate
       end
 
       it "returns lists of taxons grouped by base_path" do
         expect(AlphaTaxonomy::ImportFile.new.grouped_mappings).to eq(
-          "/foo-content-item-path" => ["Foo-Taxon"],
-          "/bar-or-baz-content-item-path" => ["Bar (Br)", "Baz (Bz)"]
+          "/foo-content-item-path" => ["foo-taxon"],
+          "/bar-or-baz-content-item-path" => ["bar (br)", "baz (bz)"]
         )
       end
     end


### PR DESCRIPTION
Also includes a commit which removes a class of error that can occur when creating taxons with
the same title but different capitalisations in the downloaded
spreadsheet data.