### PR TITLE
Don't allow tagging for redirects & gones

### DIFF
--- a/app/forms/content_lookup_form.rb
+++ b/app/forms/content_lookup_form.rb
@@ -15,12 +15,21 @@ private
 
   def base_path_should_be_a_content_item
     return if errors.any?
-    strip_host && content_item_should_have_been_found!
+
+    strip_host &&
+      content_item_should_have_been_found! &&
+      content_item_should_be_taggable!
   end
 
   def content_item_should_have_been_found!
     return true if content_item
     errors[:base_path] << "No page found with this path"
+    false
+  end
+
+  def content_item_should_be_taggable!
+    return unless content_item['format'].in?(%(redirect gone))
+    errors[:base_path] << "This is not a valid page on GOV.UK"
     false
   end
 

--- a/spec/features/tagging_content_spec.rb
+++ b/spec/features/tagging_content_spec.rb
@@ -76,6 +76,7 @@ RSpec.describe "Tagging content" do
     stub_request(:get, "https://draft-content-store.test.gov.uk/content/my-content-item")
       .to_return(body: {
         content_id: "MY-CONTENT-ID",
+        format: "placeholder",
       }.to_json)
 
     stub_request(:get, "#{PUBLISHING_API}/v2/content/MY-CONTENT-ID")

--- a/spec/forms/content_lookup_form_spec.rb
+++ b/spec/forms/content_lookup_form_spec.rb
@@ -25,16 +25,25 @@ RSpec.describe ContentLookupForm do
 
     it "is valid when the path is an absolute_path found on GOV.UK" do
       stub_request(:get, "https://draft-content-store.test.gov.uk/content/browse")
-        .to_return(body: {}.to_json)
+        .to_return(body: { format: 'placeholder' }.to_json)
 
       form = ContentLookupForm.new(base_path: '/browse')
 
       expect(form).to be_valid
     end
 
+    it "is invalid when the path is not renderable" do
+      stub_request(:get, "https://draft-content-store.test.gov.uk/content/browse")
+        .to_return(body: { format: 'redirect' }.to_json)
+
+      form = ContentLookupForm.new(base_path: '/browse')
+
+      expect(form).not_to be_valid
+    end
+
     it "treats paths and URLs the same" do
       stub_request(:get, "https://draft-content-store.test.gov.uk/content/browse")
-        .to_return(body: {}.to_json)
+        .to_return(body: { format: 'placeholder' }.to_json)
 
       form = ContentLookupForm.new(base_path: 'http://gov.uk/browse')
 


### PR DESCRIPTION
To prevent confusion, these formats shouldn't be taggable.