### PR TITLE
Add empty `details` to content item payload

### DIFF
--- a/lib/alpha_taxonomy/taxon_presenter.rb
+++ b/lib/alpha_taxonomy/taxon_presenter.rb
@@ -22,6 +22,7 @@ module AlphaTaxonomy
         rendering_app: 'collections',
         public_updated_at: DateTime.current.iso8601,
         locale: "en",
+        details: {},
         routes: [
           { path: base_path, type: "exact" },
         ]

--- a/spec/lib/alpha_taxonomy/taxon_presenter_spec.rb
+++ b/spec/lib/alpha_taxonomy/taxon_presenter_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe AlphaTaxonomy::TaxonPresenter do
         public_updated_at: DateTime.new(0).iso8601,
         publishing_app: "collections-publisher",
         rendering_app: "collections",
+        details: {},
         routes: [path: "/alpha-taxonomy/foobar-taxon", type: "exact"],
         title: "Foobar Taxon",
       )

--- a/spec/lib/alpha_taxonomy/taxon_renamer_spec.rb
+++ b/spec/lib/alpha_taxonomy/taxon_renamer_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe AlphaTaxonomy::TaxonRenamer do
         rendering_app: 'collections',
         public_updated_at: anything,
         locale: 'en',
+        details: {},
         routes: [
           { path: base_path, type: "exact" },
         ]


### PR DESCRIPTION
`details` will be required from https://github.com/alphagov/govuk-content-schemas/pull/310