### PR TITLE
Add AlphaTaxonomy::TaxonRenamer

### DIFF
--- a/lib/alpha_taxonomy/taxon_renamer.rb
+++ b/lib/alpha_taxonomy/taxon_renamer.rb
@@ -1,0 +1,43 @@
+module AlphaTaxonomy
+  class TaxonRenamer
+    def initialize(logger: Logger.new(STDOUT), base_paths:)
+      @log = logger
+      @base_paths = base_paths
+    end
+
+    def run!
+      @base_paths.each do |base_path|
+        content_id = lookup_id_by_base_path(base_path)
+
+        next unless content_id
+
+        @log.info "-- Requesting base_path change to #{base_path[:to]}"
+
+        send_to_publishing_api(
+          content_id,
+          AlphaTaxonomy::TaxonPresenter.new(title: normalised_title(base_path[:to])).present
+        )
+      end
+    end
+
+  private
+
+    def normalised_title(base_path)
+      base_path.split('/').last.tr('-', ' ').capitalize
+    end
+
+    def send_to_publishing_api(content_id, payload)
+      Services.publishing_api.put_content(content_id, payload)
+      Services.publishing_api.publish(content_id, 'major')
+    end
+
+    def lookup_id_by_base_path(base_path)
+      @log.info "Requesting content_id to Publishing API for #{base_path[:from]}"
+      content_id = Services.publishing_api.lookup_content_id(base_path: base_path[:from])
+
+      @log.info "#{base_path[:from]} content_id was not found" unless content_id
+
+      content_id
+    end
+  end
+end

--- a/lib/tasks/taxonomy.rake
+++ b/lib/tasks/taxonomy.rake
@@ -38,18 +38,19 @@ namespace :taxonomy do
   end
 
   def parse_base_paths_string(base_paths)
-    array_of_paths = base_paths.split(',')
+    pair_of_paths = base_paths.split('|')
 
-    unless (array_of_paths.size % 2).zero?
+    unless pair_of_paths.all? { |pair| (pair.split(',').size % 2).zero? }
       raise ArgumentError, base_paths_error_message
     end
 
-    array_of_paths.each_slice(2).map do |tuplet|
-      { from: tuplet.first, to: tuplet.last }
+    pair_of_paths.map do |pair|
+      split_pair = pair.split(',')
+      { from: split_pair.first, to: split_pair.last }
     end
   end
 
   def base_paths_error_message
-    "base_paths is expected to be composed of two comma-separated values, like so: '/path1,/path1-rename,/path2,/path2-rename,...'"
+    "base_paths should be a set of pairs, delimited by a pipe character, like so: '/path1,/path1-rename|/path2,/path2-rename,...'"
   end
 end

--- a/lib/tasks/taxonomy.rake
+++ b/lib/tasks/taxonomy.rake
@@ -5,6 +5,12 @@ namespace :taxonomy do
     AlphaTaxonomy::TaxonLinkDeleter.new(base_paths: base_paths).run!
   end
 
+  desc "Rename the taxon base path from the list set in the environment TAXON_RENAMES"
+  task rename_base_paths: :environment do
+    base_paths = parse_base_paths_string(ENV.fetch("TAXON_RENAMES"))
+    AlphaTaxonomy::TaxonRenamer.new(base_paths: base_paths).run!
+  end
+
   desc "Generate the import file from the taxonomy sheets specified in the environment"
   task import_file: :environment do
     sheet_identifiers = ENV.fetch("TAXON_SHEETS").split(',')
@@ -29,5 +35,21 @@ namespace :taxonomy do
     Rake::Task["taxonomy:import_file"].invoke
     Rake::Task["taxonomy:create_taxons"].invoke
     Rake::Task["taxonomy:link_taxons"].invoke
+  end
+
+  def parse_base_paths_string(base_paths)
+    array_of_paths = base_paths.split(',')
+
+    unless (array_of_paths.size % 2).zero?
+      raise ArgumentError, base_paths_error_message
+    end
+
+    array_of_paths.each_slice(2).map do |tuplet|
+      { from: tuplet.first, to: tuplet.last }
+    end
+  end
+
+  def base_paths_error_message
+    "base_paths is expected to be composed of two comma-separated values, like so: '/path1,/path1-rename,/path2,/path2-rename,...'"
   end
 end

--- a/spec/lib/alpha_taxonomy/taxon_renamer_spec.rb
+++ b/spec/lib/alpha_taxonomy/taxon_renamer_spec.rb
@@ -1,0 +1,75 @@
+require 'rails_helper'
+
+RSpec.describe AlphaTaxonomy::TaxonRenamer do
+  describe "#run!" do
+    context "given some taxon base paths might require change" do
+      let(:base_paths) do
+        [
+          { from: "/alpha-taxonomy/awesome-taxon", to: "/alpha-taxonomy/renamed-awesome-taxon" },
+          { from: "/alpha-taxonomy/4-some-taxon", to: "/alpha-taxonomy/some-taxon" },
+        ]
+      end
+
+      def test_payload(title, base_path)
+        {
+          base_path: base_path,
+          format: 'taxon',
+          title: title,
+          publishing_app: 'collections-publisher',
+          rendering_app: 'collections',
+          public_updated_at: anything,
+          locale: 'en',
+          routes: [
+            { path: base_path, type: "exact" },
+          ]
+        }
+      end
+
+      it 'should fail when a string is used on base_paths' do
+        expect { AlphaTaxonomy::TaxonRenamer.new(base_paths: '/a,/b').run! }.to raise_error
+      end
+
+      it "requests Publishing API to change title and base_path" do
+        expect(Services.publishing_api).to receive(:lookup_content_id)
+          .with(base_path: "/alpha-taxonomy/awesome-taxon")
+          .and_return("awesome-taxon-uuid")
+
+        expect(Services.publishing_api).to receive(:lookup_content_id)
+          .with(base_path: "/alpha-taxonomy/4-some-taxon")
+          .and_return("4-some-taxon-uuid")
+
+        expect(Services.publishing_api).to receive(:publish)
+          .with("awesome-taxon-uuid", "major")
+
+        expect(Services.publishing_api).to receive(:publish)
+          .with("4-some-taxon-uuid", "major")
+
+        expect(Services.publishing_api).to receive(:put_content)
+          .with("awesome-taxon-uuid", test_payload('Renamed awesome taxon', "/alpha-taxonomy/renamed-awesome-taxon"))
+
+        expect(Services.publishing_api).to receive(:put_content)
+          .with("4-some-taxon-uuid", test_payload('Some taxon', "/alpha-taxonomy/some-taxon"))
+
+        AlphaTaxonomy::TaxonRenamer.new(base_paths: base_paths).run!
+      end
+
+      it 'should be valid against the taxon schema' do
+        valid_uuid = '143ccd35-6951-425a-9ff1-166d127e8f04'
+
+        expect(Services.publishing_api).to receive(:lookup_content_id)
+          .with(base_path: "/alpha-taxonomy/awesome-taxon")
+          .and_return(valid_uuid)
+
+        expect(Services.publishing_api).to receive(:put_content)
+          .with(valid_uuid, be_valid_against_schema('taxon'))
+          .once
+
+        expect(Services.publishing_api).to receive(:publish)
+          .with(valid_uuid, "major")
+          .once
+
+        AlphaTaxonomy::TaxonRenamer.new(base_paths: [base_paths.first]).run!
+      end
+    end
+  end
+end

--- a/spec/lib/alpha_taxonomy/taxon_renamer_spec.rb
+++ b/spec/lib/alpha_taxonomy/taxon_renamer_spec.rb
@@ -2,74 +2,69 @@ require 'rails_helper'
 
 RSpec.describe AlphaTaxonomy::TaxonRenamer do
   describe "#run!" do
-    context "given some taxon base paths might require change" do
-      let(:base_paths) do
-        [
-          { from: "/alpha-taxonomy/awesome-taxon", to: "/alpha-taxonomy/renamed-awesome-taxon" },
-          { from: "/alpha-taxonomy/4-some-taxon", to: "/alpha-taxonomy/some-taxon" },
+    it 'fails when a string is used on base_paths' do
+      expect { AlphaTaxonomy::TaxonRenamer.new(base_paths: '/a,/b').run! }.to raise_error
+    end
+
+    let(:base_paths) do
+      [
+        { from: "/alpha-taxonomy/awesome-taxon", to: "/alpha-taxonomy/renamed-awesome-taxon" },
+        { from: "/alpha-taxonomy/4-some-taxon", to: "/alpha-taxonomy/some-taxon" },
+      ]
+    end
+
+    let(:lookup_hash) do
+      {
+        "/alpha-taxonomy/awesome-taxon" => "12fef5c0-c906-4889-926a-05fbb2a3742b",
+        "/alpha-taxonomy/4-some-taxon"  => "7ff013ad-9338-4a70-b770-69bdc5399324",
+      }
+    end
+
+    def test_payload(title, base_path)
+      {
+        base_path: base_path,
+        format: 'taxon',
+        title: title,
+        publishing_app: 'collections-publisher',
+        rendering_app: 'collections',
+        public_updated_at: anything,
+        locale: 'en',
+        routes: [
+          { path: base_path, type: "exact" },
         ]
-      end
+      }
+    end
 
-      def test_payload(title, base_path)
-        {
-          base_path: base_path,
-          format: 'taxon',
-          title: title,
-          publishing_app: 'collections-publisher',
-          rendering_app: 'collections',
-          public_updated_at: anything,
-          locale: 'en',
-          routes: [
-            { path: base_path, type: "exact" },
-          ]
-        }
-      end
+    before do
+      publishing_api_has_lookups(lookup_hash)
+    end
 
-      it 'should fail when a string is used on base_paths' do
-        expect { AlphaTaxonomy::TaxonRenamer.new(base_paths: '/a,/b').run! }.to raise_error
-      end
+    it "requests Publishing API to change title and base_path" do
+      expect(Services.publishing_api).to receive(:publish)
+        .with("12fef5c0-c906-4889-926a-05fbb2a3742b", "major")
 
-      it "requests Publishing API to change title and base_path" do
-        expect(Services.publishing_api).to receive(:lookup_content_id)
-          .with(base_path: "/alpha-taxonomy/awesome-taxon")
-          .and_return("awesome-taxon-uuid")
+      expect(Services.publishing_api).to receive(:publish)
+        .with("7ff013ad-9338-4a70-b770-69bdc5399324", "major")
 
-        expect(Services.publishing_api).to receive(:lookup_content_id)
-          .with(base_path: "/alpha-taxonomy/4-some-taxon")
-          .and_return("4-some-taxon-uuid")
+      expect(Services.publishing_api).to receive(:put_content)
+        .with("12fef5c0-c906-4889-926a-05fbb2a3742b", test_payload('Renamed awesome taxon', "/alpha-taxonomy/renamed-awesome-taxon"))
 
-        expect(Services.publishing_api).to receive(:publish)
-          .with("awesome-taxon-uuid", "major")
+      expect(Services.publishing_api).to receive(:put_content)
+        .with("7ff013ad-9338-4a70-b770-69bdc5399324", test_payload('Some taxon', "/alpha-taxonomy/some-taxon"))
 
-        expect(Services.publishing_api).to receive(:publish)
-          .with("4-some-taxon-uuid", "major")
+      AlphaTaxonomy::TaxonRenamer.new(base_paths: base_paths).run!
+    end
 
-        expect(Services.publishing_api).to receive(:put_content)
-          .with("awesome-taxon-uuid", test_payload('Renamed awesome taxon', "/alpha-taxonomy/renamed-awesome-taxon"))
+    it 'is valid against the taxon schema' do
+      expect(Services.publishing_api).to receive(:put_content)
+        .with("12fef5c0-c906-4889-926a-05fbb2a3742b", be_valid_against_schema('taxon'))
+        .once
 
-        expect(Services.publishing_api).to receive(:put_content)
-          .with("4-some-taxon-uuid", test_payload('Some taxon', "/alpha-taxonomy/some-taxon"))
+      expect(Services.publishing_api).to receive(:publish)
+        .with("12fef5c0-c906-4889-926a-05fbb2a3742b", "major")
+        .once
 
-        AlphaTaxonomy::TaxonRenamer.new(base_paths: base_paths).run!
-      end
-
-      it 'should be valid against the taxon schema' do
-        valid_uuid = '143ccd35-6951-425a-9ff1-166d127e8f04'
-
-        expect(Services.publishing_api).to receive(:lookup_content_id)
-          .with(base_path: "/alpha-taxonomy/awesome-taxon")
-          .and_return(valid_uuid)
-
-        expect(Services.publishing_api).to receive(:put_content)
-          .with(valid_uuid, be_valid_against_schema('taxon'))
-          .once
-
-        expect(Services.publishing_api).to receive(:publish)
-          .with(valid_uuid, "major")
-          .once
-
-        AlphaTaxonomy::TaxonRenamer.new(base_paths: [base_paths.first]).run!
-      end
+      AlphaTaxonomy::TaxonRenamer.new(base_paths: [base_paths.first]).run!
     end
   end
 end

--- a/spec/lib/tasks/taxonomy_spec.rb
+++ b/spec/lib/tasks/taxonomy_spec.rb
@@ -11,11 +11,12 @@ RSpec.describe 'taxonomy rake task' do
     let(:expected_base_paths) do
       [
         { from: '/alpha-taxonomy/a', to: '/alpha-taxonomy/b' },
+        { from: '/alpha-taxonomy/c', to: '/alpha-taxonomy/d' },
       ]
     end
 
     it 'should receive an array of hashes' do
-      ENV['TAXON_RENAMES'] = '/alpha-taxonomy/a,/alpha-taxonomy/b'
+      ENV['TAXON_RENAMES'] = '/alpha-taxonomy/a,/alpha-taxonomy/b|/alpha-taxonomy/c,/alpha-taxonomy/d'
 
       taxon_renamer_double = double run!: true
 

--- a/spec/lib/tasks/taxonomy_spec.rb
+++ b/spec/lib/tasks/taxonomy_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+require 'rake'
+
+RSpec.describe 'taxonomy rake task' do
+  describe 'taxonomy:rename_base_paths' do
+    before do
+      load './lib/tasks/taxonomy.rake'
+      Rake::Task.define_task(:environment)
+    end
+
+    let(:expected_base_paths) do
+      [
+        { from: '/alpha-taxonomy/a', to: '/alpha-taxonomy/b' },
+      ]
+    end
+
+    it 'should receive an array of hashes' do
+      ENV['TAXON_RENAMES'] = '/alpha-taxonomy/a,/alpha-taxonomy/b'
+
+      taxon_renamer_double = double run!: true
+
+      expect(AlphaTaxonomy::TaxonRenamer).to receive(:new)
+        .with(base_paths: expected_base_paths)
+        .and_return(taxon_renamer_double)
+
+      Rake::Task["taxonomy:rename_base_paths"].invoke
+    end
+  end
+end


### PR DESCRIPTION
Script to rename taxons with spurious numeric prefix.

They were introduced in a spreadsheet in order to know the hierarchy of
certain taxonomies, but they should not belong in the base_path.

This problem wont recur in future because the spreadsheet has been
fixed.

paired with @benhyland 