### PR TITLE
Change the way we determine which tag-types can be used per application 

### DIFF
--- a/app/forms/tagging_update_form.rb
+++ b/app/forms/tagging_update_form.rb
@@ -1,7 +1,9 @@
 class TaggingUpdateForm
   include ActiveModel::Model
   attr_accessor :content_item, :content_id, :previous_version
-  attr_accessor :topics, :organisations, :mainstream_browse_pages, :parent, :alpha_taxons
+
+  TAG_TYPES = %i(topics mainstream_browse_pages organisations alpha_taxons parent)
+  attr_accessor(*TAG_TYPES)
 
   # Return a new LinkUpdate object with topics, mainstream_browse_pages,
   # organisations and content_item set.
@@ -32,15 +34,14 @@ class TaggingUpdateForm
   end
 
   def links_payload
-    payload = {
-      topics: clean_content_ids(topics),
-      mainstream_browse_pages: clean_content_ids(mainstream_browse_pages),
-      organisations: clean_content_ids(organisations),
-      alpha_taxons: clean_content_ids(alpha_taxons),
-    }
+    payload = {}
 
-    # Because 'parent' might be a blacklisted field switched off in the form
-    payload.merge!(parent: clean_content_ids(parent)) unless parent.nil?
+    TAG_TYPES.each do |tag_type|
+      content_ids = send(tag_type)
+      # Because the field might be a blacklisted field switched off in the form.
+      next if content_ids.nil?
+      payload.merge!(tag_type => clean_content_ids(content_ids))
+    end
 
     payload
   end

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -1,12 +1,11 @@
 class ContentItem
   TAG_TYPES = %w(mainstream_browse_pages parent topics organisations alpha_taxons)
 
-  attr_reader :content_id, :title, :format, :base_path, :publishing_app
+  attr_reader :content_id, :title, :base_path, :publishing_app
 
   def initialize(data)
     @content_id = data.fetch('content_id')
     @title = data.fetch('title')
-    @format = data.fetch('format')
     @base_path = data.fetch('base_path')
     @publishing_app = data.fetch('publishing_app')
   end
@@ -14,6 +13,7 @@ class ContentItem
   def self.find!(content_id)
     content_item = Services.publishing_api.get_content(content_id)
     raise ItemNotFoundError unless content_item
+    raise ItemNotFoundError if content_item.format.in?(%w(redirect gone))
     new(content_item.to_h)
   end
 
@@ -21,28 +21,9 @@ class ContentItem
     @link_set ||= LinkSet.find(content_id)
   end
 
-  def tagging_allowed?
-    app_responsible_for_tagging == "content-tagger"
-  end
-
-  def app_responsible_for_tagging
-    return if format.in?(%w(redirect gone))
-
-    @tagging_apps ||= YAML.load_file("#{Rails.root}/config/blacklisted-apps.yml")
-    @tagging_apps.include?(publishing_app) ? publishing_app : "content-tagger"
-  end
-
-  def external_tagging_url
-    if app_responsible_for_tagging == 'whitehall'
-      Plek.new.find('whitehall-admin')
-    else
-      Plek.new.find(app_responsible_for_tagging)
-    end
-  end
-
   def blacklisted_tag_types
     blacklist = YAML.load_file("#{Rails.root}/config/blacklisted-tag-types.yml")
-    Array blacklist[publishing_app]
+    Array(blacklist[publishing_app])
   end
 
   class ItemNotFoundError < StandardError

--- a/app/views/content/_not_migrated_yet.html.erb
+++ b/app/views/content/_not_migrated_yet.html.erb
@@ -1,9 +1,0 @@
-<div class="callout callout-info">
-  <div class="callout-title">
-    Tagging not possible
-  </div>
-  <div class="callout-body">
-    We haven't migrated the tagging for this item yet. You can try to take a look in
-    <%= link_to @content_item.app_responsible_for_tagging.underscore.titleize, @content_item.external_tagging_url %>.
-  </div>
-</div>

--- a/app/views/content/show.html.erb
+++ b/app/views/content/show.html.erb
@@ -6,17 +6,12 @@
 
 <hr/>
 
-<% if @content_item.tagging_allowed? %>
-  <%= render(
-    partial: 'tagging_form',
-    locals: {
-      tagging_update: @tagging_update,
-      tag_types: @tag_types,
-      linkables: @linkables
-    }
-  )
+<%= render(
+  partial: 'tagging_form',
+  locals: {
+    tagging_update: @tagging_update,
+    tag_types: @tag_types,
+    linkables: @linkables
+  }
+)
 %>
-
-<% else %>
-  <%= render 'not_migrated_yet' %>
-<% end %>

--- a/config/blacklisted-apps.yml
+++ b/config/blacklisted-apps.yml
@@ -1,6 +1,0 @@
-# The list of `publishing_app`s that should not be taggable in content tagger.
-
-- publisher
-- specialist-publisher
-- whitehall
-- non-migrated-app

--- a/config/blacklisted-tag-types.yml
+++ b/config/blacklisted-tag-types.yml
@@ -1,5 +1,6 @@
 contacts:
   - parent
+
 travel-advice-publisher:
   # This is  a temporary workaround for the fact that 'parent' links
   # can sometimes be blobs of JSON (containing a breadcrumb, for example)
@@ -8,6 +9,7 @@ travel-advice-publisher:
   # support this or wait until the publishing API no longer allows writing of
   # arbitrary JSON to the parent link.
   - parent
+
 whitehall:
   # The 'parent' for a Whitehall edition (Editions being the only Whitehall
   # document type we are expecting to tag in content-tagger) is always a

--- a/config/blacklisted-tag-types.yml
+++ b/config/blacklisted-tag-types.yml
@@ -44,3 +44,10 @@ specialist-publisher:
   - mainstream_browse_pages
   - organisations
   - parent
+
+# used in the tests
+test-app-that-can-be-tagged-to-topics-only:
+  - alpha_taxons
+  - mainstream_browse_pages
+  - organisations
+  - parent

--- a/config/blacklisted-tag-types.yml
+++ b/config/blacklisted-tag-types.yml
@@ -17,3 +17,30 @@ whitehall:
   # Temporarily blacklisting this field for now until content-tagger supports
   # tagging topics in the parent field.
   - parent
+
+  # Topics are still managed in whitehall itself
+  - topics
+
+  # Organisations are still managed in whitehall itself
+  - organisations
+
+  # Mainstream browse taggings are done in panopticon
+  - mainstream_browse_pages
+
+publisher:
+  # Publisher is not migrated yet. Its browse pages, topics and parent are
+  # set inside publisher.
+  - mainstream_browse_pages
+  - topics
+  - parent
+
+  # Tagging to organisation is done in panopticon
+  - organisations
+
+# specialist-publisher is not migrated yet. Its browse pages, topics and parent are
+# set inside specialist-publisher and panopticon.
+specialist-publisher:
+  - topics
+  - mainstream_browse_pages
+  - organisations
+  - parent

--- a/spec/features/tagging_content_spec.rb
+++ b/spec/features/tagging_content_spec.rb
@@ -4,30 +4,7 @@ RSpec.describe "Tagging content", type: :feature do
   include PublishingApiHelper
 
   before do
-    publishing_api_has_topics(
-      [
-        "/topic/id-of-already-tagged",
-        "/topic/business-tax/pension-scheme-administration",
-      ]
-    )
-
-    publishing_api_has_taxons(
-      [
-        "/alpha-taxonomy/vehicle-plating",
-      ]
-    )
-
-    publishing_api_has_organisations(
-      [
-        "/government/organisations/student-loans-company",
-      ]
-    )
-
-    publishing_api_has_mainstream_browse_pages(
-      [
-        "/browse/driving/car-tax-discs",
-      ]
-    )
+    given_we_can_populate_the_dropdowns_with_content_from_publishing_api
   end
 
   scenario "User looks up and tags a content item" do
@@ -157,5 +134,24 @@ RSpec.describe "Tagging content", type: :feature do
     }
 
     expect(@tagging_request.with(body: body.to_json)).to have_been_made
+  end
+
+  def given_we_can_populate_the_dropdowns_with_content_from_publishing_api
+    publishing_api_has_topics([
+      "/topic/id-of-already-tagged",
+      "/topic/business-tax/pension-scheme-administration",
+    ])
+
+    publishing_api_has_taxons([
+      "/alpha-taxonomy/vehicle-plating",
+    ])
+
+    publishing_api_has_organisations([
+      "/government/organisations/student-loans-company",
+    ])
+
+    publishing_api_has_mainstream_browse_pages([
+      "/browse/driving/car-tax-discs",
+    ])
   end
 end

--- a/spec/features/tagging_content_spec.rb
+++ b/spec/features/tagging_content_spec.rb
@@ -43,12 +43,6 @@ RSpec.describe "Tagging content", type: :feature do
     then_the_new_links_are_sent_to_the_publishing_api
   end
 
-  scenario "User looks up an untaggable page" do
-    given_there_is_an_untaggable_page
-    and_i_am_on_the_page_for_the_item
-    then_i_see_that_the_page_is_untaggable
-  end
-
   scenario "User makes a conflicting change" do
     given_there_is_a_content_item_with_tags
     and_i_am_on_the_page_for_the_item
@@ -84,20 +78,6 @@ RSpec.describe "Tagging content", type: :feature do
     visit "/content/MY-CONTENT-ID"
   end
 
-  def given_there_is_an_untaggable_page
-    stub_request(:get, "#{PUBLISHING_API}/v2/content/MY-CONTENT-ID")
-      .to_return(body: {
-        publishing_app: "non-migrated-app",
-        content_id: "MY-CONTENT-ID",
-        base_path: '/my-content-item',
-        format: 'mainstream_browse_page',
-        title: 'This Is A Content Item',
-      }.to_json)
-
-    stub_request(:get, "#{PUBLISHING_API}/v2/links/MY-CONTENT-ID")
-      .to_return(body: {}.to_json)
-  end
-
   def given_there_is_a_content_item_with_tags
     publishing_api_has_lookups(
       '/my-content-item' => 'MY-CONTENT-ID'
@@ -120,10 +100,6 @@ RSpec.describe "Tagging content", type: :feature do
         },
         version: 54_321,
       }.to_json)
-  end
-
-  def then_i_see_that_the_page_is_untaggable
-    expect(page).to have_content "We haven't migrated the tagging for this item yet."
   end
 
   def and_i_submit_the_url_of_the_content_item

--- a/spec/features/tagging_during_migration_spec.rb
+++ b/spec/features/tagging_during_migration_spec.rb
@@ -1,0 +1,85 @@
+require "rails_helper"
+
+RSpec.describe "Tagging content during migration", type: :feature do
+  include PublishingApiHelper
+
+  before do
+    given_we_can_populate_the_dropdowns_with_content_from_publishing_api
+  end
+
+  scenario "User makes a change to a content item which has had some of its link types disabled" do
+    given_there_is_an_item_that_can_have_only_one_link_type
+
+    when_i_visit_the_homepage
+    and_i_submit_the_url_of_the_content_item
+
+    when_i_add_an_additional_tag
+    and_i_submit_the_form
+
+    then_only_that_link_type_is_sent_to_the_publishing_api
+  end
+
+  def given_we_can_populate_the_dropdowns_with_content_from_publishing_api
+    publishing_api_has_topics([
+      "/topic/id-of-already-tagged",
+      "/topic/business-tax/pension-scheme-administration",
+    ])
+  end
+
+  def given_there_is_an_item_that_can_have_only_one_link_type
+    publishing_api_has_lookups(
+      '/my-content-item' => 'MY-CONTENT-ID'
+    )
+
+    stub_request(:get, "#{PUBLISHING_API}/v2/content/MY-CONTENT-ID")
+      .to_return(body: {
+        # see blacklisted-tag-types.yml for this
+        publishing_app: "test-app-that-can-be-tagged-to-topics-only",
+        content_id: "MY-CONTENT-ID",
+        base_path: '/my-content-item',
+        format: 'mainstream_browse_page',
+        title: 'This Is A Content Item',
+      }.to_json)
+
+    stub_request(:get, "#{PUBLISHING_API}/v2/links/MY-CONTENT-ID")
+      .to_return(body: {
+        content_id: "MY-CONTENT-ID",
+        links: {
+          topics: "ID-OF-ALREADY-TAGGED",
+          mainstream_browse_pages: "ID-OF-ALREADY-TAGGED-BROWSE-PAGE",
+        },
+        version: 54_321,
+      }.to_json)
+  end
+
+  def when_i_visit_the_homepage
+    visit root_path
+  end
+
+  def and_i_submit_the_url_of_the_content_item
+    fill_in 'content_lookup_form_base_path', with: '/my-content-item'
+    click_on 'Show content item'
+  end
+
+  def when_i_add_an_additional_tag
+    select "Business tax / Pension scheme administration", from: "Topics"
+  end
+
+  def and_i_submit_the_form
+    @tagging_request = stub_request(:patch, "#{PUBLISHING_API}/v2/links/MY-CONTENT-ID")
+      .to_return(status: 200)
+
+    click_on 'Update tags'
+  end
+
+  def then_only_that_link_type_is_sent_to_the_publishing_api
+    body = {
+      links: {
+        topics: ["e1d6b771-a692-4812-a4e7-7562214286ef", "ID-OF-ALREADY-TAGGED"],
+      },
+      previous_version: 54_321,
+    }
+
+    expect(@tagging_request.with(body: body.to_json)).to have_been_made
+  end
+end

--- a/spec/forms/tagging_update_form_spec.rb
+++ b/spec/forms/tagging_update_form_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe TaggingUpdateForm do
       )
     end
 
-    it 'does not include parent if parent is not in the form list' do
+    it "does not include a key if it wasn't submitted from the form" do
       form = TaggingUpdateForm.new(
         topics: [],
         organisations: [],
@@ -33,7 +33,6 @@ RSpec.describe TaggingUpdateForm do
 
       expect(links_payload).to eql(
         topics: [],
-        mainstream_browse_pages: [],
         organisations: [],
         alpha_taxons: [],
       )

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -36,17 +36,4 @@ RSpec.describe ContentItem do
       end
     end
   end
-
-  describe '#app_responsible_for_tagging' do
-    it "doesn't have one if the format is unrenderable" do
-      item = ContentItem.new(
-        content_item_params.merge(
-          'format' => 'redirect',
-          'publishing_app' => 'a-migrated-app',
-        )
-      )
-
-      expect(item.app_responsible_for_tagging).to be_nil
-    end
-  end
 end


### PR DESCRIPTION
This PR changes the way in which we determine whether or not a item can be tagged to a certain tag type.

Currently we have a blacklist of apps for which the content-tagger doesn't allow tagging. This PR changes that to have an explicit blacklist of _tag-types_ that are not allowed per publishing-app.

This means 1) we can tag all content on the site to alpha taxons, 2) we can enable certain tag types for certain apps. This allows us to retire the tagging functionality in panopticon.

## Before

![screen shot 2016-04-19 at 12 34 28](https://cloud.githubusercontent.com/assets/233676/14637706/f5af0722-062a-11e6-8a0f-aef54925a60d.png)

## After

![screen shot 2016-04-19 at 12 34 00](https://cloud.githubusercontent.com/assets/233676/14637705/f584aa22-062a-11e6-9818-e4bfb6e85fea.png)

Trello: https://trello.com/c/4vU2VrC0