### PR TITLE
Fix URL to Whitehall

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -30,6 +30,14 @@ class ContentItem
     @tagging_apps[publishing_app]
   end
 
+  def external_tagging_url
+    if app_responsible_for_tagging == 'whitehall'
+      Plek.new.find('whitehall-admin')
+    else
+      Plek.new.find(app_responsible_for_tagging)
+    end
+  end
+
   class ItemNotFoundError < StandardError
   end
 end

--- a/app/views/content/_not_migrated_yet.html.erb
+++ b/app/views/content/_not_migrated_yet.html.erb
@@ -5,7 +5,7 @@
   <div class="callout-body">
     <% if @content_item.app_responsible_for_tagging %>
       We haven't migrated the tagging for this item yet. You can try to take a look in
-      <%= link_to @content_item.app_responsible_for_tagging.underscore.titleize, Plek.new.find(@content_item.app_responsible_for_tagging) %>.
+      <%= link_to @content_item.app_responsible_for_tagging.underscore.titleize, @content_item.external_tagging_url %>.
     <% else %>
       This page can't be tagged.
     <% end %>


### PR DESCRIPTION
We link to the app responsible for tagging by inferring this from the `publishing_app`. This always works, except for whitehall, which URL is `whitehall-admin.X.gov.uk`.

https://trello.com/c/U2grPWUp