### PR TITLE
Allow contacts pages to be tagged

### DIFF
--- a/config/tagging-apps.yml
+++ b/config/tagging-apps.yml
@@ -8,8 +8,8 @@ businesssupportfinder: content-tagger
 calculators: content-tagger
 calendars: content-tagger
 collections-publisher: content-tagger
-contacts: panopticon
-contacts-admin:
+contacts: content-tagger
+contacts-admin: content-tagger
 design-principles:
 email-campaign-frontend:
 external-link-tracker:


### PR DESCRIPTION
contacts-admin has been migrated since alphagov/contacts-admin#231.

Trello: https://trello.com/c/afa0Mfa4