### PR TITLE
Taxon bulk importer - better handling of title capitalisation

### DIFF
--- a/lib/alpha_taxonomy/import_file.rb
+++ b/lib/alpha_taxonomy/import_file.rb
@@ -77,10 +77,10 @@ module AlphaTaxonomy
     def relevant_columns_in(taxonomy_data)
       tsv_data = CSV.parse(taxonomy_data, col_sep: "\t", headers: true)
       desired_columns = ["mapped to", "link"]
-      columns_in_data = tsv_data.headers.map(&:downcase)
+      columns_in_data = tsv_data.headers.select { |header| header.downcase.in? desired_columns }
 
-      if desired_columns.all? { |column_name| columns_in_data.include? column_name }
-        tsv_data.values_at(*desired_columns)
+      if columns_in_data.count == desired_columns.count
+        tsv_data.values_at(*columns_in_data)
       else
         raise ArgumentError, "Column names in downloaded taxonomy data did not match expected values: #{desired_columns}"
       end
@@ -93,10 +93,10 @@ module AlphaTaxonomy
     end
 
     # We expect to receive a pipe-separated list.
-    # Return an array of whitespace-stripped, downcased taxon titles, removing
+    # Return an array of whitespace-stripped taxon titles, removing
     # any blank strings in the process.
     def derive_taxon_array_from(taxon_titles)
-      taxon_titles.split('|').map(&:strip).reject(&:blank?).map(&:downcase)
+      taxon_titles.split('|').map(&:strip).reject(&:blank?)
     end
   end
 end

--- a/lib/alpha_taxonomy/import_file.rb
+++ b/lib/alpha_taxonomy/import_file.rb
@@ -36,6 +36,11 @@ module AlphaTaxonomy
       File.delete(@file.path) if File.exist?(@file.path)
     end
 
+    # Return a hash in the following form
+    # {
+    #   '/content-base-path-1' => [ 'taxon-title-1', 'taxon-title-2' ],
+    #   '/content-base-path-2' => [ 'taxon-title-2', 'taxon-title-3' ],
+    # }
     def grouped_mappings
       check_import_file_is_present
       mappings = CSV.read(self.class.location, col_sep: "\t", headers: true)

--- a/lib/alpha_taxonomy/taxon_creator.rb
+++ b/lib/alpha_taxonomy/taxon_creator.rb
@@ -25,7 +25,7 @@ module AlphaTaxonomy
       end
 
       if existing.present?
-        @log.info "Taxon already exists!"
+        @log.info "Taxon with base path #{taxon_presenter.base_path} already exists!"
       else
         create_new_taxon(presented_payload: taxon_presenter.present)
       end
@@ -44,7 +44,7 @@ module AlphaTaxonomy
     end
 
     def existing_taxons
-      @existing_taxons ||= Services.publishing_api.get_content_items(
+      Services.publishing_api.get_content_items(
         content_format: 'taxon',
         fields: %i(title base_path content_id details)
       ).to_a

--- a/lib/alpha_taxonomy/taxon_linker.rb
+++ b/lib/alpha_taxonomy/taxon_linker.rb
@@ -54,7 +54,11 @@ module AlphaTaxonomy
     def find_content_ids_for(taxon_titles)
       @log.info "Determining content IDs for taxons..."
       taxon_titles.map do |taxon_title|
-        taxon_content_item = all_taxons.find { |taxon| taxon["title"] == taxon_title }
+        # Find existing taxon by a base path derived from the taxon title
+        taxon_content_item = all_taxons.find do |taxon|
+          taxon.fetch("base_path") == TaxonPresenter.new(title: taxon_title).base_path
+        end
+
         if taxon_content_item
           taxon_content_item["content_id"]
         else

--- a/spec/lib/alpha_taxonomy/import_file_spec.rb
+++ b/spec/lib/alpha_taxonomy/import_file_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe AlphaTaxonomy::ImportFile do
   let(:test_tsv_file_path) do
     FileUtils.mkdir_p Rails.root + "tmp"
-    Rails.root + "tmp/import_file_spec.csv"
+    Rails.root + "tmp/import_file_spec.tsv"
   end
   let(:sheet_downloader) { AlphaTaxonomy::SheetDownloader.new }
 
@@ -41,9 +41,9 @@ RSpec.describe AlphaTaxonomy::ImportFile do
       populated_file = File.open(test_tsv_file_path)
       expect(populated_file.read).to eq(
         expected_tsv_content([
-          "foo-taxon\t/foo-content-item-path",
-          "bar (br)\t/bar-or-baz-content-item-path",
-          "baz (bz)\t/bar-or-baz-content-item-path"
+          "Foo-Taxon\t/foo-content-item-path",
+          "Bar (Br)\t/bar-or-baz-content-item-path",
+          "Baz (Bz)\t/bar-or-baz-content-item-path"
         ])
       )
     end


### PR DESCRIPTION
This improves the handling of bulk importing taxons and taxon mappings
when taxon titles in the import file read the same but have different
capitalisations.

Rather than just downcasing the titles when generating the import file,
we preserve the capitalisation and do the following instead:

- the TaxonCreator queries the content store with every new taxon it
  creates, allowing it to check if it's already created a taxon at a
  given base path within the set of title its iterating over.
- the TaxonLinker retrieves content ID by doing a taxon lookup with the
  base path, rather than the title.
