### PR TITLE
[See other PRs] Allow tagging tariff content

### DIFF
--- a/config/tagging-apps.yml
+++ b/config/tagging-apps.yml
@@ -30,6 +30,6 @@ smartanswers: content-tagger
 specialist-publisher: specialist-publisher
 spotlight:
 static:
-tariff:
+tariff: content-tagger
 travel-advice-publisher: content-tagger
 whitehall: whitehall


### PR DESCRIPTION
Trade tariff tags are now handled by content tagger and publishing api.

Part of: https://trello.com/c/Aqvwgl1G/558-migrate-the-trade-tariff-page-to-new-tagging-infrastructure

Should be deployed with

* https://github.com/alphagov/panopticon/pull/333
* https://github.com/alphagov/rummager/pull/594
* https://github.com/alphagov/tagging-migration-verifier/pull/14