### PR TITLE
Add taxon related functionality

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -50,3 +50,37 @@ form label {
     display: none;
   }
 }
+
+table {
+  @extend .table;
+  @extend .table-bordered;
+  @extend .table-striped;
+}
+
+.heading-with-actions {
+  margin: 10px 0 20px;
+  overflow: hidden;
+
+  h1, h2 {
+    float: left;
+    line-height: 1.4;
+    margin: 0;
+  }
+
+  .actions {
+    float: right;
+  }
+}
+
+.actions {
+  @extend .btn-group;
+
+  a {
+    @extend .btn;
+    @extend .btn-default;
+  }
+}
+
+input[type='text'] {
+  @extend .form-control;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,4 +7,17 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
+
+private
+
+  helper_method :active_navigation_item, :can_edit_taxonomy?
+
+  def can_edit_taxonomy?
+    current_user.has_permission? "Edit Taxonomy"
+  end
+
+  # Can be overridden to allow controllers to choose the active menu item.
+  def active_navigation_item
+    controller_name
+  end
 end

--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -14,8 +14,13 @@ class TaxonsController < ApplicationController
 
   def create
     new_taxon = TaxonForm.new(params[:taxon_form])
-    new_taxon.create!
-    redirect_to taxons_path
+    if new_taxon.valid?
+      new_taxon.create!
+      redirect_to taxons_path
+    else
+      error_messages = new_taxon.errors.full_messages.join('; ')
+      redirect_to new_taxon_path, flash: { error: error_messages }
+    end
   end
 
   def show

--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -1,0 +1,70 @@
+class TaxonsController < ApplicationController
+  before_filter :require_permissions!
+
+  def index
+    render :index, locals: { taxons: taxon_fetcher.taxons }
+  end
+
+  def new
+    render :new, locals: {
+      taxon_form: TaxonForm.new,
+      taxons_for_select: taxons_for_select,
+    }
+  end
+
+  def create
+    new_taxon = TaxonForm.new(params[:taxon_form])
+    new_taxon.create!
+    redirect_to taxons_path
+  end
+
+  def show
+    render :show, locals: {
+      taxon_form: taxon_form,
+      tagged: tagged,
+      parent_taxons: parent_taxons,
+    }
+  end
+
+  def edit
+    render :edit, locals: {
+      taxon_form: taxon_form,
+      taxons_for_select: taxons_for_select,
+    }
+  end
+
+  def update
+    new_taxon = TaxonForm.new(params[:taxon_form])
+    new_taxon.create!
+    redirect_to taxons_path
+  end
+
+private
+
+  def taxons_for_select
+    taxon_fetcher.taxons_for_select
+  end
+
+  def parent_taxons
+    taxon_fetcher.parents_for_taxon_form(taxon_form)
+  end
+
+  def taxon_fetcher
+    @taxon_fetcher ||= Taxonomy::TaxonFetcher.new
+  end
+
+  def taxon_form
+    TaxonForm.build(content_id: params[:id])
+  end
+
+  def tagged
+    Services.content_store.incoming_links!(
+      taxon_form.base_path,
+      types: ["alpha_taxons"],
+    ).alpha_taxons
+  end
+
+  def require_permissions!
+    authorise_user!("Edit Taxonomy")
+  end
+end

--- a/app/forms/taxon_form.rb
+++ b/app/forms/taxon_form.rb
@@ -23,18 +23,16 @@ class TaxonForm
     self.content_id ||= SecureRandom.uuid
     self.base_path ||= '/alpha-taxonomy/' + title.parameterize
 
-    presenter = TaxonPresenter.new(
-      base_path: base_path,
-      title: title,
-    )
+    presenter = TaxonPresenter.new(base_path: base_path, title: title)
 
-    Services.publishing_api.put_content(
-      content_id,
-      presenter.payload
-    )
+    publish_taxon(presenter)
+  end
 
+private
+
+  def publish_taxon(presenter)
+    Services.publishing_api.put_content(content_id, presenter.payload)
     Services.publishing_api.publish(content_id, "minor")
-
     Services.publishing_api.patch_links(
       content_id,
       links: { parent_taxons: parent_taxons.select(&:present?) }

--- a/app/forms/taxon_form.rb
+++ b/app/forms/taxon_form.rb
@@ -1,0 +1,43 @@
+class TaxonForm
+  attr_accessor :title, :parent_taxons, :content_id, :base_path
+  include ActiveModel::Model
+
+  def self.build(content_id:)
+    content_item = Services.publishing_api.get_content(content_id)
+    links = Services.publishing_api.get_links(content_id).try(:links)
+    form = new(
+      content_id: content_id,
+      title: content_item.title,
+      base_path: content_item.base_path,
+    )
+
+    form.parent_taxons = links.parent_taxons if links.present? && links.parent_taxons.any?
+    form
+  end
+
+  def parent_taxons
+    @parent_taxons ||= []
+  end
+
+  def create!
+    self.content_id ||= SecureRandom.uuid
+    self.base_path ||= '/alpha-taxonomy/' + title.parameterize
+
+    presenter = TaxonPresenter.new(
+      base_path: base_path,
+      title: title,
+    )
+
+    Services.publishing_api.put_content(
+      content_id,
+      presenter.payload
+    )
+
+    Services.publishing_api.publish(content_id, "minor")
+
+    Services.publishing_api.patch_links(
+      content_id,
+      links: { parent_taxons: parent_taxons.select(&:present?) }
+    )
+  end
+end

--- a/app/forms/taxon_form.rb
+++ b/app/forms/taxon_form.rb
@@ -2,6 +2,8 @@ class TaxonForm
   attr_accessor :title, :parent_taxons, :content_id, :base_path
   include ActiveModel::Model
 
+  validates_presence_of :title
+
   def self.build(content_id:)
     content_item = Services.publishing_api.get_content(content_id)
     links = Services.publishing_api.get_links(content_id).try(:links)

--- a/app/presenters/taxon_presenter.rb
+++ b/app/presenters/taxon_presenter.rb
@@ -1,0 +1,27 @@
+class TaxonPresenter
+  def initialize(base_path:, title:)
+    @base_path = base_path
+    @title = title
+  end
+
+  def payload
+    {
+      base_path: base_path,
+      document_type: 'taxon',
+      schema_name: 'taxon',
+      title: title,
+      publishing_app: 'collections-publisher',
+      rendering_app: 'collections',
+      public_updated_at: Time.now.iso8601,
+      locale: 'en',
+      details: {},
+      routes: [
+        { path: base_path, type: "exact" },
+      ]
+    }
+  end
+
+private
+
+  attr_reader :base_path, :title
+end

--- a/app/services/taxonomy/populate_parent_taxons.rb
+++ b/app/services/taxonomy/populate_parent_taxons.rb
@@ -1,0 +1,55 @@
+module Taxonomy
+  # Copies the parent links to the new field parent_taxons
+  class PopulateParentTaxons
+    attr_reader :content_id, :parent_taxons
+
+    def initialize(content_id)
+      @content_id = content_id
+    end
+
+    def self.run(content_id:)
+      new(content_id).run
+    end
+
+    def run
+      if parent_taxons_present?
+        Rails.logger.info "skip: [#{content_id}] already has a taxon parents"
+        return
+      end
+      assign_existing_parents_to_parent_taxons
+
+      if parent_taxons.empty?
+        Rails.logger.info "skip: [#{content_id}] has no taxon parents to add"
+        return
+      end
+      post_new_parent_taxons
+
+      parent_taxons
+    end
+
+  private
+
+    def post_new_parent_taxons
+      Services.publishing_api.patch_links(
+        content_id,
+        links: { parent_taxons: parent_taxons }
+      )
+    end
+
+    def assign_existing_parents_to_parent_taxons
+      @parent_taxons = links.parent if links.present? && links.parent.present?
+    end
+
+    def parent_taxons_present?
+      links.present? && links.parent_taxons.present?
+    end
+
+    def links
+      @links ||= Services.publishing_api.get_links(content_id).try(:links)
+    end
+
+    def parent_taxons
+      @parent_taxons ||= []
+    end
+  end
+end

--- a/app/services/taxonomy/taxon_fetcher.rb
+++ b/app/services/taxonomy/taxon_fetcher.rb
@@ -1,0 +1,21 @@
+module Taxonomy
+  # Return a list of taxons from the publishing API with links included.
+  class TaxonFetcher
+    def taxons
+      @taxons ||=
+        Services.publishing_api.get_linkables(
+          document_type: 'taxon'
+        ).sort_by { |taxon| taxon["title"] }
+    end
+
+    def taxons_for_select
+      taxons.map { |taxon| [taxon['title'], taxon['content_id']] }
+    end
+
+    def parents_for_taxon_form(taxon_form)
+      taxons.select do |taxon|
+        taxon_form.parent_taxons.include?(taxon['content_id'])
+      end
+    end
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,4 +3,12 @@
   <%= javascript_include_tag 'application' %>
 <% end %>
 
+<% content_for :navbar_items do %>
+  <% if can_edit_taxonomy? %>
+    <li class='<%= active_navigation_item == 'taxons' ? 'active' : nil %>'>
+      <%= link_to 'Taxons', taxons_path %>
+    </li>
+  <% end %>
+<% end %>
+
 <%= render template: 'layouts/govuk_admin_template' %>

--- a/app/views/taxons/edit.html.erb
+++ b/app/views/taxons/edit.html.erb
@@ -1,0 +1,12 @@
+<%= header taxon_form.title, breadcrumbs: [:taxons, taxon_form] %>
+
+<%= form_for taxon_form, url: taxon_path(taxon_form.content_id), method: "patch" do |f| %>
+  <%= f.text_field :title %>
+  <%= f.hidden_field :content_id, value: taxon_form.content_id %>
+  <%= f.hidden_field :base_path, value: taxon_form.base_path %>
+  <%= f.select :parent_taxons,
+    options_for_select(taxons_for_select, taxon_form.parent_taxons),
+    { include_blank: true },
+    { class: "select2", multiple: true } %>
+  <%= f.submit "Save", class: "btn btn-lg btn-primary" %>
+<% end %>

--- a/app/views/taxons/edit.html.erb
+++ b/app/views/taxons/edit.html.erb
@@ -1,4 +1,4 @@
-<%= header taxon_form.title, breadcrumbs: [:taxons, taxon_form] %>
+<%= display_header title: taxon_form.title, breadcrumbs: [:taxons, taxon_form] %>
 
 <%= form_for taxon_form, url: taxon_path(taxon_form.content_id), method: "patch" do |f| %>
   <%= f.text_field :title %>

--- a/app/views/taxons/index.html.erb
+++ b/app/views/taxons/index.html.erb
@@ -1,4 +1,4 @@
-<%= header "Alpha Taxons", breadcrumbs: ["Taxons"] do %>
+<%= display_header title: "Alpha Taxons", breadcrumbs: ["Taxons"] do %>
   <%= link_to 'Add a taxon', new_taxon_path, class: 'btn btn-lg btn-default' %>
 <% end %>
 

--- a/app/views/taxons/index.html.erb
+++ b/app/views/taxons/index.html.erb
@@ -1,0 +1,20 @@
+<%= header "Alpha Taxons", breadcrumbs: ["Taxons"] do %>
+  <%= link_to 'Add a taxon', new_taxon_path, class: 'btn btn-lg btn-default' %>
+<% end %>
+
+<table class="tags-list">
+<tr>
+  <th>Title</th>
+  <th>Slug</th>
+  <th></th>
+  <th></th>
+</tr>
+<% taxons.each do |taxon| %>
+  <tr>
+    <td><%= taxon['title'] %></td>
+    <td><%= link_to taxon['base_path'], "#{Plek.new.find('www') + '/api/content' + taxon['base_path']}" %></td>
+    <td><%= link_to 'View tagged', taxon_path(taxon['content_id']) %></td>
+    <td><%= link_to 'Edit taxon', edit_taxon_path(taxon['content_id']) %></td>
+  </tr>
+<% end %>
+</table>

--- a/app/views/taxons/new.html.erb
+++ b/app/views/taxons/new.html.erb
@@ -1,0 +1,10 @@
+<%= header "Taxons", breadcrumbs: [:taxons, "New taxon"] %>
+
+<%= form_for taxon_form, url: taxons_path do |f| %>
+  <%= f.text_field :title %>
+  <%= f.select :parent_taxons,
+    options_for_select(taxons_for_select),
+    { include_blank: true },
+    { class: "select2", multiple: true } %>
+  <%= f.submit "Save", class: "btn btn-lg btn-primary" %>
+<% end %>

--- a/app/views/taxons/new.html.erb
+++ b/app/views/taxons/new.html.erb
@@ -1,4 +1,4 @@
-<%= header "Taxons", breadcrumbs: [:taxons, "New taxon"] %>
+<%= display_header title: "Taxons", breadcrumbs: [:taxons, "New taxon"] %>
 
 <%= form_for taxon_form, url: taxons_path do |f| %>
   <%= f.text_field :title %>

--- a/app/views/taxons/new.html.erb
+++ b/app/views/taxons/new.html.erb
@@ -1,6 +1,11 @@
 <%= display_header title: "Taxons", breadcrumbs: [:taxons, "New taxon"] %>
 
 <%= form_for taxon_form, url: taxons_path do |f| %>
+  <% if flash[:error].present? %>
+    <div class="alert alert-danger" role="alert">
+      <%= flash[:error] %>
+    </div>
+  <% end %>
   <%= f.text_field :title %>
   <%= f.select :parent_taxons,
     options_for_select(taxons_for_select),

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -1,4 +1,4 @@
-<%= header taxon_form.title, breadcrumbs: [:taxons, taxon_form] %>
+<%= display_header title: taxon_form.title, breadcrumbs: [:taxons, taxon_form] %>
 
 <table class="tags-list">
 <tr>

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -1,0 +1,28 @@
+<%= header taxon_form.title, breadcrumbs: [:taxons, taxon_form] %>
+
+<table class="tags-list">
+<tr>
+  <th>Parent taxons</th>
+  <th>Base path</th>
+</tr>
+<% parent_taxons.each do |parent_taxon| %>
+  <tr>
+    <td><%= link_to parent_taxon['title'], taxon_path(parent_taxon['content_id']) %></td>
+    <td><%= link_to parent_taxon['base_path'], "#{Plek.new.find('www') + '/api/content' + parent_taxon['base_path']}" %></td>
+  </tr>
+<% end %>
+</table>
+
+<table class="tags-list">
+<tr>
+  <th>Title</th>
+  <th>URL</th>
+</tr>
+<% tagged.each do |content_item| %>
+  <tr>
+    <td><%= content_item["title"] %></td>
+    <% content_item_url = Plek.new.website_root + content_item["base_path"] %>
+    <td><%= link_to content_item["base_path"], content_item_url %></td>
+  </tr>
+<% end %>
+</table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
   root to: 'lookup#new'
 
+  resources :taxons
+
   controller :lookup do
     get '/lookup', action: :new, as: :lookup
     get '/lookup/:slug', action: :find_by_slug

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -1,4 +1,5 @@
 require 'gds_api/publishing_api_v2'
+require 'gds_api/content_store'
 
 module Services
   def self.publishing_api
@@ -6,6 +7,13 @@ module Services
       Plek.new.find('publishing-api'),
       disable_cache: true,
       bearer_token: ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example',
+    )
+  end
+
+  def self.content_store
+    @content_store ||= GdsApi::ContentStore.new(
+      Plek.new.find('content-store'),
+      disable_cache: true
     )
   end
 end

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -1,12 +1,12 @@
 namespace :publishing_api do
   desc "Send all tags to the publishing-api, skipping any marked as dirty"
-  task :send_all_tags => :environment do
+  task send_all_tags: :environment do
     TagRepublisher.new.republish_tags(Tag.all)
     RedirectPublisher.new.republish_redirects
   end
 
   desc "Send all published tags to the publishing-api, skipping any marked as dirty"
-  task :send_published_tags => :environment do
+  task send_published_tags: :environment do
     TagRepublisher.new.republish_tags(Tag.published)
   end
 

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -1,0 +1,20 @@
+namespace :publishing_api do
+  desc "Send all tags to the publishing-api, skipping any marked as dirty"
+  task :send_all_tags => :environment do
+    TagRepublisher.new.republish_tags(Tag.all)
+    RedirectPublisher.new.republish_redirects
+  end
+
+  desc "Send all published tags to the publishing-api, skipping any marked as dirty"
+  task :send_published_tags => :environment do
+    TagRepublisher.new.republish_tags(Tag.published)
+  end
+
+  desc "Populates parent taxons with the links parent"
+  task populate_parent_taxons: :environment do
+    Taxonomy::TaxonFetcher.new.taxons.each do |taxon|
+      Rails.logger.info "Populating taxon parent for #{taxon['title']}"
+      Taxonomy::PopulateParentTaxons.run(content_id: taxon['content_id'])
+    end
+  end
+end

--- a/spec/features/taxonomy_manager_spec.rb
+++ b/spec/features/taxonomy_manager_spec.rb
@@ -1,0 +1,82 @@
+require "rails_helper"
+
+RSpec.feature "Managing taxonomies" do
+  before do
+    stub_user.permissions << "Edit Taxonomy"
+    @taxon_1 = { title: "I Am A Taxon", content_id: "ID-1", base_path: "/foo" }
+    @taxon_2 = { title: "I Am Another Taxon", content_id: "ID-2", base_path: "/bar" }
+
+    @create_item = stub_request(:put, %r[https://publishing-api.test.gov.uk/v2/content*]).
+      to_return(status: 200, body: {}.to_json)
+
+    @publish_item = stub_request(:post, %r[https://publishing-api.test.gov.uk/v2/.*/publish]).
+      to_return(status: 200, body: {}.to_json)
+
+    @create_links = stub_request(:patch, %r[https://publishing-api.test.gov.uk/v2/links*]).
+      to_return(status: 200, body: {}.to_json)
+  end
+
+  scenario "User creates a taxon with multiple parents" do
+    given_there_are_taxons
+    when_I_visit_the_taxonomy_page
+    and_I_click_on_the_new_taxon_button
+    when_I_submit_the_form_with_a_title_and_parents
+    then_a_taxon_is_created
+  end
+
+  scenario "User edits a taxon" do
+    given_there_are_taxons
+    when_I_visit_the_taxonomy_page
+    and_I_click_on_the_edit_taxon_link
+    when_I_submit_the_form_with_a_title_and_parents
+    then_my_taxon_is_updated
+  end
+
+  def and_I_click_on_the_edit_taxon_link
+    first('a', text: 'Edit taxon').click
+  end
+
+  def given_there_are_taxons
+    stub_request(:get, "https://publishing-api.test.gov.uk/v2/linkables?document_type=taxon").
+      to_return(body: [@taxon_1, @taxon_2].to_json)
+
+    stub_request(:get, "https://publishing-api.test.gov.uk/v2/links/ID-1").
+      to_return(body: { links: { parent_taxons: [] } }.to_json)
+
+    stub_request(:get, "https://publishing-api.test.gov.uk/v2/content/ID-1").
+      to_return(body: @taxon_1.to_json)
+
+    stub_request(:get, "https://publishing-api.test.gov.uk/v2/content/ID-2").
+      to_return(body: @taxon_2.to_json)
+  end
+
+  def when_I_visit_the_taxonomy_page
+    visit taxons_path
+  end
+
+  def and_I_click_on_the_new_taxon_button
+    click_on "Add a taxon"
+  end
+
+  def when_I_submit_the_form_with_a_title_and_parents
+    fill_in :taxon_form_title, with: "My Lovely Taxon"
+
+    select @taxon_1[:title]
+    expect(find('select').value).to include(@taxon_1[:content_id])
+
+    select @taxon_2[:title]
+    expect(find('select').value).to include(@taxon_2[:content_id])
+
+    click_on "Save"
+  end
+
+  def then_a_taxon_is_created
+    expect(@create_item).to have_been_requested
+    expect(@publish_item).to have_been_requested
+    expect(@create_links).to have_been_requested
+  end
+
+  def then_my_taxon_is_updated
+    then_a_taxon_is_created
+  end
+end

--- a/spec/features/taxonomy_manager_spec.rb
+++ b/spec/features/taxonomy_manager_spec.rb
@@ -6,59 +6,59 @@ RSpec.feature "Managing taxonomies" do
     @taxon_1 = { title: "I Am A Taxon", content_id: "ID-1", base_path: "/foo" }
     @taxon_2 = { title: "I Am Another Taxon", content_id: "ID-2", base_path: "/bar" }
 
-    @create_item = stub_request(:put, %r[https://publishing-api.test.gov.uk/v2/content*]).
-      to_return(status: 200, body: {}.to_json)
+    @create_item = stub_request(:put, %r{https://publishing-api.test.gov.uk/v2/content*})
+      .to_return(status: 200, body: {}.to_json)
 
-    @publish_item = stub_request(:post, %r[https://publishing-api.test.gov.uk/v2/.*/publish]).
-      to_return(status: 200, body: {}.to_json)
+    @publish_item = stub_request(:post, %r{https://publishing-api.test.gov.uk/v2/.*/publish})
+      .to_return(status: 200, body: {}.to_json)
 
-    @create_links = stub_request(:patch, %r[https://publishing-api.test.gov.uk/v2/links*]).
-      to_return(status: 200, body: {}.to_json)
+    @create_links = stub_request(:patch, %r{https://publishing-api.test.gov.uk/v2/links*})
+      .to_return(status: 200, body: {}.to_json)
   end
 
   scenario "User creates a taxon with multiple parents" do
     given_there_are_taxons
-    when_I_visit_the_taxonomy_page
-    and_I_click_on_the_new_taxon_button
-    when_I_submit_the_form_with_a_title_and_parents
+    when_i_visit_the_taxonomy_page
+    and_i_click_on_the_new_taxon_button
+    when_i_submit_the_form_with_a_title_and_parents
     then_a_taxon_is_created
   end
 
   scenario "User edits a taxon" do
     given_there_are_taxons
-    when_I_visit_the_taxonomy_page
-    and_I_click_on_the_edit_taxon_link
-    when_I_submit_the_form_with_a_title_and_parents
+    when_i_visit_the_taxonomy_page
+    and_i_click_on_the_edit_taxon_link
+    when_i_submit_the_form_with_a_title_and_parents
     then_my_taxon_is_updated
   end
 
-  def and_I_click_on_the_edit_taxon_link
+  def and_i_click_on_the_edit_taxon_link
     first('a', text: 'Edit taxon').click
   end
 
   def given_there_are_taxons
-    stub_request(:get, "https://publishing-api.test.gov.uk/v2/linkables?document_type=taxon").
-      to_return(body: [@taxon_1, @taxon_2].to_json)
+    stub_request(:get, "https://publishing-api.test.gov.uk/v2/linkables?document_type=taxon")
+      .to_return(body: [@taxon_1, @taxon_2].to_json)
 
-    stub_request(:get, "https://publishing-api.test.gov.uk/v2/links/ID-1").
-      to_return(body: { links: { parent_taxons: [] } }.to_json)
+    stub_request(:get, "https://publishing-api.test.gov.uk/v2/links/ID-1")
+      .to_return(body: { links: { parent_taxons: [] } }.to_json)
 
-    stub_request(:get, "https://publishing-api.test.gov.uk/v2/content/ID-1").
-      to_return(body: @taxon_1.to_json)
+    stub_request(:get, "https://publishing-api.test.gov.uk/v2/content/ID-1")
+      .to_return(body: @taxon_1.to_json)
 
-    stub_request(:get, "https://publishing-api.test.gov.uk/v2/content/ID-2").
-      to_return(body: @taxon_2.to_json)
+    stub_request(:get, "https://publishing-api.test.gov.uk/v2/content/ID-2")
+      .to_return(body: @taxon_2.to_json)
   end
 
-  def when_I_visit_the_taxonomy_page
+  def when_i_visit_the_taxonomy_page
     visit taxons_path
   end
 
-  def and_I_click_on_the_new_taxon_button
+  def and_i_click_on_the_new_taxon_button
     click_on "Add a taxon"
   end
 
-  def when_I_submit_the_form_with_a_title_and_parents
+  def when_i_submit_the_form_with_a_title_and_parents
     fill_in :taxon_form_title, with: "My Lovely Taxon"
 
     select @taxon_1[:title]

--- a/spec/features/taxonomy_manager_spec.rb
+++ b/spec/features/taxonomy_manager_spec.rb
@@ -2,7 +2,9 @@ require "rails_helper"
 
 RSpec.feature "Managing taxonomies" do
   before do
-    stub_user.permissions << "Edit Taxonomy"
+    user = User.first
+    user.permissions << 'Edit Taxonomy'
+    user.save!
     @taxon_1 = { title: "I Am A Taxon", content_id: "ID-1", base_path: "/foo" }
     @taxon_2 = { title: "I Am Another Taxon", content_id: "ID-2", base_path: "/bar" }
 

--- a/spec/forms/taxon_form_spec.rb
+++ b/spec/forms/taxon_form_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+require 'gds_api/test_helpers/publishing_api_v2'
+
+RSpec.describe TaxonForm do
+  include GdsApi::TestHelpers::PublishingApiV2
+
+  describe '.build' do
+    let(:content_id) { SecureRandom.uuid }
+    let(:subject) { described_class.build(content_id: content_id) }
+    let(:content) do
+      {
+        content_id: content_id,
+        title: 'A title',
+        base_path: 'A base path'
+      }
+    end
+
+    before do
+      publishing_api_has_item(content)
+      publishing_api_has_links(
+        content_id: content_id,
+        links: {
+          topics: [],
+          parent_taxons: []
+      })
+    end
+
+    it 'assigns the parents to the form' do
+      expect(subject.parent_taxons).to be_empty
+    end
+
+    it 'assigns the content id correctly' do
+      expect(subject.content_id).to eq(content_id)
+    end
+
+    it 'assigns the title correctly' do
+      expect(subject.title).to eq(content[:title])
+    end
+
+    it 'assigns the base_path correctly' do
+      expect(subject.base_path).to eq(content[:base_path])
+    end
+
+    context 'with existing links' do
+      let(:parent_taxons) { ["CONTENT-ID-RTI", "CONTENT-ID-VAT"] }
+      before do
+        publishing_api_has_links(
+          content_id: content_id,
+          links: {
+            topics: [],
+            parent_taxons: parent_taxons
+        })
+      end
+
+      it 'assigns the parents to the form' do
+        expect(subject.parent_taxons).to eq(parent_taxons)
+      end
+    end
+  end
+end

--- a/spec/forms/taxon_form_spec.rb
+++ b/spec/forms/taxon_form_spec.rb
@@ -22,7 +22,8 @@ RSpec.describe TaxonForm do
         links: {
           topics: [],
           parent_taxons: []
-      })
+        }
+      )
     end
 
     it 'assigns the parents to the form' do
@@ -49,7 +50,8 @@ RSpec.describe TaxonForm do
           links: {
             topics: [],
             parent_taxons: parent_taxons
-        })
+          }
+        )
       end
 
       it 'assigns the parents to the form' do

--- a/spec/forms/taxon_form_spec.rb
+++ b/spec/forms/taxon_form_spec.rb
@@ -4,6 +4,14 @@ require 'gds_api/test_helpers/publishing_api_v2'
 RSpec.describe TaxonForm do
   include GdsApi::TestHelpers::PublishingApiV2
 
+  context 'validations' do
+    it 'is not valid without a title' do
+      taxon_form = described_class.new
+      expect(taxon_form).to_not be_valid
+      expect(taxon_form.errors.keys).to include(:title)
+    end
+  end
+
   describe '.build' do
     let(:content_id) { SecureRandom.uuid }
     let(:subject) { described_class.build(content_id: content_id) }

--- a/spec/presenters/taxon_presenter_spec.rb
+++ b/spec/presenters/taxon_presenter_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe TaxonPresenter do
+  describe "#payload" do
+    it "generates a valid payload" do
+      presenter = TaxonPresenter.new(
+        title: "My Title",
+        base_path: "/taxons/my-taxon"
+      )
+
+      payload = presenter.payload
+
+      expect(payload).to be_valid_against_schema('taxon')
+    end
+  end
+end

--- a/spec/services/taxonomy/populate_parent_taxons_spec.rb
+++ b/spec/services/taxonomy/populate_parent_taxons_spec.rb
@@ -1,0 +1,88 @@
+require 'rails_helper'
+require 'gds_api/test_helpers/publishing_api_v2'
+
+RSpec.describe Taxonomy::PopulateParentTaxons do
+  include GdsApi::TestHelpers::PublishingApiV2
+
+  describe '.run' do
+    let(:content_id) { SecureRandom.uuid }
+    let(:linkables) do
+      [
+        {"title" => "foo", "base_path" => "/foo", "content_id" => content_id},
+      ]
+    end
+
+    before do
+      publishing_api_has_linkables(linkables, document_type: 'taxon')
+    end
+
+    it 'copies the links parent to taxon parents' do
+      publishing_api_has_links(
+        "content_id" => content_id,
+        "links" => {
+          parent: ['CONTENT-ID-RTI'],
+        },
+      )
+
+      stub_publishing_api_patch_links(
+        content_id,
+        links: {
+          parent_taxons: ['CONTENT-ID-RTI']
+        }
+      )
+
+      expect(described_class.run(content_id: content_id)).to eq(['CONTENT-ID-RTI'])
+    end
+
+    shared_examples_for 'does not add taxon parents' do
+      it { expect(Services.publishing_api).to_not receive(:patch_links) }
+      it { expect(described_class.run(content_id: content_id)).to be_nil }
+    end
+
+    context 'without links' do
+      before do
+        publishing_api_has_links("content_id" => content_id)
+      end
+
+      it_behaves_like 'does not add taxon parents'
+    end
+
+    context 'with existing links and taxon parents' do
+      before do
+        publishing_api_has_links(
+          "content_id" => content_id,
+          "links" => {
+            parent: ['CONTENT-ID-RTI'],
+            parent_taxons: ['CONTENT-ID-RTI']
+          },
+        )
+      end
+
+      it_behaves_like 'does not add taxon parents'
+    end
+
+    context 'with links with an empty parent' do
+      before do
+        publishing_api_has_links(
+          "content_id" => content_id,
+          "links" => {
+            parent: []
+          },
+        )
+      end
+
+      it_behaves_like 'does not add taxon parents'
+    end
+
+    context 'without parent links' do
+      before do
+        publishing_api_has_links(
+          "content_id" => content_id,
+          "links" => {},
+        )
+      end
+
+      it_behaves_like 'does not add taxon parents'
+    end
+  end
+end

--- a/spec/services/taxonomy/populate_parent_taxons_spec.rb
+++ b/spec/services/taxonomy/populate_parent_taxons_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Taxonomy::PopulateParentTaxons do
     let(:content_id) { SecureRandom.uuid }
     let(:linkables) do
       [
-        {"title" => "foo", "base_path" => "/foo", "content_id" => content_id},
+        { "title" => "foo", "base_path" => "/foo", "content_id" => content_id },
       ]
     end
 

--- a/spec/services/taxonomy/taxon_fetcher_spec.rb
+++ b/spec/services/taxonomy/taxon_fetcher_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe Taxonomy::TaxonFetcher do
   describe '#taxons' do
     it 'retrieves content items from publishing api and orders by title' do
       linkables = [
-        {"title" => "foo", "base_path" => "/foo", "content_id" => SecureRandom.uuid},
-        {"title" => "bar", "base_path" => "/bar", "content_id" => SecureRandom.uuid},
-        {"title" => "aha", "base_path" => "/aha", "content_id" => SecureRandom.uuid},
+        { "title" => "foo", "base_path" => "/foo", "content_id" => SecureRandom.uuid },
+        { "title" => "bar", "base_path" => "/bar", "content_id" => SecureRandom.uuid },
+        { "title" => "aha", "base_path" => "/aha", "content_id" => SecureRandom.uuid },
       ]
 
       publishing_api_has_linkables(linkables, document_type: 'taxon')
@@ -28,13 +28,13 @@ RSpec.describe Taxonomy::TaxonFetcher do
       instance_double(TaxonForm, parent_taxons: [taxon_id_1, taxon_id_2])
     end
     let(:link_1) do
-      {"title" => "foo", "base_path" => "/foo", "content_id" => taxon_id_1 }
+      { "title" => "foo", "base_path" => "/foo", "content_id" => taxon_id_1 }
     end
     let(:link_2) do
-      {"title" => "bar", "base_path" => "/bar", "content_id" => taxon_id_2}
+      { "title" => "bar", "base_path" => "/bar", "content_id" => taxon_id_2 }
     end
     let(:link_3) do
-      {"title" => "aha", "base_path" => "/aha", "content_id" => SecureRandom.uuid}
+      { "title" => "aha", "base_path" => "/aha", "content_id" => SecureRandom.uuid }
     end
     let(:linkables) { [link_1, link_2, link_3] }
 

--- a/spec/services/taxonomy/taxon_fetcher_spec.rb
+++ b/spec/services/taxonomy/taxon_fetcher_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+require 'gds_api/test_helpers/publishing_api_v2'
+
+RSpec.describe Taxonomy::TaxonFetcher do
+  include GdsApi::TestHelpers::PublishingApiV2
+
+  describe '#taxons' do
+    it 'retrieves content items from publishing api and orders by title' do
+      linkables = [
+        {"title" => "foo", "base_path" => "/foo", "content_id" => SecureRandom.uuid},
+        {"title" => "bar", "base_path" => "/bar", "content_id" => SecureRandom.uuid},
+        {"title" => "aha", "base_path" => "/aha", "content_id" => SecureRandom.uuid},
+      ]
+
+      publishing_api_has_linkables(linkables, document_type: 'taxon')
+
+      result = described_class.new.taxons
+
+      expect(result.first["title"]).to eq("aha")
+      expect(result.last["title"]).to eq("foo")
+    end
+  end
+
+  describe '#parents_for_taxon_form' do
+    let(:taxon_id_1) { SecureRandom.uuid }
+    let(:taxon_id_2) { SecureRandom.uuid }
+    let(:taxon_form) do
+      instance_double(TaxonForm, parent_taxons: [taxon_id_1, taxon_id_2])
+    end
+    let(:link_1) do
+      {"title" => "foo", "base_path" => "/foo", "content_id" => taxon_id_1 }
+    end
+    let(:link_2) do
+      {"title" => "bar", "base_path" => "/bar", "content_id" => taxon_id_2}
+    end
+    let(:link_3) do
+      {"title" => "aha", "base_path" => "/aha", "content_id" => SecureRandom.uuid}
+    end
+    let(:linkables) { [link_1, link_2, link_3] }
+
+    it 'returns the parent taxons for a given taxon' do
+      publishing_api_has_linkables(linkables, document_type: 'taxon')
+      result = described_class.new.parents_for_taxon_form(taxon_form)
+
+      expect(result.count).to eq(2)
+      expect(result).to include(link_1)
+      expect(result).to include(link_2)
+    end
+  end
+end


### PR DESCRIPTION
This PR moves taxon-related functionality from `collections-publisher` into `content-tagger`, where it belongs.

**NOTE:**
In doing so, we ported the entire commit history of those files so we can keep track of past edits. That is why you see so many commits in this PR. The only thing that matters for review purposes is the files being added to the repo.

In order to make sure these files include the history, you can open one of them and check git-blame or git-history.

It now looks like this:

<img width="1422" alt="screen shot 2016-07-20 at 10 39 49" src="https://cloud.githubusercontent.com/assets/416701/16982173/58aad5e4-4e66-11e6-859b-ada0ed4731ea.png">

Trello ticket: https://trello.com/c/merLW6kn/23-move-taxonomy-management-and-tagging-to-content-tagger