### PR TITLE
Fix Rubocop styleguide violations

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
     post '/content/taggings', action: :update_links, as: :content_update_links
   end
 
-  resources :tagging_spreadsheets, except: [:update, :edit]  do
+  resources :tagging_spreadsheets, except: [:update, :edit] do
     post 'refetch'
     post 'publish_tags'
   end

--- a/spec/features/bulk_tagging_spec.rb
+++ b/spec/features/bulk_tagging_spec.rb
@@ -27,8 +27,8 @@ RSpec.feature "Bulk tagging", type: :feature do
     then_i_can_preview_which_taggings_will_be_imported
   end
 
-  SHEET_KEY = "THE-KEY-123"
-  SHEET_GID = "123456"
+  SHEET_KEY = "THE-KEY-123".freeze
+  SHEET_GID = "123456".freeze
 
   def when_i_correct_the_data_and_reimport
     given_tagging_data_is_present_in_a_google_spreadsheet

--- a/spec/services/bulk_tagging/fetch_remote_data_spec.rb
+++ b/spec/services/bulk_tagging/fetch_remote_data_spec.rb
@@ -20,12 +20,8 @@ RSpec.describe BulkTagging::FetchRemoteData do
     it "creates tag mappings based on the retrieved data" do
       BulkTagging::FetchRemoteData.new(tagging_spreadsheet).run
 
-      expect(TagMapping.all.map(&:content_base_path)).to eq (
-        %w{/content-1/ /content-1/ /content-1/ /content-2/}
-      )
-      expect(TagMapping.all.map(&:link_type)).to eq(
-        %w{taxons taxons organisations taxons}
-      )
+      expect(TagMapping.all.map(&:content_base_path)).to eq(%w(/content-1/ /content-1/ /content-1/ /content-2/))
+      expect(TagMapping.all.map(&:link_type)).to eq(%w(taxons taxons organisations taxons))
     end
   end
 end

--- a/spec/services/bulk_tagging/publish_spec.rb
+++ b/spec/services/bulk_tagging/publish_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe BulkTagging::Publish do
-  GoogleSheetHelper
-
   let(:tagging_spreadsheet) { TaggingSpreadsheet.create(url: "https://tagging/spreadsheet/") }
   let(:user) { double(uid: "user-123") }
 
@@ -24,9 +22,7 @@ RSpec.describe BulkTagging::Publish do
         content_base_path: "/content-2", link_title: "Education",
         link_content_id: "education-ID", link_type: "taxons"
       )
-      publishing_api_has_lookups({
-        "/content-1" => "content-1-ID", "/content-2" => "content-2-ID",
-      })
+      publishing_api_has_lookups("/content-1" => "content-1-ID", "/content-2" => "content-2-ID")
       api_response = double(code: 200)
       allow(Time.zone).to receive(:now).and_return(Time.new(0))
 

--- a/spec/support/google_sheet_helper.rb
+++ b/spec/support/google_sheet_helper.rb
@@ -3,13 +3,13 @@ module GoogleSheetHelper
     "https://docs.google.com/spreadsheets/d/#{key}/pub?gid=#{gid}&single=true&output=tsv"
   end
 
-  def google_sheet_fixture(extra_rows=[])
+  def google_sheet_fixture(extra_rows = [])
     [
-      google_sheet_row(content_base_path: "content_base_path" , link_title: "link_title"     , link_content_id: "link_content_id"           , link_type: "link_type")     ,
-      google_sheet_row(content_base_path: "/content-1/"       , link_title: "Education"      , link_content_id: "education-content-id"      , link_type: "taxons")        ,
-      google_sheet_row(content_base_path: "/content-1/"       , link_title: "Education"      , link_content_id: "education-content-id"      , link_type: "taxons")        ,
-      google_sheet_row(content_base_path: "/content-1/"       , link_title: "Cabinet Office" , link_content_id: "cabinet-office-content-id" , link_type: "organisations") ,
-      google_sheet_row(content_base_path: "/content-2/"       , link_title: "Early Years"    , link_content_id: "early-years-content-id"    , link_type: "taxons")        ,
+      google_sheet_row(content_base_path: "content_base_path", link_title: "link_title", link_content_id: "link_content_id", link_type: "link_type"),
+      google_sheet_row(content_base_path: "/content-1/", link_title: "Education", link_content_id: "education-content-id", link_type: "taxons"),
+      google_sheet_row(content_base_path: "/content-1/", link_title: "Education", link_content_id: "education-content-id", link_type: "taxons"),
+      google_sheet_row(content_base_path: "/content-1/", link_title: "Cabinet Office", link_content_id: "cabinet-office-content-id", link_type: "organisations"),
+      google_sheet_row(content_base_path: "/content-2/", link_title: "Early Years", link_content_id: "early-years-content-id", link_type: "taxons"),
     ].concat(extra_rows).join("\n")
   end
 
@@ -24,7 +24,7 @@ module GoogleSheetHelper
   def google_sheet_content_items
     content_base_paths = parsed_google_sheet.map { |row| row["content_base_path"] }.uniq
     content_base_paths.each_with_object({}) do |base_path, hash|
-      fake_content_id = base_path.gsub(/\//, '') + "-cid"
+      fake_content_id = base_path.delete('/') + "-cid"
       hash[base_path] = fake_content_id
     end
   end


### PR DESCRIPTION
Not sure why this wasn't caught by Rubocop earlier.

Mostly fixed with `govuk-lint-ruby -a`.