### PR TITLE
Add a jenkins-schema.sh script for contract testing

### DIFF
--- a/jenkins-schema.sh
+++ b/jenkins-schema.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+GH_STATUS_REPO_NAME="alphagov/govuk-content-schemas"
+CONTEXT_MESSAGE="Verify collections-publisher against content schemas"
+
+exec ./jenkins.sh


### PR DESCRIPTION
This script will be used by the jenkins schema test job, which will be called as a downstream project for content schema tests:

https://ci.dev.publishing.service.gov.uk/job/govuk_content_tagger_schema_tests/