### PR TITLE
Add functionality to bulk delete mappings for a taxon

### DIFF
--- a/lib/alpha_taxonomy/README.md
+++ b/lib/alpha_taxonomy/README.md
@@ -30,9 +30,10 @@ taxons in `mapped to`.
    The `19Ghka...` part is the `key` and the param at the end is the `gid`.
 0. In the environment in which you're running the import, set an environment
    variable `TAXON_SHEETS` with values in the form
-   `name-of-sheet,the-key,the-gid,name-of-some-other-sheet,its-key,its-gid`.
+   `description,the-key,the-gid,description-of-some-other-sheet,its-key,its-gid`.
    You can set as many sets of credentials as you need as long as the values
-   are comma-delimited and provided in this order.
+   are comma-delimited and provided in this order. The 'description' can be any
+   value - its sole use is clearer log output.
 0. Run `AlphaTaxonomy::ImportFile.new.populate`.
 0. This should pull down each sheet defined in the environment variable and
    write the contents into a single import file. A default location for the

--- a/lib/alpha_taxonomy/import_file.rb
+++ b/lib/alpha_taxonomy/import_file.rb
@@ -34,23 +34,6 @@ module AlphaTaxonomy
       File.delete(@file.path) if File.exist?(@file.path)
     end
 
-    # Return a hash in the following form
-    # {
-    #   '/content-base-path-1' => [ 'taxon-title-1', 'taxon-title-2' ],
-    #   '/content-base-path-2' => [ 'taxon-title-2', 'taxon-title-3' ],
-    # }
-    def grouped_mappings
-      check_import_file_is_present
-      mappings = CSV.read(self.class.location, col_sep: "\t", headers: true)
-      mappings.each_with_object({}) do |row, hash|
-        base_path = row["base_path"]
-        taxon_title = row["taxon_title"]
-
-        hash[base_path] = [] unless hash[base_path].present?
-        hash[base_path] << taxon_title
-      end
-    end
-
   private
 
     def write_headers

--- a/lib/alpha_taxonomy/import_file.rb
+++ b/lib/alpha_taxonomy/import_file.rb
@@ -7,25 +7,23 @@ module AlphaTaxonomy
 
     class_attribute :location
     self.location = begin
-      if ENV["TAXON_IMPORT_FILE"].present?
-        ENV["TAXON_IMPORT_FILE"]
-      else
-        FileUtils.mkdir_p Rails.root + "lib/data/"
-        Rails.root + "lib/data/alpha_taxonomy_import.tsv"
-      end
+      FileUtils.mkdir_p Rails.root + "lib/data/"
+      Rails.root + "lib/data/alpha_taxonomy_import.tsv"
     end
 
-    def initialize(logger: Logger.new(STDOUT))
+    def initialize(logger: Logger.new(STDOUT), sheet_identifiers:)
       @log = logger
+      @sheet_identifiers = sheet_identifiers
     end
 
     def populate
       @file = File.new(self.class.location, "wb")
       write_headers
 
-      SheetDownloader.new(logger: @log).each_sheet do |taxonomy_data|
+      SheetDownloader.new(logger: @log, sheet_identifiers: @sheet_identifiers).each_sheet do |taxonomy_data|
         write(taxonomy_data)
       end
+
       @file.close
     rescue => e
       log_failure(e)

--- a/lib/alpha_taxonomy/import_file_groupings.rb
+++ b/lib/alpha_taxonomy/import_file_groupings.rb
@@ -1,0 +1,24 @@
+require 'csv'
+
+module AlphaTaxonomy
+  class ImportFileGroupings
+    include AlphaTaxonomy::Helpers::ImportFileHelper
+
+    # Return a hash in the following form
+    # {
+    #   '/content-base-path-1' => [ 'taxon-title-1', 'taxon-title-2' ],
+    #   '/content-base-path-2' => [ 'taxon-title-2', 'taxon-title-3' ],
+    # }
+    def extract
+      check_import_file_is_present
+      mappings = CSV.read(AlphaTaxonomy::ImportFile.location, col_sep: "\t", headers: true)
+      mappings.each_with_object({}) do |row, hash|
+        base_path = row["base_path"]
+        taxon_title = row["taxon_title"]
+
+        hash[base_path] = [] unless hash[base_path].present?
+        hash[base_path] << taxon_title
+      end
+    end
+  end
+end

--- a/lib/alpha_taxonomy/sheet_downloader.rb
+++ b/lib/alpha_taxonomy/sheet_downloader.rb
@@ -1,17 +1,5 @@
 module AlphaTaxonomy
   class SheetDownloader
-    # This class downloads taxonomy data from a specified set of spreadsheets.
-    # It assumes the following about each sheet it imports:
-    # a) it is stored on Google drive.
-    # b) it is 'published' as a single sheet (not the entire document/workbook),
-    #    with tab-seperated values.
-    # c) an environment variable called TAXON_SHEETS, containing the name, key
-    #    and gid (in that order) is specified at the point this class is used by
-    #    any client code.
-
-    # Example credentials set in environment variable:
-    # TAXON_SHEETS=early_years,1zjRy7XKrcroscX4cEqc4gM9Eq0DuVWEm_5wATsolRJY,1025053831
-
     def initialize(logger: Logger.new(STDOUT))
       @log = logger
     end

--- a/lib/alpha_taxonomy/sheet_downloader.rb
+++ b/lib/alpha_taxonomy/sheet_downloader.rb
@@ -1,28 +1,28 @@
 module AlphaTaxonomy
   class SheetDownloader
-    def initialize(logger: Logger.new(STDOUT))
+    attr_reader :sheet_identifier_tuples
+
+    def initialize(logger: Logger.new(STDOUT), sheet_identifiers:)
       @log = logger
+      if sheet_identifiers.count % 3 != 0
+        raise ArgumentError, sheet_identifiers_error_message
+      end
+      @sheet_identifier_tuples = parse_identifiers(sheet_identifiers)
     end
 
     def each_sheet
-      sheet_credential_tuples.each do |sheet_credentials|
-        yield remote_taxonomy_data(sheet_credentials)
-      end
-    end
-
-    def sheet_credential_tuples
-      environment_values = ENV.fetch("TAXON_SHEETS")
-      environment_values = environment_values.split(',')
-      if environment_values.count % 3 != 0
-        raise ArgumentError, "TAXON_SHEETS should be a sequence of three comma-separated values, like so: name1,key1,gid1,name2,key2,gid2"
-      end
-
-      environment_values.each_slice(3).map do |triplet|
-        { name: triplet[0], key: triplet[1], gid: triplet[2] }
+      @sheet_identifier_tuples.each do |sheet_identifiers|
+        yield remote_taxonomy_data(sheet_identifiers)
       end
     end
 
   private
+
+    def parse_identifiers(sheet_identifiers)
+      sheet_identifiers.each_slice(3).map do |triplet|
+        { name: triplet[0], key: triplet[1], gid: triplet[2] }
+      end
+    end
 
     def remote_taxonomy_data(sheet_info)
       sheet_url = spreadsheet_url(key: sheet_info[:key], gid: sheet_info[:gid])
@@ -34,6 +34,10 @@ module AlphaTaxonomy
 
     def spreadsheet_url(key:, gid:)
       "https://docs.google.com/spreadsheets/d/#{key}/pub?gid=#{gid}&single=true&output=tsv"
+    end
+
+    def sheet_identifiers_error_message
+      "sheet_identifiers should be a sequence of three comma-separated values, like so: ['name1','key1','gid1','name2','key2','gid2']"
     end
   end
 end

--- a/lib/alpha_taxonomy/taxon_link_deleter.rb
+++ b/lib/alpha_taxonomy/taxon_link_deleter.rb
@@ -1,0 +1,31 @@
+module AlphaTaxonomy
+  class TaxonLinkDeleter
+    def initialize(logger: Logger.new(STDOUT), base_paths:)
+      @log = logger
+      @base_paths = base_paths
+    end
+
+    def run!
+      @base_paths.each do |base_path|
+        @log.info "Clearing links for #{base_path}"
+
+        taxon_content_id = Services.publishing_api.lookup_content_id(base_path: base_path)
+        if taxon_content_id.blank?
+          raise ArgumentError, "No content ID found for base path #{base_path}"
+        end
+
+        linked_items = Services.publishing_api.get_linked_items(
+          taxon_content_id, link_type: 'alpha_taxons', fields: %w(content_id base_path)
+        )
+
+        linked_items.each do |linked_item|
+          @log.info "-- updated #{linked_item.fetch('base_path')}"
+          Services.publishing_api.patch_links(
+            linked_item.fetch("content_id"),
+            links: { alpha_taxons: [] }
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/alpha_taxonomy/taxon_linker.rb
+++ b/lib/alpha_taxonomy/taxon_linker.rb
@@ -10,7 +10,7 @@ module AlphaTaxonomy
     end
 
     def run!
-      ImportFile.new.grouped_mappings.each do |base_path, taxon_titles|
+      AlphaTaxonomy::ImportFileGroupings.new.extract.each do |base_path, taxon_titles|
         @log.info "BEGIN mapping for #{base_path}"
         taxon_content_ids = find_content_ids_for(taxon_titles)
         @log.info "Content IDs are: #{taxon_content_ids}"

--- a/lib/tasks/taxonomy.rake
+++ b/lib/tasks/taxonomy.rake
@@ -1,0 +1,32 @@
+namespace :taxonomy do
+  desc "Delete all taxon links for the list of taxon base paths set in the environment"
+  task delete_links: :environment do
+    base_paths = ENV.fetch("TAXON_CLEANUP").split(",")
+    AlphaTaxonomy::TaxonLinkDeleter.new(base_paths: base_paths).run!
+  end
+
+  desc "Generate the import file from the taxonomy sheets specified in the environment"
+  task import_file: :environment do
+    AlphaTaxonomy::ImportFile.new.populate
+  end
+
+  desc "Read the import file and create any new taxons found within"
+  task create_taxons: :environment do
+    AlphaTaxonomy::TaxonCreator.new.run!
+  end
+
+  desc "Read the import file and create all the taxon links specified"
+  task link_taxons: :environment do
+    AlphaTaxonomy::TaxonLinker.new.run!
+  end
+
+  desc "Run the complete bulk import process end-to-end"
+  task bulk_import: :environment do
+    # Note that this task is simply a wrapper for the discrete stages of the bulk
+    # import process. It makes no effort to clear pre-existing taxon links that
+    # no longer appear in the import file.
+    Rake::Task["import_file"].invoke
+    Rake::Task["create_taxons"].invoke
+    Rake::Task["link_taxons"].invoke
+  end
+end

--- a/lib/tasks/taxonomy.rake
+++ b/lib/tasks/taxonomy.rake
@@ -7,7 +7,8 @@ namespace :taxonomy do
 
   desc "Generate the import file from the taxonomy sheets specified in the environment"
   task import_file: :environment do
-    AlphaTaxonomy::ImportFile.new.populate
+    sheet_identifiers = ENV.fetch("TAXON_SHEETS").split(',')
+    AlphaTaxonomy::ImportFile.new(sheet_identifiers: sheet_identifiers).populate
   end
 
   desc "Read the import file and create any new taxons found within"

--- a/spec/features/bulk_taxon_import_spec.rb
+++ b/spec/features/bulk_taxon_import_spec.rb
@@ -36,17 +36,16 @@ RSpec.feature "Bulk taxon import" do
   end
 
   def given_taxonomy_data_is_available_from_a_remote_location
-    allow(ENV).to receive(:fetch).with("TAXON_SHEETS").and_return(
-      "test-spreadsheet,the-key,the-gid"
-    )
+    @the_key = 'the-key'
+    @the_gid = 'the-gid'
     stub_request(
-      :get, "https://docs.google.com/spreadsheets/d/the-key/pub?gid=the-gid&single=true&output=tsv"
+      :get, "https://docs.google.com/spreadsheets/d/#{@the_key}/pub?gid=#{@the_gid}&single=true&output=tsv"
     ).to_return(body: "mapped to\tlink\n" + "foo-taxon\t/test-path-1\n" + "bar-taxon\t/test-path-2\n")
   end
 
   def and_i_have_populated_a_local_import_file
     allow(AlphaTaxonomy::ImportFile).to receive(:location).and_return(test_import_file_location)
-    AlphaTaxonomy::ImportFile.new(logger: @dummy_logger).populate
+    AlphaTaxonomy::ImportFile.new(logger: @dummy_logger, sheet_identifiers: ['test-sheet', @the_key, @the_gid]).populate
 
     expect(File.exist? test_import_file_location).to be true
     expect(IO.readlines(test_import_file_location)).to include("foo-taxon\t/test-path-1\n")

--- a/spec/lib/alpha_taxonomy/import_file_groupings_spec.rb
+++ b/spec/lib/alpha_taxonomy/import_file_groupings_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+require "tempfile"
+
+RSpec.describe AlphaTaxonomy::ImportFileGroupings do
+  describe "#extract" do
+    context "if the import file is present and contains taxon data" do
+      before do
+        @temp_import_file = Tempfile.new('import_file_groupings_spec')
+        allow(AlphaTaxonomy::ImportFile).to receive(:location).and_return(@temp_import_file.path)
+        allow(CSV).to receive(:read).with(AlphaTaxonomy::ImportFile.location, col_sep: "\t", headers: true)
+          .and_return([
+            { "base_path" => "/foo-content-item-path", "taxon_title" => "foo-taxon" },
+            { "base_path" => "/bar-or-baz-content-item-path", "taxon_title" => "bar-taxon" },
+            { "base_path" => "/bar-or-baz-content-item-path", "taxon_title" => "baz-taxon" },
+          ])
+      end
+
+      after do
+        @temp_import_file.close
+        @temp_import_file.unlink
+      end
+
+      it "returns lists of taxons grouped by base_path" do
+        expect(AlphaTaxonomy::ImportFileGroupings.new.extract).to eq(
+          "/foo-content-item-path" => ["foo-taxon"],
+          "/bar-or-baz-content-item-path" => ["bar-taxon", "baz-taxon"]
+        )
+      end
+    end
+
+    context "if the import file is missing" do
+      it "raises an error" do
+        allow(AlphaTaxonomy::ImportFile).to receive(:location).and_return("/some-crazy-non-existing-path")
+        expect { AlphaTaxonomy::ImportFileGroupings.new.extract }.to raise_error(AlphaTaxonomy::SharedExceptions::MissingImportFileError)
+      end
+    end
+  end
+end

--- a/spec/lib/alpha_taxonomy/import_file_spec.rb
+++ b/spec/lib/alpha_taxonomy/import_file_spec.rb
@@ -77,33 +77,4 @@ RSpec.describe AlphaTaxonomy::ImportFile do
       expect(File.exist?(test_tsv_file_path)).to be false
     end
   end
-
-  describe "#grouped_mappings" do
-    context "if the import file is present" do
-      before do
-        stub_downloaded_sheet_data([
-          "foo-taxon\t" + "/foo-content-item-path",
-          "bar (br)| baz (bz)\t" + "/bar-or-baz-content-item-path",
-        ])
-        AlphaTaxonomy::ImportFile.new.populate
-      end
-
-      it "returns lists of taxons grouped by base_path" do
-        expect(AlphaTaxonomy::ImportFile.new.grouped_mappings).to eq(
-          "/foo-content-item-path" => ["foo-taxon"],
-          "/bar-or-baz-content-item-path" => ["bar (br)", "baz (bz)"]
-        )
-      end
-    end
-
-    context "if the import file is missing" do
-      it "raises an error" do
-        allow(AlphaTaxonomy::ImportFile).to receive(:location).and_return("/some-crazy-non-existing-path")
-
-        expect { AlphaTaxonomy::ImportFile.new.grouped_mappings }.to raise_error(
-          AlphaTaxonomy::SharedExceptions::MissingImportFileError
-        )
-      end
-    end
-  end
 end

--- a/spec/lib/alpha_taxonomy/sheet_downloader_spec.rb
+++ b/spec/lib/alpha_taxonomy/sheet_downloader_spec.rb
@@ -1,12 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe AlphaTaxonomy::SheetDownloader do
-  describe "#sheet_credential_tuples" do
-    context "given ENV is set with appropriate values" do
-      it "returns an array of sheet credentials" do
-        allow(ENV).to receive(:fetch).with("TAXON_SHEETS").and_return("sheet-name,the-key,the-gid")
+  describe "#new" do
+    context "sheet identifiers are set with appropriate values" do
+      it "correctly parses the identifiers into an array of tuples" do
+        downloader = AlphaTaxonomy::SheetDownloader.new(
+          logger: StringIO.new,
+          sheet_identifiers: ["sheet-name", "the-key", "the-gid"]
+        )
 
-        expect(AlphaTaxonomy::SheetDownloader.new(logger: StringIO.new).sheet_credential_tuples).to eq(
+        expect(downloader.sheet_identifier_tuples).to eq(
           [{ name: "sheet-name", key: "the-key", gid: "the-gid" }]
         )
       end
@@ -14,11 +17,14 @@ RSpec.describe AlphaTaxonomy::SheetDownloader do
 
     context "given ENV is set with inappropriate values" do
       it "raises an error" do
-        allow(ENV).to receive(:fetch).with("TAXON_SHEETS").and_return("sheet-name,the-key,the-gid,another-sheet-name")
+        instantiate_downloader = lambda do
+          AlphaTaxonomy::SheetDownloader.new(
+            logger: StringIO.new,
+            sheet_identifiers: ["sheet-name", "the-key", "the-gid", "another-sheet-name"]
+          )
+        end
 
-        expect { AlphaTaxonomy::SheetDownloader.new(logger: StringIO.new).sheet_credential_tuples }.to raise_error(
-          ArgumentError
-        )
+        expect(instantiate_downloader).to raise_error(ArgumentError)
       end
     end
   end

--- a/spec/lib/alpha_taxonomy/taxon_link_deleter_spec.rb
+++ b/spec/lib/alpha_taxonomy/taxon_link_deleter_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+RSpec.describe AlphaTaxonomy::TaxonLinkDeleter do
+  describe "#run!" do
+    context "given some taxon base paths that are linked to content" do
+      before do
+        publishing_api_has_lookups(
+          "/foo-taxon" => "foo-taxon-uuid",
+          "/bar-taxon" => "bar-taxon-uuid",
+        )
+        allow(Services.publishing_api).to receive(:get_linked_items)
+          .with("foo-taxon-uuid", link_type: 'alpha_taxons', fields: %w(content_id base_path))
+          .and_return([{ "content_id" => "linked-item-1", "base_path" => "/linked-item-1" }])
+        allow(Services.publishing_api).to receive(:get_linked_items)
+          .with("bar-taxon-uuid", link_type: 'alpha_taxons', fields: %w(content_id base_path))
+          .and_return([
+            { "content_id" => "linked-item-2", "base_path" => "/linked_item-2" },
+            { "content_id" => "linked-item-3", "base_path" => "/linked_item-3" }
+          ])
+      end
+
+      it "deletes the taxon links of any content items tagged to the provided taxons" do
+        expect(Services.publishing_api).to receive(:patch_links).with("linked-item-1", links: { alpha_taxons: [] })
+        expect(Services.publishing_api).to receive(:patch_links).with("linked-item-2", links: { alpha_taxons: [] })
+        expect(Services.publishing_api).to receive(:patch_links).with("linked-item-3", links: { alpha_taxons: [] })
+
+        AlphaTaxonomy::TaxonLinkDeleter.new(
+          logger: Logger.new(StringIO.new), base_paths: ["/foo-taxon", "/bar-taxon"]
+        ).run!
+      end
+    end
+
+    context "given a taxon base path that isn't linked to anything" do
+      before do
+        publishing_api_has_lookups("/foo-taxon" => "foo-taxon-uuid")
+        allow(Services.publishing_api).to receive(:get_linked_items)
+          .with("foo-taxon-uuid", link_type: 'alpha_taxons', fields: %w(content_id base_path))
+          .and_return([])
+      end
+
+      it "does nothing" do
+        expect(Services.publishing_api).to_not receive(:patch_links)
+
+        AlphaTaxonomy::TaxonLinkDeleter.new(
+          logger: Logger.new(StringIO.new), base_paths: ["/foo-taxon"]
+        ).run!
+      end
+    end
+  end
+end

--- a/spec/lib/alpha_taxonomy/taxon_linker_spec.rb
+++ b/spec/lib/alpha_taxonomy/taxon_linker_spec.rb
@@ -15,10 +15,9 @@ RSpec.describe AlphaTaxonomy::TaxonLinker do
       ).and_return(returned_taxon_collection.map(&:stringify_keys))
     end
 
-    def stub_import_file_mappings(returned_mappings)
-      import_file = AlphaTaxonomy::ImportFile.new
-      allow(import_file).to receive(:grouped_mappings).and_return(returned_mappings)
-      allow(AlphaTaxonomy::ImportFile).to receive(:new).and_return(import_file)
+    def stub_import_file_groupings(returned_groupings)
+      mock_grouping_object = double(AlphaTaxonomy::ImportFileGroupings, extract: returned_groupings)
+      allow(AlphaTaxonomy::ImportFileGroupings).to receive(:new).and_return(mock_grouping_object)
     end
 
     before do
@@ -27,7 +26,7 @@ RSpec.describe AlphaTaxonomy::TaxonLinker do
     end
 
     it "creates taxon links based on the grouped mappings" do
-      stub_import_file_mappings(
+      stub_import_file_groupings(
         "/a-foo-content-item" => ["Foo Taxon"],
         "/a-foo-bar-content-item" => ["foo Taxon", "Bar Taxon"]
       )
@@ -55,7 +54,7 @@ RSpec.describe AlphaTaxonomy::TaxonLinker do
 
     context "the import file taxons have inconsistent capitalisation" do
       before do
-        stub_import_file_mappings(
+        stub_import_file_groupings(
           "/a-foo-content-item" => ["Foo Taxon"],
           "/a-foo-bar-content-item" => ["foo tAxon"]
         )
@@ -86,7 +85,7 @@ RSpec.describe AlphaTaxonomy::TaxonLinker do
 
     context "when a duplicate mapping exists" do
       before do
-        stub_import_file_mappings(
+        stub_import_file_groupings(
           "/a-foo-content-item" => ["Foo Taxon", "Foo Taxon"],
         )
       end
@@ -111,7 +110,7 @@ RSpec.describe AlphaTaxonomy::TaxonLinker do
 
     context "when the grouped mappings contain a taxon not present in the content store" do
       it "raises an error" do
-        stub_import_file_mappings("/a-foo-content-item" => ["Foo Taxon"])
+        stub_import_file_groupings("/a-foo-content-item" => ["Foo Taxon"])
         stub_taxons_fetch([{ content_id: "irrelevant", base_path: "/alpha-taxonomy/other-taxon" }])
 
         expect { run_the_taxon_linker! }.to raise_error(
@@ -122,7 +121,7 @@ RSpec.describe AlphaTaxonomy::TaxonLinker do
 
     context "when the target content_item is not found by the lookup" do
       before do
-        stub_import_file_mappings("/a-foo-content-item" => ["Foo Taxon"], "/invalid-content-item" => ["Foo Taxon"])
+        stub_import_file_groupings("/a-foo-content-item" => ["Foo Taxon"], "/invalid-content-item" => ["Foo Taxon"])
         stub_taxons_fetch([{ content_id: "foo-taxon-uuid", base_path: "/alpha-taxonomy/foo-taxon" }])
 
         publishing_api_has_lookups(


### PR DESCRIPTION
This is useful in cases we want to upload a revised dataset for a given
taxon level as part of the alpha taxonomy definition work.

Trello: https://trello.com/c/UiRIcF91/551-taxon-bulk-import-add-functionality-to-bulk-delete-mappings-and-rename-taxons-with-dodgy-base-paths