### PR TITLE
Taxon bulk importer - change sheet downloader to use env-var

### DIFF
--- a/spec/features/bulk_taxon_import_spec.rb
+++ b/spec/features/bulk_taxon_import_spec.rb
@@ -36,8 +36,8 @@ RSpec.feature "Bulk taxon import" do
   end
 
   def given_taxonomy_data_is_available_from_a_remote_location
-    allow(AlphaTaxonomy::SheetDownloader).to receive(:sheets).and_return(
-      [{ name: "test-spreadsheet", key: "the-key", gid: "the-gid" }]
+    allow(ENV).to receive(:fetch).with("TAXON_SHEETS").and_return(
+      "test-spreadsheet,the-key,the-gid"
     )
     stub_request(
       :get, "https://docs.google.com/spreadsheets/d/the-key/pub?gid=the-gid&single=true&output=tsv"

--- a/spec/lib/alpha_taxonomy/sheet_downloader_spec.rb
+++ b/spec/lib/alpha_taxonomy/sheet_downloader_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe AlphaTaxonomy::SheetDownloader do
+  describe "#sheet_credential_tuples" do
+    context "given ENV is set with appropriate values" do
+      it "returns an array of sheet credentials" do
+        allow(ENV).to receive(:fetch).with("TAXON_SHEETS").and_return("sheet-name,the-key,the-gid")
+
+        expect(AlphaTaxonomy::SheetDownloader.new(logger: StringIO.new).sheet_credential_tuples).to eq(
+          [{ name: "sheet-name", key: "the-key", gid: "the-gid" }]
+        )
+      end
+    end
+
+    context "given ENV is set with inappropriate values" do
+      it "raises an error" do
+        allow(ENV).to receive(:fetch).with("TAXON_SHEETS").and_return("sheet-name,the-key,the-gid,another-sheet-name")
+
+        expect { AlphaTaxonomy::SheetDownloader.new(logger: StringIO.new).sheet_credential_tuples }.to raise_error(
+          ArgumentError
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Make the downloader read from an environment variable instead of hard-
coding sheet credentials in the class. This makes running different
imports easier by removing the need for a new deploy.