### PR TITLE
Hide parent tag for contacts pages

### DIFF
--- a/config/blacklisted_tag_types.yml
+++ b/config/blacklisted_tag_types.yml
@@ -1,4 +1,4 @@
-contacts-admin:
+contacts:
   - parent
 travel-advice-publisher:
   # This is  a temporary workaround for the fact that 'parent' links

--- a/config/tagging-apps.yml
+++ b/config/tagging-apps.yml
@@ -9,7 +9,6 @@ calculators: content-tagger
 calendars: content-tagger
 collections-publisher: content-tagger
 contacts: content-tagger
-contacts-admin: content-tagger
 design-principles:
 email-campaign-frontend:
 external-link-tracker:


### PR DESCRIPTION
Pages published by contacts should not have a "Primary mainstream browse page" tagging.
https://github.com/alphagov/content-tagger/pull/48 tried to add that, but disallowed it for the wrong publishing app.

I've removed `contacts-admin` from the list to avoid confusion. This value was used for certain pages, but isn't anymore. All pages by `contacts-admin` have the publishing_app value of `contacts`.

Trello: https://trello.com/c/afa0Mfa4