### PR TITLE
Taxonomy bulk import - ensure duplicate content IDs are not sent in put links

### DIFF
--- a/lib/alpha_taxonomy/sheet_downloader.rb
+++ b/lib/alpha_taxonomy/sheet_downloader.rb
@@ -26,7 +26,7 @@ module AlphaTaxonomy
       environment_values = ENV.fetch("TAXON_SHEETS")
       environment_values = environment_values.split(',')
       if environment_values.count % 3 != 0
-        raise ArgumentError, "TAXON_SHEETS should be a sequence of comma-separated tuples, like so: name1,key1,gid1,name2,key2,gid2"
+        raise ArgumentError, "TAXON_SHEETS should be a sequence of three comma-separated values, like so: name1,key1,gid1,name2,key2,gid2"
       end
 
       environment_values.each_slice(3).map do |triplet|

--- a/lib/alpha_taxonomy/taxon_linker.rb
+++ b/lib/alpha_taxonomy/taxon_linker.rb
@@ -53,7 +53,7 @@ module AlphaTaxonomy
 
     def find_content_ids_for(taxon_titles)
       @log.info "Determining content IDs for taxons..."
-      taxon_titles.map do |taxon_title|
+      content_id_list = taxon_titles.map do |taxon_title|
         # Find existing taxon by a base path derived from the taxon title
         taxon_content_item = all_taxons.find do |taxon|
           taxon.fetch("base_path") == TaxonPresenter.new(title: taxon_title).base_path
@@ -65,6 +65,10 @@ module AlphaTaxonomy
           raise TaxonNotInContentStoreError, "Use TaxonCreator#run! to ensure all taxons have been created"
         end
       end
+
+      # Ensure the list is unique, in case we had any duplicate mappings in
+      # the import file
+      content_id_list.uniq
     end
 
     def fetch_content_item_id_with(base_path)

--- a/spec/lib/alpha_taxonomy/taxon_linker_spec.rb
+++ b/spec/lib/alpha_taxonomy/taxon_linker_spec.rb
@@ -82,6 +82,28 @@ RSpec.describe AlphaTaxonomy::TaxonLinker do
       end
     end
 
+    context "when a duplicate mapping exists" do
+      before do
+        stub_import_file_mappings(
+          "/a-foo-content-item" => ["Foo Taxon", "Foo Taxon"],
+        )
+      end
+
+      it "does not duplicate content IDs in the put_links payload" do
+        stub_taxons_fetch([
+          { content_id: "foo-taxon-uuid", base_path: "/alpha-taxonomy/foo-taxon" },
+        ])
+        stub_content_item_lookup(base_path: "/a-foo-content-item", content_id: "foo-item-uuid")
+
+        expect(Services.publishing_api).to receive(:put_links).with(
+          "foo-item-uuid",
+          links: { alpha_taxons: ["foo-taxon-uuid"] }
+        ).once
+
+        run_the_taxon_linker!
+      end
+    end
+
     context "when the grouped mappings contain a taxon not present in the content store" do
       it "raises an error" do
         stub_import_file_mappings("/a-foo-content-item" => ["Foo Taxon"])


### PR DESCRIPTION

This handles a potential case where the import file has duplicate
mappings, i.e. - the same taxon mapped multiple times to the same piece
of content.