### PR TITLE
Fix status message sent to GitHub

### DIFF
--- a/jenkins-schema.sh
+++ b/jenkins-schema.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 GH_STATUS_REPO_NAME="alphagov/govuk-content-schemas"
-CONTEXT_MESSAGE="Verify collections-publisher against content schemas"
+CONTEXT_MESSAGE="Verify content-tagger against content schemas"
 
 exec ./jenkins.sh


### PR DESCRIPTION
This message will be sent to GitHub when testing a branch. This copy-paste error causes GitHub to override the status collections-publisher.