### PR TITLE
Use `get_linkables` endpoint for tag fetching

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'gds-sso', '~> 11.1'
 gem 'govuk_admin_template', '~> 4.1.1'
 gem 'generic_form_builder', '~> 0.13.0'
 gem 'govuk-lint', '~> 0.5'
-gem 'gds-api-adapters', '~> 25.3'
+gem 'gds-api-adapters', '~> 29.5'
 
 gem 'airbrake', '~> 4.3.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,17 +68,17 @@ GEM
     debug_inspector (0.0.2)
     diff-lcs (1.2.5)
     docile (1.1.5)
-    domain_name (0.5.25)
+    domain_name (0.5.20160309)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.6.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
-    gds-api-adapters (25.3.0)
+    gds-api-adapters (29.5.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
-      plek
+      plek (>= 1.9.0)
       rack-cache
       rest-client (~> 1.8.0)
     gds-sso (11.1.0)
@@ -126,7 +126,7 @@ GEM
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
     method_source (0.8.2)
-    mime-types (2.99)
+    mime-types (2.99.1)
     mini_portile2 (2.0.0)
     minitest (5.8.4)
     multi_json (1.11.2)
@@ -154,7 +154,7 @@ GEM
     parser (2.2.3.0)
       ast (>= 1.1, < 3.0)
     pg (0.18.4)
-    plek (1.11.0)
+    plek (1.12.0)
     powerpack (0.1.1)
     pry (0.10.3)
       coderay (~> 1.1.0)
@@ -168,7 +168,7 @@ GEM
     rack (1.6.4)
     rack-accept (0.4.5)
       rack (>= 0.4)
-    rack-cache (1.5.1)
+    rack-cache (1.6.1)
       rack (>= 0.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -265,7 +265,7 @@ GEM
       json (>= 1.8.0)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.1)
+    unf_ext (0.0.7.2)
     unicorn (5.0.1)
       kgio (~> 2.6)
       rack
@@ -292,7 +292,7 @@ PLATFORMS
 DEPENDENCIES
   airbrake (~> 4.3.1)
   capybara
-  gds-api-adapters (~> 25.3)
+  gds-api-adapters (~> 29.5)
   gds-sso (~> 11.1)
   generic_form_builder (~> 0.13.0)
   govuk-content-schema-test-helpers (~> 1.4)

--- a/app/forms/tagging_update_form.rb
+++ b/app/forms/tagging_update_form.rb
@@ -24,7 +24,7 @@ class TaggingUpdateForm
   end
 
   def publish!
-    Services.publishing_api.put_links(
+    Services.publishing_api.patch_links(
       content_id,
       links: {
         topics: topics,

--- a/app/services/tag_fetcher.rb
+++ b/app/services/tag_fetcher.rb
@@ -10,7 +10,8 @@ class TagFetcher
 private
 
   def fetch_items_for_format(document_type)
-    Services.publishing_api.get_linkables(document_type: document_type)
+    @cache ||= {}
+    @cache[document_type] ||= Services.publishing_api.get_linkables(document_type: document_type)
   end
 
   def present_items_for_select(items)

--- a/app/services/tag_fetcher.rb
+++ b/app/services/tag_fetcher.rb
@@ -9,34 +9,24 @@ class TagFetcher
 
 private
 
-  def fetch_items_for_format(content_format)
-    Services.publishing_api.get_content_items(
-      content_format: content_format,
-      fields: %i(title content_id details)
-    )
+  def fetch_items_for_format(document_type)
+    Services.publishing_api.get_linkables(document_type: document_type)
   end
 
   def present_items_for_select(items)
-    items.map { |tag| TagItem.new(tag).to_select }.sort_by(&:first)
+    items.map do |tag|
+      [tag_name_with_publication_state(tag), tag.fetch('content_id')]
+    end
   end
 
-  class TagItem
-    attr_accessor :content_id, :title, :publication_state, :details
-    include ActiveModel::Model
+  def tag_name_with_publication_state(item)
+    name = item['internal_name'] || item.fetch('title')
+    publication_state = item.fetch('publication_state')
 
-    def to_select
-      [tag_name_with_publication_state, content_id]
-    end
-
-  private
-
-    def tag_name_with_publication_state
-      name = details.to_h.fetch('internal_name', title)
-      if publication_state == 'draft'
-        "#{name} (#{publication_state})"
-      else
-        name
-      end
+    if publication_state == 'draft'
+      "#{name} (#{publication_state})"
+    else
+      name
     end
   end
 end

--- a/lib/alpha_taxonomy/taxon_linker.rb
+++ b/lib/alpha_taxonomy/taxon_linker.rb
@@ -28,14 +28,14 @@ module AlphaTaxonomy
         @log.info "No content ID found!"
       else
         @log.info "Content ID is #{content_item_id}"
-        put_links_response = Services.publishing_api.put_links(
+        patch_links_response = Services.publishing_api.patch_links(
           content_item_id,
           links: {
             alpha_taxons: taxon_content_ids
           }
         )
 
-        @log.info "Publishing API 'put' complete, response code: #{put_links_response.code}"
+        @log.info "Publishing API 'put' complete, response code: #{patch_links_response.code}"
       end
     end
 

--- a/spec/features/bulk_taxon_import_spec.rb
+++ b/spec/features/bulk_taxon_import_spec.rb
@@ -104,8 +104,8 @@ RSpec.feature "Bulk taxon import" do
     stub_request(:get, "#{LIVE_CONTENT_STORE}/content/test-path-1").to_return(body: { content_id: "uuid-1" }.to_json)
     stub_request(:get, "#{LIVE_CONTENT_STORE}/content/test-path-2").to_return(body: { content_id: "uuid-2" }.to_json)
 
-    @update_links_1 = stub_publishing_api_put_links("uuid-1", links: { alpha_taxons: ["foo-uuid"] })
-    @update_links_2 = stub_publishing_api_put_links("uuid-2", links: { alpha_taxons: ["bar-uuid"] })
+    @update_links_1 = stub_publishing_api_patch_links("uuid-1", links: { alpha_taxons: ["foo-uuid"] })
+    @update_links_2 = stub_publishing_api_patch_links("uuid-2", links: { alpha_taxons: ["bar-uuid"] })
 
     AlphaTaxonomy::TaxonLinker.new(logger: @dummy_logger).run!
   end

--- a/spec/features/tagging_content_spec.rb
+++ b/spec/features/tagging_content_spec.rb
@@ -162,20 +162,19 @@ RSpec.describe "Tagging content" do
   def setup_tags_for_select_boxes
     content = [
       {
-        "content_id" => "ID-OF-FIRST-TAG",
-        "title" => "Some Tag",
-        "details" => {},
+        content_id: "ID-OF-FIRST-TAG",
+        title: "Some Tag",
+        publication_state: "published",
       },
       {
-        "content_id" => "ID-OF-ALREADY-TAGGED",
-        "title" => "Something Else",
-        "details" => {},
+        content_id: "ID-OF-ALREADY-TAGGED",
+        title: "Something Else",
+        publication_state: "published",
       }
     ]
 
-    %w(topic organisation mainstream_browse_page taxon).each do |content_format|
-      stub_request(:get, "#{PUBLISHING_API}/v2/content?content_format=#{content_format}&fields%5B%5D=content_id&fields%5B%5D=title&fields%5B%5D=details")
-        .to_return(body: content.to_json)
+    %w(topic organisation mainstream_browse_page taxon).each do |document_type|
+      publishing_api_has_linkables(content, document_type: document_type)
     end
   end
 end

--- a/spec/features/tagging_content_spec.rb
+++ b/spec/features/tagging_content_spec.rb
@@ -125,14 +125,14 @@ RSpec.describe "Tagging content" do
   end
 
   def when_i_add_an_additional_tag
-    @tagging_request = stub_request(:put, "#{PUBLISHING_API}/v2/links/MY-CONTENT-ID")
+    @tagging_request = stub_request(:patch, "#{PUBLISHING_API}/v2/links/MY-CONTENT-ID")
       .to_return(status: 200)
 
     select "Some Tag", from: "Topics"
   end
 
   def and_somebody_else_makes_a_change
-    @tagging_request = stub_request(:put, "#{PUBLISHING_API}/v2/links/MY-CONTENT-ID")
+    @tagging_request = stub_request(:patch, "#{PUBLISHING_API}/v2/links/MY-CONTENT-ID")
       .to_return(status: 409)
   end
 

--- a/spec/lib/alpha_taxonomy/taxon_linker_spec.rb
+++ b/spec/lib/alpha_taxonomy/taxon_linker_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe AlphaTaxonomy::TaxonLinker do
 
     before do
       # We log the response code from the publishing API, stub out the returned value
-      allow(Services.publishing_api).to receive(:put_links).and_return(double(code: 200))
+      allow(Services.publishing_api).to receive(:patch_links).and_return(double(code: 200))
     end
 
     it "creates taxon links based on the grouped mappings" do
@@ -43,11 +43,11 @@ RSpec.describe AlphaTaxonomy::TaxonLinker do
       stub_content_item_lookup(base_path: "/a-foo-content-item", content_id: "foo-item-uuid")
       stub_content_item_lookup(base_path: "/a-foo-bar-content-item", content_id: "foo-bar-item-uuid")
 
-      expect(Services.publishing_api).to receive(:put_links).with(
+      expect(Services.publishing_api).to receive(:patch_links).with(
         "foo-item-uuid",
         links: { alpha_taxons: ["foo-taxon-uuid"] }
       ).once
-      expect(Services.publishing_api).to receive(:put_links).with(
+      expect(Services.publishing_api).to receive(:patch_links).with(
         "foo-bar-item-uuid",
         links: { alpha_taxons: ["foo-taxon-uuid", "bar-taxon-uuid"] }
       ).once
@@ -71,11 +71,11 @@ RSpec.describe AlphaTaxonomy::TaxonLinker do
         stub_content_item_lookup(base_path: "/a-foo-content-item", content_id: "foo-item-uuid")
         stub_content_item_lookup(base_path: "/a-foo-bar-content-item", content_id: "foo-bar-item-uuid")
 
-        expect(Services.publishing_api).to receive(:put_links).with(
+        expect(Services.publishing_api).to receive(:patch_links).with(
           "foo-item-uuid",
           links: { alpha_taxons: ["foo-taxon-uuid"] }
         ).once
-        expect(Services.publishing_api).to receive(:put_links).with(
+        expect(Services.publishing_api).to receive(:patch_links).with(
           "foo-bar-item-uuid",
           links: { alpha_taxons: ["foo-taxon-uuid"] }
         ).once
@@ -91,13 +91,13 @@ RSpec.describe AlphaTaxonomy::TaxonLinker do
         )
       end
 
-      it "does not duplicate content IDs in the put_links payload" do
+      it "does not duplicate content IDs in the patch_links payload" do
         stub_taxons_fetch([
           { content_id: "foo-taxon-uuid", base_path: "/alpha-taxonomy/foo-taxon" },
         ])
         stub_content_item_lookup(base_path: "/a-foo-content-item", content_id: "foo-item-uuid")
 
-        expect(Services.publishing_api).to receive(:put_links).with(
+        expect(Services.publishing_api).to receive(:patch_links).with(
           "foo-item-uuid",
           links: { alpha_taxons: ["foo-taxon-uuid"] }
         ).once
@@ -126,7 +126,7 @@ RSpec.describe AlphaTaxonomy::TaxonLinker do
       end
 
       it "does not create a link and reports the error" do
-        expect(Services.publishing_api).to receive(:put_links).with(
+        expect(Services.publishing_api).to receive(:patch_links).with(
           "foo-item-uuid",
           links: { alpha_taxons: ["foo-taxon-uuid"] }
         ).once

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -19,10 +19,13 @@ DRAFT_CONTENT_STORE = "https://draft-content-store.test.gov.uk"
 LIVE_CONTENT_STORE = "https://content-store.test.gov.uk"
 
 require 'capybara/rails'
+require 'gds_api/test_helpers/publishing_api_v2'
 
 ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
+  config.include GdsApi::TestHelpers::PublishingApiV2
+
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
   config.use_transactional_fixtures = true
   config.infer_spec_type_from_file_location!


### PR DESCRIPTION
This new endpoint is better suited to populate the dropdowns. This also fixes a current bug caused by the publishing-api returning more data than expected.