### PR TITLE
Use website_root to access base paths correctly

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,7 +10,11 @@ class ApplicationController < ActionController::Base
 
 private
 
-  helper_method :active_navigation_item
+  helper_method :active_navigation_item, :website_url
+
+  def website_url(base_path)
+    Plek.new.website_root + base_path
+  end
 
   # Can be overridden to allow controllers to choose the active menu item.
   def active_navigation_item

--- a/app/views/content/show.html.erb
+++ b/app/views/content/show.html.erb
@@ -1,7 +1,7 @@
 <%= display_header title: @content_item.title, breadcrumbs: [link_to("Tag content", lookup_path), @content_item] %>
 
 <div class='view-on-site'>
-  View on site: <%= link_to @content_item.base_path, Plek.new.website_root + @content_item.base_path, target: "_blank" %>
+  View on site: <%= link_to @content_item.base_path, website_url(@content_item.base_path), target: "_blank" %>
 </div>
 
 <hr/>

--- a/app/views/taxons/index.html.erb
+++ b/app/views/taxons/index.html.erb
@@ -12,7 +12,7 @@
 <% taxons.each do |taxon| %>
   <tr>
     <td><%= taxon['title'] %></td>
-    <td><%= link_to taxon['base_path'], "#{Plek.new.find('www') + '/api/content' + taxon['base_path']}" %></td>
+    <td><%= link_to taxon['base_path'], "#{website_url('/api/content' + taxon['base_path'])}" %></td>
     <td><%= link_to 'View tagged', taxon_path(taxon['content_id']) %></td>
     <td><%= link_to 'Edit taxon', edit_taxon_path(taxon['content_id']) %></td>
   </tr>

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -8,7 +8,7 @@
 <% parent_taxons.each do |parent_taxon| %>
   <tr>
     <td><%= link_to parent_taxon['title'], taxon_path(parent_taxon['content_id']) %></td>
-    <td><%= link_to parent_taxon['base_path'], "#{Plek.new.find('www') + '/api/content' + parent_taxon['base_path']}" %></td>
+    <td><%= link_to parent_taxon['base_path'], "#{website_url('/api/content' + parent_taxon['base_path'])}" %></td>
   </tr>
 <% end %>
 </table>
@@ -21,7 +21,7 @@
 <% tagged.each do |content_item| %>
   <tr>
     <td><%= content_item["title"] %></td>
-    <% content_item_url = Plek.new.website_root + content_item["base_path"] %>
+    <% content_item_url = website_url(content_item["base_path"]) %>
     <td><%= link_to content_item["base_path"], content_item_url %></td>
   </tr>
 <% end %>


### PR DESCRIPTION
By using `Plek.new.find('www')`, we manage to get working links in development
and production, but not in integration. Integration expects `www-origin` instead
of `www`. There is already a [method](https://github.com/alphagov/plek/blob/master/lib/plek.rb#L105-L107) in Plek to determine the website root path
called `website_root`. That method looks for an environment variable to see
what the expected root is. If it doesn't find it, it defaults to `www`. The
integration environment already has that variable set:

```
carlosvilhena@integration-backend-1:~$ govuk_setenv content-tagger env | grep GOVUK_WEBSITE_ROOT
GOVUK_WEBSITE_ROOT=https://www-origin.integration.publishing.service.gov.uk
```

This commit replaces occurences of `Plek.new.find('www')` with a newly created
method called `website_url` which delegates the root to `Plek.new.website_root`.

Trello card: https://trello.com/c/1JGNgYEX/36-fix-integration-links-from-collections-publisher-to-www