### PR TITLE
Add support for `lock_version` rename

### DIFF
--- a/app/models/link_set.rb
+++ b/app/models/link_set.rb
@@ -8,6 +8,8 @@ class LinkSet
 
   def initialize(data)
     @links = data['links'] || {}
-    @version = data['version'] || 0
+    # TODO: Remove check for `version` once the rename of the
+    # field has been deployed.
+    @version = data['lock_version'] || data['version'] || 0
   end
 end


### PR DESCRIPTION
`version` is going to be renamed to `lock_version` in https://github.com/alphagov/publishing-api/pull/206.