### PR TITLE
Allow content-tagger to deal with specialist-publisher content

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -1,13 +1,14 @@
 class ContentItem
   TAG_TYPES = %w(mainstream_browse_pages parent topics organisations alpha_taxons)
 
-  attr_reader :content_id, :title, :base_path, :publishing_app
+  attr_reader :content_id, :title, :base_path, :publishing_app, :format
 
   def initialize(data)
     @content_id = data.fetch('content_id')
     @title = data.fetch('title')
     @base_path = data.fetch('base_path')
     @publishing_app = data.fetch('publishing_app')
+    @format = data.fetch('format')
   end
 
   def self.find!(content_id)
@@ -23,9 +24,15 @@ class ContentItem
 
   def blacklisted_tag_types
     blacklist = YAML.load_file("#{Rails.root}/config/blacklisted-tag-types.yml")
-    Array(blacklist[publishing_app])
+    Array(blacklist[publishing_app]) + additional_temporary_blacklist
   end
 
   class ItemNotFoundError < StandardError
+  end
+
+private
+
+  def additional_temporary_blacklist
+    publishing_app == 'specialist-publisher' && format == 'finder' ? ['topics'] : []
   end
 end

--- a/config/blacklisted-tag-types.yml
+++ b/config/blacklisted-tag-types.yml
@@ -37,11 +37,9 @@ publisher:
   # Tagging to organisation is done in panopticon
   - organisations
 
-# specialist-publisher is not migrated yet. Its browse pages, topics and parent are
+# specialist-publisher is not migrated yet. Its organisations and parent are
 # set inside specialist-publisher and panopticon.
 specialist-publisher:
-  - topics
-  - mainstream_browse_pages
   - organisations
   - parent
 

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -35,5 +35,20 @@ RSpec.describe ContentItem do
         expect(content_item.blacklisted_tag_types).to eq []
       end
     end
+
+    context "for finder blacklisting during specialist-publisher migration" do
+      let(:content_item) do
+        ContentItem.new(
+          content_item_params.merge(
+            'publishing_app' => 'specialist-publisher',
+            'format' => 'finder',
+          )
+        )
+      end
+
+      it "blacklists topics as well as other tag types" do
+        expect(content_item.blacklisted_tag_types).to include 'topics'
+      end
+    end
   end
 end


### PR DESCRIPTION
As part of migrating specialist-publisher tagging to content-tagger,
allow content-tagger to handle browse pages and topics for specialist-publisher.

We already prevented panopticon from handling specialist-publisher tags
(https://github.com/alphagov/panopticon/pull/357 and https://github.com/alphagov/panopticon/pull/358).

We make an exception for the link type 'topics' for specialist-publisher finders.
Specialist publisher still hardcodes these, and they are not yet in publishing-api,
so it is not safe to handle them in content-tagger.

https://trello.com/c/YoeWtswr/609-totally-migrate-specialist-publisher-v1-tagging