### PR TITLE
Use get_linkables endpoint to get taxon data.

### DIFF
--- a/lib/alpha_taxonomy/taxon_creator.rb
+++ b/lib/alpha_taxonomy/taxon_creator.rb
@@ -44,9 +44,8 @@ module AlphaTaxonomy
     end
 
     def existing_taxons
-      Services.publishing_api.get_content_items(
-        content_format: 'taxon',
-        fields: %i(title base_path content_id details)
+      Services.publishing_api.get_linkables(
+        document_type: 'taxon',
       ).to_a
     end
 

--- a/lib/alpha_taxonomy/taxon_linker.rb
+++ b/lib/alpha_taxonomy/taxon_linker.rb
@@ -46,8 +46,8 @@ module AlphaTaxonomy
     end
 
     def all_taxons
-      @all_taxons ||= Services.publishing_api.get_content_items(
-        content_format: 'taxon', fields: %i(title base_path content_id)
+      @all_taxons ||= Services.publishing_api.get_linkables(
+        document_type: 'taxon'
       ).sort_by { |taxon| taxon["title"] }
     end
 

--- a/spec/features/bulk_taxon_import_spec.rb
+++ b/spec/features/bulk_taxon_import_spec.rb
@@ -59,7 +59,7 @@ RSpec.feature "Bulk taxon import" do
       { title: "bar-taxon", base_path: "/alpha-taxonomy/bar-taxon" }
     ]
     stub_request(
-      :get, "#{PUBLISHING_API}/v2/content?content_format=taxon&fields%5B%5D=base_path&fields%5B%5D=content_id&fields%5B%5D=details&fields%5B%5D=title"
+      :get, "#{PUBLISHING_API}/v2/linkables?document_type=taxon"
     ).to_return(body: publishing_api_response.to_json)
   end
 
@@ -95,7 +95,7 @@ RSpec.feature "Bulk taxon import" do
       { title: "bar-taxon", base_path: "/alpha-taxonomy/bar-taxon", content_id: "bar-uuid" }
     ]
     stub_request(
-      :get, "#{PUBLISHING_API}/v2/content?content_format=taxon&fields%5B%5D=base_path&fields%5B%5D=content_id&fields%5B%5D=title"
+      :get, "#{PUBLISHING_API}/v2/linkables?document_type=taxon"
     ).to_return(body: publishing_api_response.to_json)
   end
 

--- a/spec/lib/alpha_taxonomy/taxon_creator_spec.rb
+++ b/spec/lib/alpha_taxonomy/taxon_creator_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe AlphaTaxonomy::TaxonCreator do
 
       def stub_taxon_fetch(results:)
         mock_response = double(to_a: results)
-        allow(Services.publishing_api).to receive(:get_content_items).and_return(mock_response)
+        allow(Services.publishing_api).to receive(:get_linkables).and_return(mock_response)
       end
 
       after do

--- a/spec/lib/alpha_taxonomy/taxon_linker_spec.rb
+++ b/spec/lib/alpha_taxonomy/taxon_linker_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe AlphaTaxonomy::TaxonLinker do
     end
 
     def stub_taxons_fetch(returned_taxon_collection)
-      allow(Services.publishing_api).to receive(:get_content_items).with(
-        content_format: 'taxon', fields: %i(title base_path content_id)
+      allow(Services.publishing_api).to receive(:get_linkables).with(
+        document_type: 'taxon'
       ).and_return(returned_taxon_collection.map(&:stringify_keys))
     end
 


### PR DESCRIPTION
TaxonCreator was requesting the details hash, but was not using it (and the
hash is empty for all taxons anyway), so linkables provides all the necessary
data.