### PR TITLE
Disable tagging to orgs for service-manual-publisher

### DIFF
--- a/config/blacklisted-tag-types.yml
+++ b/config/blacklisted-tag-types.yml
@@ -56,6 +56,11 @@ specialist-publisher:
   # navigation.
   - parent
 
+service-manual-publisher:
+  # The service-manual-publisher automatically tags everything to the GDS
+  # organisation and overwrites the `organisations` link type on each publish.
+  - organisations
+
 # Used in the tests
 test-app-that-can-be-tagged-to-topics-only:
   - alpha_taxons


### PR DESCRIPTION
This is needed after: https://github.com/alphagov/service-manual-publisher/pull/277