### PR TITLE
Fix publishing_app name on the Taxon Presenter

### DIFF
--- a/app/presenters/taxon_presenter.rb
+++ b/app/presenters/taxon_presenter.rb
@@ -10,7 +10,7 @@ class TaxonPresenter
       document_type: 'taxon',
       schema_name: 'taxon',
       title: title,
-      publishing_app: 'collections-publisher',
+      publishing_app: 'content-tagger',
       rendering_app: 'collections',
       public_updated_at: Time.now.iso8601,
       locale: 'en',

--- a/spec/presenters/taxon_presenter_spec.rb
+++ b/spec/presenters/taxon_presenter_spec.rb
@@ -2,15 +2,20 @@ require 'rails_helper'
 
 RSpec.describe TaxonPresenter do
   describe "#payload" do
-    it "generates a valid payload" do
-      presenter = TaxonPresenter.new(
+    let(:presenter) do
+      TaxonPresenter.new(
         title: "My Title",
         base_path: "/taxons/my-taxon"
       )
+    end
+    let(:payload) { presenter.payload }
 
-      payload = presenter.payload
-
+    it "generates a valid payload" do
       expect(payload).to be_valid_against_schema('taxon')
+    end
+
+    it 'assigns the expected rendering app' do
+      expect(payload[:publishing_app]).to eq('content-tagger')
     end
   end
 end


### PR DESCRIPTION
This code was originally copied from `collections-publisher`. Back then, the `publishing_app` was correct, but not anymore. This commit fixes it.