### PR TITLE
Add support for blacklisting fields, and blacklist parent for TAP content

### DIFF
--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -2,6 +2,7 @@ class ContentController < ApplicationController
   def show
     @content_item = ContentItem.find!(params[:content_id])
     @tagging_update = TaggingUpdateForm.init_with_content_item(@content_item)
+    @tag_types = ContentItem::TAG_TYPES - @content_item.blacklisted_tag_types
   rescue ContentItem::ItemNotFoundError
     render "item_not_found", status: 404
   end

--- a/app/forms/tagging_update_form.rb
+++ b/app/forms/tagging_update_form.rb
@@ -24,15 +24,19 @@ class TaggingUpdateForm
   end
 
   def publish!
+    links_payload = {
+      topics: topics,
+      mainstream_browse_pages: mainstream_browse_pages,
+      organisations: organisations,
+      alpha_taxons: alpha_taxons,
+    }
+
+    # Because 'parent' might be a blacklisted field switched off in the form
+    links_payload.merge!(parent: parent) unless parent.nil?
+
     Services.publishing_api.patch_links(
       content_id,
-      links: {
-        topics: topics,
-        mainstream_browse_pages: mainstream_browse_pages,
-        organisations: organisations,
-        parent: parent,
-        alpha_taxons: alpha_taxons,
-      },
+      links: links_payload,
       previous_version: previous_version.to_i,
     )
   end

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -38,6 +38,23 @@ class ContentItem
     end
   end
 
+  def blacklisted_tag_types
+    # FIXME: This is  a temporary workaround for the fact that 'parent' links
+    # can sometimes be blobs of JSON (containing a breadcrumb, for example)
+    # rather than the array of content IDs content-tagger currently expects. We
+    # need to either improve the editing interface in content tagger to somehow
+    # support this or wait until the publishing API no longer allows writing of
+    # arbitrary JSON to the parent link.
+    #
+    # If we have to do any more of this consider moving it out into a separate
+    # piece of configuration (perhaps something like the tagging-apps.yml).
+    if publishing_app == "travel-advice-publisher"
+      %w(parent)
+    else
+      []
+    end
+  end
+
   class ItemNotFoundError < StandardError
   end
 end

--- a/app/views/content/_tagging_form.html.erb
+++ b/app/views/content/_tagging_form.html.erb
@@ -1,8 +1,8 @@
-<%= form_for @tagging_update, url: content_update_links_path do |f| %>
+<%= form_for tagging_update, url: content_update_links_path do |f| %>
   <%= f.hidden_field :content_id %>
   <%= f.hidden_field :previous_version %>
 
-  <% ContentItem::TAG_TYPES.each do |tag_type| %>
+  <% tag_types.each do |tag_type| %>
     <div class='tag-section'>
       <%= render "form_for_#{tag_type}", f: f %>
     </div>

--- a/app/views/content/show.html.erb
+++ b/app/views/content/show.html.erb
@@ -7,7 +7,7 @@
 <hr/>
 
 <% if @content_item.tagging_allowed? %>
-  <%= render 'tagging_form' %>
+  <%= render partial: 'tagging_form', locals: { tagging_update: @tagging_update, tag_types: @tag_types }  %>
 <% else %>
   <%= render 'not_migrated_yet' %>
 <% end %>

--- a/spec/features/tagging_content_spec.rb
+++ b/spec/features/tagging_content_spec.rb
@@ -150,8 +150,8 @@ RSpec.describe "Tagging content" do
         topics: ["ID-OF-FIRST-TAG", "ID-OF-ALREADY-TAGGED"],
         mainstream_browse_pages: [],
         organisations: [],
-        parent: [],
         alpha_taxons: [],
+        parent: [],
       },
       previous_version: 54_321,
     }

--- a/spec/forms/tagging_update_form_spec.rb
+++ b/spec/forms/tagging_update_form_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe TaggingUpdateForm do
+  describe '#links_payload' do
+    it 'generates a payload with links' do
+      form = TaggingUpdateForm.new(
+        topics: ['', '877a4785-bcec-4e23-98b6-1a3a84e33755'],
+        mainstream_browse_pages: [''],
+        organisations: [''],
+        alpha_taxons: [''],
+        parent: [''],
+      )
+
+      links_payload = form.links_payload
+
+      expect(links_payload).to eql(
+        topics: ['877a4785-bcec-4e23-98b6-1a3a84e33755'],
+        mainstream_browse_pages: [],
+        organisations: [],
+        alpha_taxons: [],
+        parent: [],
+      )
+    end
+
+    it 'does not include parent if parent is not in the form list' do
+      form = TaggingUpdateForm.new(
+        topics: [],
+        organisations: [],
+        alpha_taxons: [],
+      )
+
+      links_payload = form.links_payload
+
+      expect(links_payload).to eql(
+        topics: [],
+        mainstream_browse_pages: [],
+        organisations: [],
+        alpha_taxons: [],
+      )
+    end
+  end
+end

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe ContentItem do
+  let(:content_item_params) do
+    {
+      'content_id'     => 'uuid-88',
+      'title'          => 'A content item',
+      'format'         => 'placeholder',
+      'base_path'      => '/a-content-item',
+      'publishing_app' => 'whitehall'
+    }
+  end
+
+  describe "#blacklisted_tag_types" do
+    context "for apps in the blacklist" do
+      let(:content_item) do
+        ContentItem.new(
+          content_item_params.merge('publishing_app' => 'travel-advice-publisher')
+        )
+      end
+
+      it "returns the blacklisted fields" do
+        content_item.blacklisted_tag_types == ['parent']
+      end
+    end
+
+    context "for apps not in the blacklist" do
+      let(:content_item) { ContentItem.new(content_item_params) }
+
+      it "returns an empty list" do
+        content_item.blacklisted_tag_types == []
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds functionality to switch off certain kinds of links in the
content tagger form, and sets this up specifically for 'parent' fields
when the document being tagged is owned by Travel Advice Publisher.

We need to be able to do this in order to migrate Travel Advice Publisher
to the new tagging architecture. Currently, the parent link for TAP
content is set by default to be an array of hashes modelling a
breadcrumb. This isn't something we're able to handle in content-tagger
right now. The workaround in this commit allows us to migrate TAP away
from Panopticon while we determine how best to handle this on an ongoing
basis.

Part of: https://trello.com/c/Unia7Z0B