### PR TITLE
Taxon bulk importer - update taxon linker to use live content store

### DIFF
--- a/lib/alpha_taxonomy/bulk_import_report.rb
+++ b/lib/alpha_taxonomy/bulk_import_report.rb
@@ -26,7 +26,7 @@ module AlphaTaxonomy
     end
 
     def determine_update_state_of(path)
-      content_item = Services.content_store.content_item(path)
+      content_item = Services.live_content_store.content_item(path)
 
       if content_item.blank?
         @no_content_item << { path: path }

--- a/lib/alpha_taxonomy/taxon_linker.rb
+++ b/lib/alpha_taxonomy/taxon_linker.rb
@@ -73,10 +73,11 @@ module AlphaTaxonomy
 
     def fetch_content_item_id_with(base_path)
       @log.info "Fetching content ID for base path above..."
-      lookup = ContentLookupForm.new(base_path: base_path)
-      return lookup.content_id if lookup.valid?
-      report_error("Error fetching content id for #{base_path}: #{lookup.errors[:base_path]}")
-      nil
+      content_item = Services.live_content_store.content_item(base_path)
+      return content_item.content_id if content_item.present?
+      report_error("No content item found at #{base_path}")
+    rescue
+      report_error("Error fetching content id for #{base_path}: #{e}, Backtrace: #{e.backtrace.join("\n")}")
     end
   end
 end

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -16,4 +16,11 @@ module Services
       disable_cache: true
     )
   end
+
+  def self.live_content_store
+    @live_content_store ||= GdsApi::ContentStore.new(
+      Plek.new.find('content-store'),
+      disable_cache: true
+    )
+  end
 end

--- a/spec/features/bulk_taxon_import_spec.rb
+++ b/spec/features/bulk_taxon_import_spec.rb
@@ -101,8 +101,8 @@ RSpec.feature "Bulk taxon import" do
 
   def when_i_run_the_taxon_linker
     # Assume that valid content items exist at the test-paths
-    stub_request(:get, "#{DRAFT_CONTENT_STORE}/content/test-path-1").to_return(body: { content_id: "uuid-1" }.to_json)
-    stub_request(:get, "#{DRAFT_CONTENT_STORE}/content/test-path-2").to_return(body: { content_id: "uuid-2" }.to_json)
+    stub_request(:get, "#{LIVE_CONTENT_STORE}/content/test-path-1").to_return(body: { content_id: "uuid-1" }.to_json)
+    stub_request(:get, "#{LIVE_CONTENT_STORE}/content/test-path-2").to_return(body: { content_id: "uuid-2" }.to_json)
 
     @update_links_1 = stub_publishing_api_put_links("uuid-1", links: { alpha_taxons: ["foo-uuid"] })
     @update_links_2 = stub_publishing_api_put_links("uuid-2", links: { alpha_taxons: ["bar-uuid"] })

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -16,6 +16,7 @@ Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 
 PUBLISHING_API = "https://publishing-api.test.gov.uk"
 DRAFT_CONTENT_STORE = "https://draft-content-store.test.gov.uk"
+LIVE_CONTENT_STORE = "https://content-store.test.gov.uk"
 
 require 'capybara/rails'
 


### PR DESCRIPTION
Using the draft content store to fetch content items results in the
occasional 403 due to access limitation. This uses the live content
store to retrieve content IDs instead, where access limits aren't
present.