### PR TITLE
Use publishing-api for tagged content

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,2 +1,0 @@
-class DashboardController < ApplicationController
-end

--- a/app/controllers/tagging_spreadsheets_controller.rb
+++ b/app/controllers/tagging_spreadsheets_controller.rb
@@ -8,12 +8,13 @@ class TaggingSpreadsheetsController < ApplicationController
   end
 
   def create
-    @tagging_spreadsheet = TaggingSpreadsheet.new(tagging_spreadsheet_params)
-    @tagging_spreadsheet.added_by = current_user.uid
-    if @tagging_spreadsheet.valid?
-      @tagging_spreadsheet.save!
+    tagging_spreadsheet = TaggingSpreadsheet.new(tagging_spreadsheet_params)
+    tagging_spreadsheet.added_by = current_user.uid
+    if tagging_spreadsheet.valid?
+      tagging_spreadsheet.save!
       redirect_to tagging_spreadsheets_path
     else
+      @tagging_spreadsheet = tagging_spreadsheet
       render :new
     end
   end
@@ -29,23 +30,25 @@ class TaggingSpreadsheetsController < ApplicationController
   end
 
   def refetch
-    @tagging_spreadsheet = TaggingSpreadsheet.find(params.fetch(:tagging_spreadsheet_id))
-    @tagging_spreadsheet.tag_mappings.delete_all
-    redirect_to tagging_spreadsheet_path(@tagging_spreadsheet)
+    tagging_spreadsheet = TaggingSpreadsheet.find(params.fetch(:tagging_spreadsheet_id))
+    tagging_spreadsheet.tag_mappings.delete_all
+    redirect_to tagging_spreadsheet_path(tagging_spreadsheet)
   end
 
   def publish_tags
-    @tagging_spreadsheet = TaggingSpreadsheet.find(params.fetch(:tagging_spreadsheet_id))
-    errors = BulkTagging::Publish.new(@tagging_spreadsheet, user: current_user).run
+    tagging_spreadsheet = TaggingSpreadsheet.find(params.fetch(:tagging_spreadsheet_id))
+    errors = BulkTagging::Publish.new(tagging_spreadsheet, user: current_user).run
+
     if errors.present?
       flash[:import_error] = "Failed with the following errors: #{errors}"
     end
-    redirect_to tagging_spreadsheet_path(@tagging_spreadsheet)
+
+    redirect_to tagging_spreadsheet_path(tagging_spreadsheet)
   end
 
   def destroy
-    @tagging_spreadsheet = TaggingSpreadsheet.find(params[:id])
-    @tagging_spreadsheet.destroy!
+    tagging_spreadsheet = TaggingSpreadsheet.find(params[:id])
+    tagging_spreadsheet.destroy!
     redirect_to tagging_spreadsheets_path
   end
 

--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -61,9 +61,10 @@ private
   end
 
   def tagged
-    Services.content_store.incoming_links!(
-      taxon_form.base_path,
-      types: ["taxons"],
-    ).taxons
+    Services.publishing_api.get_linked_items(
+      taxon_form.content_id,
+      link_type: "taxons",
+      fields: %w[title content_id base_path]
+    )
   end
 end

--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -64,7 +64,7 @@ private
     Services.publishing_api.get_linked_items(
       taxon_form.content_id,
       link_type: "taxons",
-      fields: %w[title content_id base_path]
+      fields: %w(title content_id base_path)
     )
   end
 end

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -1,1 +1,0 @@
-Welcome to the content tagger.

--- a/app/views/taxons/index.html.erb
+++ b/app/views/taxons/index.html.erb
@@ -13,7 +13,7 @@
   <tr>
     <td><%= taxon['title'] %></td>
     <td><%= link_to taxon['base_path'], "#{website_url('/api/content' + taxon['base_path'])}" %></td>
-    <td><%= link_to 'View tagged', taxon_path(taxon['content_id']) %></td>
+    <td><%= link_to 'View tagged', taxon_path(taxon['content_id']), class: 'view-tagged-content' %></td>
     <td><%= link_to 'Edit taxon', edit_taxon_path(taxon['content_id']) %></td>
   </tr>
 <% end %>

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -1,5 +1,4 @@
 require 'gds_api/publishing_api_v2'
-require 'gds_api/content_store'
 
 module Services
   def self.publishing_api
@@ -7,13 +6,6 @@ module Services
       Plek.new.find('publishing-api'),
       disable_cache: true,
       bearer_token: ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example',
-    )
-  end
-
-  def self.content_store
-    @content_store ||= GdsApi::ContentStore.new(
-      Plek.new.find('content-store'),
-      disable_cache: true
     )
   end
 end

--- a/spec/features/taxonomy_manager_spec.rb
+++ b/spec/features/taxonomy_manager_spec.rb
@@ -31,6 +31,14 @@ RSpec.feature "Managing taxonomies" do
     then_my_taxon_is_updated
   end
 
+  scenario "Viewing tagged content of a taxon" do
+    given_there_are_taxons
+    and_theres_content_tagged_to_the_taxons
+    when_i_visit_the_taxonomy_page
+    and_i_click_on_view_tagged_content
+    then_i_see_tagged_content
+  end
+
   def and_i_click_on_the_edit_taxon_link
     first('a', text: 'Edit taxon').click
   end
@@ -77,5 +85,18 @@ RSpec.feature "Managing taxonomies" do
 
   def then_my_taxon_is_updated
     then_a_taxon_is_created
+  end
+
+  def and_theres_content_tagged_to_the_taxons
+    stub_request(:get, "https://publishing-api.test.gov.uk/v2/linked/ID-1?fields%5B%5D=base_path&fields%5B%5D=content_id&fields%5B%5D=title&link_type=taxons").
+      to_return(body: [{ content_id: 'ID', title: 'Tagged Item', base_path: '/my/item' }].to_json)
+  end
+
+  def and_i_click_on_view_tagged_content
+    first('.view-tagged-content').click
+  end
+
+  def then_i_see_tagged_content
+    expect(page).to have_content "Tagged Item"
   end
 end


### PR DESCRIPTION
Use publishing-api endpoint for linked items. Publisher apps should never use the content-store, because it's not synchronous and could cause confusion for users. In this case, taggings would not immediately show up because publishing-api sends the tags to the content-store via a Sidekiq worker.

This commit replaces the call to content-store with a call to the publishing-api, so we only have one dependency.

Also does some other cleanup. See commits for details.