### PR TITLE
Allow tagging for service-manual-publisher

### DIFF
--- a/config/blacklisted-apps.yml
+++ b/config/blacklisted-apps.yml
@@ -1,7 +1,6 @@
 # The list of `publishing_app`s that should not be taggable in content tagger.
 
 - publisher
-- service-manual-publisher
 - specialist-publisher
 - whitehall
 - non-migrated-app


### PR DESCRIPTION
Service manual publisher has been migrated to the new tagging mechanism.

See https://trello.com/c/FSo3C9Qf/591-allow-tagging-for-service-manual-publisher

Other blacklists:
https://github.com/alphagov/panopticon/pull/343
https://github.com/alphagov/rummager/pull/621