### PR TITLE
Use document_type instead of format

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -1,20 +1,20 @@
 class ContentItem
   TAG_TYPES = %w(mainstream_browse_pages parent topics organisations alpha_taxons)
 
-  attr_reader :content_id, :title, :base_path, :publishing_app, :format
+  attr_reader :content_id, :title, :base_path, :publishing_app, :document_type
 
   def initialize(data)
     @content_id = data.fetch('content_id')
     @title = data.fetch('title')
     @base_path = data.fetch('base_path')
     @publishing_app = data.fetch('publishing_app')
-    @format = data.fetch('format')
+    @document_type = data.fetch('document_type')
   end
 
   def self.find!(content_id)
     content_item = Services.publishing_api.get_content(content_id)
     raise ItemNotFoundError unless content_item
-    raise ItemNotFoundError if content_item.format.in?(%w(redirect gone))
+    raise ItemNotFoundError if content_item.document_type.in?(%w(redirect gone))
     new(content_item.to_h)
   end
 
@@ -33,6 +33,6 @@ class ContentItem
 private
 
   def additional_temporary_blacklist
-    publishing_app == 'specialist-publisher' && format == 'finder' ? ['topics'] : []
+    publishing_app == 'specialist-publisher' && document_type == 'finder' ? ['topics'] : []
   end
 end

--- a/spec/features/tagging_content_spec.rb
+++ b/spec/features/tagging_content_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe "Tagging content", type: :feature do
         publishing_app: "a-migrated-app",
         content_id: "MY-CONTENT-ID",
         base_path: '/my-content-item',
-        format: 'mainstream_browse_page',
+        document_type: 'mainstream_browse_page',
         title: 'This Is A Content Item',
       }.to_json)
 

--- a/spec/features/tagging_during_migration_spec.rb
+++ b/spec/features/tagging_during_migration_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "Tagging content during migration", type: :feature do
         publishing_app: "test-app-that-can-be-tagged-to-topics-only",
         content_id: "MY-CONTENT-ID",
         base_path: '/my-content-item',
-        format: 'mainstream_browse_page',
+        document_type: 'mainstream_browse_page',
         title: 'This Is A Content Item',
       }.to_json)
 

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ContentItem do
     {
       'content_id'     => 'uuid-88',
       'title'          => 'A content item',
-      'format'         => 'placeholder',
+      'document_type'         => 'placeholder',
       'base_path'      => '/a-content-item',
       'publishing_app' => 'whitehall'
     }
@@ -41,7 +41,7 @@ RSpec.describe ContentItem do
         ContentItem.new(
           content_item_params.merge(
             'publishing_app' => 'specialist-publisher',
-            'format' => 'finder',
+            'document_type' => 'finder',
           )
         )
       end


### PR DESCRIPTION
Format is going to be removed from publishing api responses.

This field was split into two new fields:
- schema_name: used for validatation
- document_type: used by frontend and filtering in publishing apps

Further information: https://gov-uk.atlassian.net/wiki/display/GOVUK/RFC+41%3A+Separate+document+type+from+format