### PR TITLE
Revert "Blacklist organisations for Contacts"

### DIFF
--- a/config/blacklisted-tag-types.yml
+++ b/config/blacklisted-tag-types.yml
@@ -3,8 +3,6 @@ contacts:
   # have a breadcrumb to the HMRC contact page (https://www.gov.uk/government/organisations/hm-revenue-customs/contact)
   # Allowing to tag to the parent here would be confusing to the user.
   - parent
-  # Organisations are currently set by the contacts-admin application
-  - organisations
 
 travel-advice-publisher:
   # This is  a temporary workaround for the fact that 'parent' links


### PR DESCRIPTION
Reverts alphagov/content-tagger#72. We're allowing this anyway, because contacts only sends `organisations` on creation.

More context: https://github.com/alphagov/contacts-admin/pull/231