### PR TITLE
Allow tagging of pages by travel advice publisher

### DIFF
--- a/config/tagging-apps.yml
+++ b/config/tagging-apps.yml
@@ -31,5 +31,5 @@ specialist-publisher: specialist-publisher
 spotlight:
 static:
 tariff:
-travel-advice-publisher:
+travel-advice-publisher: content-tagger
 whitehall: whitehall


### PR DESCRIPTION
This commit makes it possible for users to tag pages by travel advice publisher. This should be deployed at the same time as https://github.com/alphagov/content-tagger/pull/42 to prevent overwriting the `parent` entry in the links hash (which TAP populates in its own special way).

This functionality should be deployed after https://github.com/alphagov/panopticon/pull/330 &
https://github.com/alphagov/panopticon/pull/331, which disallow tagging of the pages in panopticon.

Part of: https://trello.com/c/Unia7Z0B