### PR TITLE
[REBASE FIXUPS] Self-serve Bulk Tagging

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,7 @@ AllCops:
   TargetRubyVersion: 2.3
   Exclude:
     - db/**/*
+    - spec/support/google_sheet_helper.rb
 
 SignalException:
   Enabled: true

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7,6 +7,7 @@
 
 @import 'govuk_admin_template';
 
+
 .select2 {
   width: 100%;
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7,6 +7,9 @@
 
 @import 'govuk_admin_template';
 
+.btn.bulkTaggingButton {
+  margin-bottom: 1rem;
+}
 
 .select2 {
   width: 100%;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,7 +16,6 @@ private
     Plek.new.website_root + base_path
   end
 
-  # Can be overridden to allow controllers to choose the active menu item.
   def active_navigation_item
     controller_name
   end

--- a/app/controllers/tagging_spreadsheets_controller.rb
+++ b/app/controllers/tagging_spreadsheets_controller.rb
@@ -9,6 +9,7 @@ class TaggingSpreadsheetsController < ApplicationController
 
   def create
     @tagging_spreadsheet = TaggingSpreadsheet.new(tagging_spreadsheet_params)
+    @tagging_spreadsheet.added_by = current_user.uid
     if @tagging_spreadsheet.valid?
       @tagging_spreadsheet.save!
       redirect_to tagging_spreadsheets_path
@@ -35,7 +36,7 @@ class TaggingSpreadsheetsController < ApplicationController
 
   def publish_tags
     @tagging_spreadsheet = TaggingSpreadsheet.find(params.fetch(:tagging_spreadsheet_id))
-    errors = BulkTagging::Publish.new(@tagging_spreadsheet.tag_mappings).run
+    errors = BulkTagging::Publish.new(@tagging_spreadsheet, user: current_user).run
     if errors.present?
       flash[:import_error] = "Failed with the following errors: #{errors}"
     end

--- a/app/controllers/tagging_spreadsheets_controller.rb
+++ b/app/controllers/tagging_spreadsheets_controller.rb
@@ -1,0 +1,56 @@
+class TaggingSpreadsheetsController < ApplicationController
+  def index
+    @tagging_spreadsheets = TaggingSpreadsheet.all.newest_first
+  end
+
+  def new
+    @tagging_spreadsheet = TaggingSpreadsheet.new
+  end
+
+  def create
+    @tagging_spreadsheet = TaggingSpreadsheet.new(tagging_spreadsheet_params)
+    if @tagging_spreadsheet.valid?
+      @tagging_spreadsheet.save!
+      redirect_to tagging_spreadsheets_path
+    else
+      render :new
+    end
+  end
+
+  def show
+    @tagging_spreadsheet = TaggingSpreadsheet.find(params[:id])
+
+    if @tagging_spreadsheet.tag_mappings.count.zero?
+      @fetch_errors = BulkTagging::FetchRemoteData.new(@tagging_spreadsheet).run
+    end
+
+    @tag_mappings = @tagging_spreadsheet.tag_mappings.by_content_base_path.by_link_title
+  end
+
+  def refetch
+    @tagging_spreadsheet = TaggingSpreadsheet.find(params.fetch(:tagging_spreadsheet_id))
+    @tagging_spreadsheet.tag_mappings.delete_all
+    redirect_to tagging_spreadsheet_path(@tagging_spreadsheet)
+  end
+
+  def publish_tags
+    @tagging_spreadsheet = TaggingSpreadsheet.find(params.fetch(:tagging_spreadsheet_id))
+    errors = BulkTagging::Publish.new(@tagging_spreadsheet.tag_mappings).run
+    if errors.present?
+      flash[:import_error] = "Failed with the following errors: #{errors}"
+    end
+    redirect_to tagging_spreadsheet_path(@tagging_spreadsheet)
+  end
+
+  def destroy
+    @tagging_spreadsheet = TaggingSpreadsheet.find(params[:id])
+    @tagging_spreadsheet.destroy!
+    redirect_to tagging_spreadsheets_path
+  end
+
+private
+
+  def tagging_spreadsheet_params
+    params.require(:tagging_spreadsheet).permit(:url)
+  end
+end

--- a/app/models/tag_mapping.rb
+++ b/app/models/tag_mapping.rb
@@ -1,0 +1,5 @@
+class TagMapping < ActiveRecord::Base
+  belongs_to :tagging_spreadsheet
+  scope :by_content_base_path, -> { order(content_base_path: :asc) }
+  scope :by_link_title, -> { order(link_title: :asc) }
+end

--- a/app/models/tagging_spreadsheet.rb
+++ b/app/models/tagging_spreadsheet.rb
@@ -1,0 +1,5 @@
+class TaggingSpreadsheet < ActiveRecord::Base
+  validates :url, presence: true
+  has_many :tag_mappings, dependent: :delete_all
+  scope :newest_first, -> { order(created_at: :desc) }
+end

--- a/app/services/bulk_tagging/fetch_remote_data.rb
+++ b/app/services/bulk_tagging/fetch_remote_data.rb
@@ -1,0 +1,35 @@
+require 'csv'
+
+module BulkTagging
+  class FetchRemoteData
+    attr_reader :tagging_spreadsheet
+
+    def initialize(tagging_spreadsheet)
+      @tagging_spreadsheet = tagging_spreadsheet
+    end
+
+    def run
+      errors = []
+      begin
+        parsed_data = CSV.parse(sheet_data, col_sep: "\t", headers: true)
+        parsed_data.each do |row|
+          tagging_spreadsheet.tag_mappings.build(
+            content_base_path:  row["content_base_path"],
+            link_title:         row["link_title"],
+            link_content_id:    row["link_content_id"],
+            link_type:          row["link_type"],
+          ).save
+        end
+      rescue => e
+        errors << e
+      end
+      errors
+    end
+
+  private
+
+    def sheet_data
+      @sheet_data ||= Net::HTTP.get URI(tagging_spreadsheet.url)
+    end
+  end
+end

--- a/app/services/bulk_tagging/publish.rb
+++ b/app/services/bulk_tagging/publish.rb
@@ -1,28 +1,20 @@
 module BulkTagging
   class Publish
-    attr_reader :tag_mappings
+    attr_reader :tagging_spreadsheet
     attr_reader :logger
+    attr_reader :user
 
-    def initialize(tag_mappings, logger: Rails.logger)
-      @tag_mappings = tag_mappings
+    def initialize(tagging_spreadsheet, user:, logger: Rails.logger)
+      @tagging_spreadsheet = tagging_spreadsheet
       @logger = logger
+      @user = user
     end
 
     def run
       errors = []
       begin
-        link_payloads.each do |base_path, links|
-          tagged_log "Patching links on #{base_path}"
-          target_content_id = Services.publishing_api.lookup_content_id(base_path: base_path)
-
-          if target_content_id.blank?
-            tagged_log "No content ID found for #{base_path}"
-            next
-          end
-
-          response_code = patch_links(target_content_id, links)
-          tagged_log "patch_links response: #{response_code}"
-        end
+        update_publishing_details
+        send_links_to_publishing_api
       rescue => e
         errors << e
       end
@@ -30,6 +22,25 @@ module BulkTagging
     end
 
   private
+
+    def update_publishing_details
+      tagging_spreadsheet.update(
+        last_published_by: user.uid, last_published_at: Time.zone.now
+      )
+    end
+
+    def send_links_to_publishing_api
+      link_payloads.each do |base_path, links|
+        tagged_log "Patching links on #{base_path}"
+        target_content_id = Services.publishing_api.lookup_content_id(base_path: base_path)
+        if target_content_id.blank?
+          tagged_log "No content ID found for #{base_path}"
+          next
+        end
+        response_code = patch_links(target_content_id, links)
+        tagged_log "patch_links response: #{response_code}"
+      end
+    end
 
     def patch_links(content_id, links)
       Services.publishing_api.patch_links(content_id, links: links).code
@@ -40,7 +51,7 @@ module BulkTagging
     end
 
     def link_payloads
-      tag_mappings.each_with_object({}) do |mapping, hash|
+      tagging_spreadsheet.tag_mappings.each_with_object({}) do |mapping, hash|
         content_base_path = mapping.content_base_path
         link_type = mapping.link_type
         link_content_id = mapping.link_content_id

--- a/app/services/bulk_tagging/publish.rb
+++ b/app/services/bulk_tagging/publish.rb
@@ -1,0 +1,53 @@
+module BulkTagging
+  class Publish
+    attr_reader :tag_mappings
+    attr_reader :logger
+
+    def initialize(tag_mappings, logger: Rails.logger)
+      @tag_mappings = tag_mappings
+      @logger = logger
+    end
+
+    def run
+      errors = []
+      begin
+        link_payloads.each do |base_path, links|
+          tagged_log "Patching links on #{base_path}"
+          target_content_id = Services.publishing_api.lookup_content_id(base_path: base_path)
+
+          if target_content_id.blank?
+            tagged_log "No content ID found for #{base_path}"
+            next
+          end
+
+          response_code = patch_links(target_content_id, links)
+          tagged_log "patch_links response: #{response_code}"
+        end
+      rescue => e
+        errors << e
+      end
+      errors
+    end
+
+  private
+
+    def patch_links(content_id, links)
+      Services.publishing_api.patch_links(content_id, links: links).code
+    end
+
+    def tagged_log(message)
+      logger.tagged("BULK-TAG") { logger.info message }
+    end
+
+    def link_payloads
+      tag_mappings.each_with_object({}) do |mapping, hash|
+        content_base_path = mapping.content_base_path
+        link_type = mapping.link_type
+        link_content_id = mapping.link_content_id
+
+        hash[content_base_path] = {} unless hash[content_base_path].present?
+        hash[content_base_path][link_type] = hash[content_base_path].fetch(link_type, []) << link_content_id
+      end
+    end
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,6 +1,7 @@
 <% content_for :head do %>
   <%= stylesheet_link_tag "application", media: "all" %>
   <%= javascript_include_tag 'application' %>
+  <%= csrf_meta_tags %>
 <% end %>
 
 <% content_for :navbar_items do %>
@@ -9,6 +10,9 @@
   </li>
   <li class='<%= active_navigation_item == 'taxons' ? 'active' : nil %>'>
     <%= link_to 'Taxons', taxons_path %>
+  </li>
+  <li class='<%= active_navigation_item == 'tagging_spreadsheets' ? 'active' : nil %>'>
+    <%= link_to 'Bulk Tagging', tagging_spreadsheets_path %>
   </li>
 <% end %>
 

--- a/app/views/tagging_spreadsheets/index.html.erb
+++ b/app/views/tagging_spreadsheets/index.html.erb
@@ -1,0 +1,23 @@
+<%= link_to "Add spreadsheet", new_tagging_spreadsheet_path, class: "btn btn-success" %>
+
+<br/>
+<br/>
+
+<table>
+  <tr>
+    <th>Google Sheet URL</th>
+    <th>Date added</th>
+    <th>Actions</th>
+  </tr>
+  <% @tagging_spreadsheets.each do |spreadsheet| %>
+    <tr>
+      <td><%= spreadsheet.url %></td>
+      <td><%= spreadsheet.created_at %></td>
+      <td>
+        <%= link_to "Preview taggings", tagging_spreadsheet_path(spreadsheet), class: "btn btn-primary btn-sm bulkTaggingButton" %>
+        <%= link_to "Delete job", tagging_spreadsheet_path(spreadsheet), method: :delete, class: "btn btn-danger btn-sm" %>
+      </td>
+    </tr>
+  <% end %>
+</table>
+

--- a/app/views/tagging_spreadsheets/new.html.erb
+++ b/app/views/tagging_spreadsheets/new.html.erb
@@ -1,0 +1,13 @@
+<h1>Bulk Tagging</h1>
+
+<p>
+  <%= link_to "Example spreadsheet",
+      "https://docs.google.com/spreadsheets/d/1BB4mAcaf0pfCUUxrt3pmFvebiPv0yUAkfLEeEJjIT0M/pub?gid=386284585&single=true&output=tsv" %>
+</p>
+
+<%= form_for @tagging_spreadsheet, url: tagging_spreadsheets_path do |form| %>
+  <div class="form-group">
+    <%= form.text_field :url, label: "Spreadsheet URL", class: "form-control" %>
+    <%= form.submit "Import", class: "btn btn-primary btn-md" %>
+  </div>
+<% end %>

--- a/app/views/tagging_spreadsheets/show.html.erb
+++ b/app/views/tagging_spreadsheets/show.html.erb
@@ -1,0 +1,43 @@
+<h1>Taggings</h1>
+
+<% if flash[:import_error] %>
+  <div class="alert alert-danger"><%= flash[:import_error] %></div>
+<% end %>
+
+<% if @fetch_errors.present? %>
+  <p>
+    <%= link_to "Fetch from Google again", tagging_spreadsheet_refetch_path(@tagging_spreadsheet), method: :post, class: "btn btn-lg btn-warning" %>
+  </p>
+  <p>
+    This import broke. The following error happened when attempting to read
+    the spreadsheet.
+  </p>
+
+  <div class="well">
+    <%= @fetch_errors.first.inspect %>
+  </div>
+
+<% else %>
+
+  <p>
+    <%= link_to "Create these tags", tagging_spreadsheet_publish_tags_path(@tagging_spreadsheet), method: :post, class: "btn btn-lg btn-success" %>
+    <%= link_to "Fetch from Google again", tagging_spreadsheet_refetch_path(@tagging_spreadsheet), method: :post, class: "btn btn-lg btn-warning" %>
+  </p>
+
+  <table>
+    <tr>
+      <th>Content Base Path</th>
+      <th>Link Title</th>
+      <th>Link Content ID</th>
+      <th>Link Type</th>
+    </tr>
+    <% @tag_mappings.each do |tag| %>
+      <tr>
+        <td><%= tag.content_base_path %></td>
+        <td><%= tag.link_title %></td>
+        <td><%= tag.link_content_id %></td>
+        <td><%= tag.link_type %></td>
+      </tr>
+    <% end %>
+  </table>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,11 @@ Rails.application.routes.draw do
     post '/content/taggings', action: :update_links, as: :content_update_links
   end
 
+  resources :tagging_spreadsheets, except: [:update, :edit]  do
+    post 'refetch'
+    post 'publish_tags'
+  end
+
   get '/healthcheck', to: proc { [200, {}, ['OK']] }
 
   mount GovukAdminTemplate::Engine, at: "/style-guide" if Rails.env.development?

--- a/db/migrate/20160718104316_create_tagging_spreadsheets.rb
+++ b/db/migrate/20160718104316_create_tagging_spreadsheets.rb
@@ -1,0 +1,9 @@
+class CreateTaggingSpreadsheets < ActiveRecord::Migration
+  def change
+    create_table :tagging_spreadsheets do |t|
+      t.string :url, null: false
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20160719142645_create_tag_mappings.rb
+++ b/db/migrate/20160719142645_create_tag_mappings.rb
@@ -1,0 +1,13 @@
+class CreateTagMappings < ActiveRecord::Migration
+  def change
+    create_table :tag_mappings do |t|
+      t.references :tagging_spreadsheet, index: true, foreign_key: true
+      t.string :content_base_path
+      t.string :link_title
+      t.string :link_content_id
+      t.string :link_type
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20160727095240_modify_foreign_key_on_tag_mappings.rb
+++ b/db/migrate/20160727095240_modify_foreign_key_on_tag_mappings.rb
@@ -1,0 +1,6 @@
+class ModifyForeignKeyOnTagMappings < ActiveRecord::Migration
+  def change
+    remove_foreign_key :tag_mappings, :tagging_spreadsheets
+    add_foreign_key :tag_mappings, :tagging_spreadsheets, on_delete: :cascade
+  end
+end

--- a/db/migrate/20160727101957_add_user_uid_to_tagging_spreadsheets.rb
+++ b/db/migrate/20160727101957_add_user_uid_to_tagging_spreadsheets.rb
@@ -1,0 +1,7 @@
+class AddUserUidToTaggingSpreadsheets < ActiveRecord::Migration
+  def change
+    add_column :tagging_spreadsheets, :added_by, :string
+    add_column :tagging_spreadsheets, :last_published_by, :string
+    add_column :tagging_spreadsheets, :last_published_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160727095240) do
+ActiveRecord::Schema.define(version: 20160727101957) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -29,9 +29,12 @@ ActiveRecord::Schema.define(version: 20160727095240) do
   add_index "tag_mappings", ["tagging_spreadsheet_id"], name: "index_tag_mappings_on_tagging_spreadsheet_id", using: :btree
 
   create_table "tagging_spreadsheets", force: :cascade do |t|
-    t.string   "url",        null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.string   "url",               null: false
+    t.datetime "created_at",        null: false
+    t.datetime "updated_at",        null: false
+    t.string   "added_by"
+    t.string   "last_published_by"
+    t.datetime "last_published_at"
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,9 +11,28 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151115132026) do
+ActiveRecord::Schema.define(version: 20160727095240) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "tag_mappings", force: :cascade do |t|
+    t.integer  "tagging_spreadsheet_id"
+    t.string   "content_base_path"
+    t.string   "link_title"
+    t.string   "link_content_id"
+    t.string   "link_type"
+    t.datetime "created_at",             null: false
+    t.datetime "updated_at",             null: false
+  end
+
+  add_index "tag_mappings", ["tagging_spreadsheet_id"], name: "index_tag_mappings_on_tagging_spreadsheet_id", using: :btree
+
+  create_table "tagging_spreadsheets", force: :cascade do |t|
+    t.string   "url",        null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "users", force: :cascade do |t|
     t.string   "name"
@@ -27,4 +46,6 @@ ActiveRecord::Schema.define(version: 20151115132026) do
     t.datetime "created_at",              null: false
     t.datetime "updated_at",              null: false
   end
+
+  add_foreign_key "tag_mappings", "tagging_spreadsheets", on_delete: :cascade
 end

--- a/spec/features/bulk_tagging_spec.rb
+++ b/spec/features/bulk_tagging_spec.rb
@@ -1,0 +1,122 @@
+require "rails_helper"
+
+RSpec.feature "Bulk tagging", type: :feature do
+  require 'gds_api/test_helpers/publishing_api_v2'
+  include GdsApi::TestHelpers::PublishingApiV2
+  include GoogleSheetHelper
+
+  scenario "Importing tags" do
+    given_tagging_data_is_present_in_a_google_spreadsheet
+    when_i_provide_the_public_uri_of_this_spreadsheet
+    then_i_can_preview_which_taggings_will_be_imported
+    and_confirming_this_will_import_taggings
+  end
+
+  scenario "Reimporting tags" do
+    given_some_imported_tags
+    when_i_update_the_spreadsheet
+    and_refetch_the_tags
+    then_i_should_see_an_updated_preview
+  end
+
+  scenario "The spreadsheet contains bad data" do
+    given_no_tagging_data_was_found
+    when_i_provide_the_public_uri_of_this_spreadsheet
+    then_i_see_an_error_summary_instead_of_a_tagging_preview
+    when_i_correct_the_data_and_reimport
+    then_i_can_preview_which_taggings_will_be_imported
+  end
+
+  SHEET_KEY = "THE-KEY-123"
+  SHEET_GID = "123456"
+
+  def when_i_correct_the_data_and_reimport
+    given_tagging_data_is_present_in_a_google_spreadsheet
+    click_link "Fetch from Google again"
+    click_link "Bulk Tagging"
+  end
+
+  def given_tagging_data_is_present_in_a_google_spreadsheet
+    stub_request(:get, google_sheet_url(key: SHEET_KEY, gid: SHEET_GID))
+      .to_return(body: google_sheet_fixture)
+  end
+
+  def then_i_see_an_error_summary_instead_of_a_tagging_preview
+    click_link "Preview taggings"
+    expect(page).to have_content "This import broke."
+  end
+
+  def given_no_tagging_data_was_found
+    stub_request(:get, google_sheet_url(key: SHEET_KEY, gid: SHEET_GID))
+      .to_return(status: 404)
+  end
+
+  def when_i_provide_the_public_uri_of_this_spreadsheet
+    visit root_path
+    click_link "Bulk Tagging"
+    click_link "Add spreadsheet"
+    fill_in "Spreadsheet URL", with: google_sheet_url(key: SHEET_KEY, gid: SHEET_GID)
+    click_button "Import"
+  end
+
+  def then_i_can_preview_which_taggings_will_be_imported
+    click_link "Preview taggings"
+    expect_page_to_contain_details_of(tag_mappings: TagMapping.all)
+  end
+
+  def expect_page_to_contain_details_of(tag_mappings: [])
+    tag_mappings.each do |tag_mapping|
+      expect(page).to have_content tag_mapping.content_base_path
+      expect(page).to have_content tag_mapping.link_title
+      expect(page).to have_content tag_mapping.link_content_id
+      expect(page).to have_content tag_mapping.link_type
+    end
+  end
+
+  def and_confirming_this_will_import_taggings
+    publishing_api_has_lookups(google_sheet_content_items)
+    link_update_1 = stub_publishing_api_patch_links(
+      "content-1-cid",
+      links: {
+        taxons: ["education-content-id", "education-content-id"],
+        organisations: ["cabinet-office-content-id"],
+      }
+    )
+    link_update_2 = stub_publishing_api_patch_links(
+      "content-2-cid",
+      links: {
+        taxons: ["early-years-content-id"],
+      }
+    )
+
+    click_link "Create these tags"
+
+    expect(link_update_1).to have_been_requested
+    expect(link_update_2).to have_been_requested
+  end
+
+  def given_some_imported_tags
+    given_tagging_data_is_present_in_a_google_spreadsheet
+    when_i_provide_the_public_uri_of_this_spreadsheet
+    then_i_can_preview_which_taggings_will_be_imported
+  end
+
+  def when_i_update_the_spreadsheet
+    extra_row = google_sheet_row(
+      content_base_path: "/content-2/",
+      link_title: "GDS",
+      link_content_id: "gds-content-id",
+      link_type: "organisation",
+    )
+    stub_request(:get, google_sheet_url(key: SHEET_KEY, gid: SHEET_GID))
+      .to_return(body: google_sheet_fixture([extra_row]))
+  end
+
+  def and_refetch_the_tags
+    expect { click_link "Fetch from Google again" }.to change { TagMapping.count }.by(1)
+  end
+
+  def then_i_should_see_an_updated_preview
+    expect_page_to_contain_details_of(tag_mappings: TagMapping.all)
+  end
+end

--- a/spec/features/bulk_taxon_import_scripts_spec.rb
+++ b/spec/features/bulk_taxon_import_scripts_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Bulk taxon import", type: :feature do
+RSpec.feature "Bulk taxon import scripts", type: :feature do
   require 'gds_api/test_helpers/publishing_api_v2'
   include GdsApi::TestHelpers::PublishingApiV2
 

--- a/spec/services/bulk_tagging/fetch_remote_data_spec.rb
+++ b/spec/services/bulk_tagging/fetch_remote_data_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe BulkTagging::FetchRemoteData do
+  include GoogleSheetHelper
+
+  describe "#run" do
+    let(:url) { URI "https://remote-data/path" }
+    let(:tagging_spreadsheet) { TaggingSpreadsheet.new(url: url) }
+
+    before do
+      allow(Net::HTTP).to receive(:get).with(url).and_return(google_sheet_fixture)
+    end
+
+    it "retrieves data from the tagging spreadsheet URL" do
+      expect(Net::HTTP).to receive(:get).with(url)
+
+      BulkTagging::FetchRemoteData.new(tagging_spreadsheet).run
+    end
+
+    it "creates tag mappings based on the retrieved data" do
+      BulkTagging::FetchRemoteData.new(tagging_spreadsheet).run
+
+      expect(TagMapping.all.map(&:content_base_path)).to eq (
+        %w{/content-1/ /content-1/ /content-1/ /content-2/}
+      )
+      expect(TagMapping.all.map(&:link_type)).to eq(
+        %w{taxons taxons organisations taxons}
+      )
+    end
+  end
+end

--- a/spec/services/bulk_tagging/publish_spec.rb
+++ b/spec/services/bulk_tagging/publish_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.describe BulkTagging::Publish do
+  GoogleSheetHelper
+
+  let(:tagging_spreadsheet) { TaggingSpreadsheet.create(url: "https://tagging/spreadsheet/") }
+
+  describe "#run" do
+    it "it constructs link payloads from tag mappings and publishes them" do
+      tagging_spreadsheet.tag_mappings.create(
+        content_base_path: "/content-1", link_title: "GDS",
+        link_content_id: "gds-ID", link_type: "organisations"
+      )
+      tagging_spreadsheet.tag_mappings.create(
+        content_base_path: "/content-1", link_title: "GDS",
+        link_content_id: "gds-ID", link_type: "organisations"
+      )
+      tagging_spreadsheet.tag_mappings.create(
+        content_base_path: "/content-1", link_title: "Education",
+        link_content_id: "education-ID", link_type: "taxons"
+      )
+      tagging_spreadsheet.tag_mappings.create(
+        content_base_path: "/content-2", link_title: "Education",
+        link_content_id: "education-ID", link_type: "taxons"
+      )
+      publishing_api_has_lookups({
+        "/content-1" => "content-1-ID", "/content-2" => "content-2-ID",
+      })
+      expected_links_1 = {
+        "taxons" => ["education-ID"], "organisations" => ["gds-ID", "gds-ID"]
+      }
+      expected_links_2 = {
+        "taxons" => ["education-ID"]
+      }
+      api_response = double(code: 200)
+
+      expect(Services.publishing_api).to receive(:patch_links)
+        .with("content-1-ID", links: expected_links_1)
+        .and_return(api_response)
+      expect(Services.publishing_api).to receive(:patch_links)
+        .with("content-2-ID", links: expected_links_2)
+        .and_return(api_response)
+
+      BulkTagging::Publish.new(tagging_spreadsheet.tag_mappings).run
+    end
+
+    context "when no matching link_content_id is found" do
+      it "doesn't send anything to the publshing API" do
+        publishing_api_has_lookups("/content-1" => nil)
+        tagging_spreadsheet.tag_mappings.create(
+          content_base_path: "/content-1", link_title: "GDS",
+          link_content_id: "gds-ID", link_type: "organisations"
+        )
+
+        expect(Services.publishing_api).to_not receive(:patch_links)
+
+        BulkTagging::Publish.new(tagging_spreadsheet.tag_mappings).run
+      end
+    end
+  end
+end

--- a/spec/support/google_sheet_helper.rb
+++ b/spec/support/google_sheet_helper.rb
@@ -1,0 +1,31 @@
+module GoogleSheetHelper
+  def google_sheet_url(key:, gid:)
+    "https://docs.google.com/spreadsheets/d/#{key}/pub?gid=#{gid}&single=true&output=tsv"
+  end
+
+  def google_sheet_fixture(extra_rows=[])
+    [
+      google_sheet_row(content_base_path: "content_base_path" , link_title: "link_title"     , link_content_id: "link_content_id"           , link_type: "link_type")     ,
+      google_sheet_row(content_base_path: "/content-1/"       , link_title: "Education"      , link_content_id: "education-content-id"      , link_type: "taxons")        ,
+      google_sheet_row(content_base_path: "/content-1/"       , link_title: "Education"      , link_content_id: "education-content-id"      , link_type: "taxons")        ,
+      google_sheet_row(content_base_path: "/content-1/"       , link_title: "Cabinet Office" , link_content_id: "cabinet-office-content-id" , link_type: "organisations") ,
+      google_sheet_row(content_base_path: "/content-2/"       , link_title: "Early Years"    , link_content_id: "early-years-content-id"    , link_type: "taxons")        ,
+    ].concat(extra_rows).join("\n")
+  end
+
+  def google_sheet_row(content_base_path:, link_title:, link_content_id:, link_type:)
+    [content_base_path, link_title, link_content_id, link_type].join("\t")
+  end
+
+  def parsed_google_sheet
+    CSV.parse(google_sheet_fixture, col_sep: "\t", headers: true)
+  end
+
+  def google_sheet_content_items
+    content_base_paths = parsed_google_sheet.map { |row| row["content_base_path"] }.uniq
+    content_base_paths.each_with_object({}) do |base_path, hash|
+      fake_content_id = base_path.gsub(/\//, '') + "-cid"
+      hash[base_path] = fake_content_id
+    end
+  end
+end


### PR DESCRIPTION
A general purpose interface for bulk tagging of GOV.UK content via
mapping spreadsheets stored on Google Drive. "General purpose" in the
sense that any piece of content can be tagged with any link type, as
long as the required fields are found in the source spreadsheet.

Includes:

- A BulkTagging model storing the public URLs of the spreadsheets.
- A TagMapping model capturing all of the fields required to tag a piece
  of content.
- Rudimentary error handling when fetching tags from the spreadsheet,
  storing them locally, and sending them to the publishing API.
- A series of screens for creating a new BulkTagging, previewing its
  TagMappings, refreshing these TagMappings following an update to the
  spreadsheet, and sending these tags to the publishing API.


trello https://trello.com/c/yndptBXH/22-allow-self-service-bulk-tagging-with-google-docs