### PR TITLE
Bugfix - handle taxon's unprocessable entity errors

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,7 @@ LineLength:
 
 Metrics/AbcSize:
   Enabled: true
+  Max: 20
   Exclude:
     - spec/features/**/*
 

--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -19,6 +19,8 @@ class TaxonsController < ApplicationController
       error_messages = new_taxon.errors.full_messages.join('; ')
       redirect_to new_taxon_path, flash: { error: error_messages }
     end
+  rescue TaxonForm::InvalidTaxonError => e
+    redirect_to new_taxon_path, flash: { error: e.message }
   end
 
   def show

--- a/app/forms/taxon_form.rb
+++ b/app/forms/taxon_form.rb
@@ -23,11 +23,15 @@ class TaxonForm
     @parent_taxons ||= []
   end
 
-  def create!
-    self.content_id ||= SecureRandom.uuid
-    self.base_path ||= '/alpha-taxonomy/' + title.parameterize
-    presenter = TaxonPresenter.new(base_path: base_path, title: title)
+  def content_id
+    @content_id ||= SecureRandom.uuid
+  end
 
+  def base_path
+    @base_path ||= '/alpha-taxonomy/' + SecureRandom.uuid + '-' + title.parameterize
+  end
+
+  def create!
     publish_taxon(presenter)
   rescue GdsApi::HTTPUnprocessableEntity => e
     Airbrake.notify(e)
@@ -35,6 +39,10 @@ class TaxonForm
   end
 
 private
+
+  def presenter
+    TaxonPresenter.new(base_path: base_path, title: title)
+  end
 
   def publish_taxon(presenter)
     Services.publishing_api.put_content(content_id, presenter.payload)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,0 +1,3 @@
+en:
+  errors:
+    invalid_taxon: There was a problem with your request and we were notified about it. We will fix this issue as soon as possible

--- a/spec/features/taxonomy_manager_spec.rb
+++ b/spec/features/taxonomy_manager_spec.rb
@@ -23,6 +23,14 @@ RSpec.feature "Managing taxonomies" do
     then_a_taxon_is_created
   end
 
+  scenario "User attempts to create a taxon that isn't semantically valid" do
+    given_there_are_taxons
+    when_i_visit_the_taxonomy_page
+    and_i_click_on_the_new_taxon_button
+    when_i_submit_the_form_with_a_taxon_with_semantic_issues
+    then_i_can_see_an_error_message
+  end
+
   scenario "User edits a taxon" do
     given_there_are_taxons
     when_i_visit_the_taxonomy_page
@@ -67,6 +75,19 @@ RSpec.feature "Managing taxonomies" do
     expect(find('select').value).to include(@taxon_2[:content_id])
 
     click_on "Save"
+  end
+
+  def when_i_submit_the_form_with_a_taxon_with_semantic_issues
+    fill_in :taxon_form_title, with: 'My Taxon'
+
+    stub_request(:put, %r{https://publishing-api.test.gov.uk/v2/content*})
+      .to_return(status: 422, body: {}.to_json)
+
+    click_on "Save"
+  end
+
+  def then_i_can_see_an_error_message
+    expect(page).to have_selector('.alert', text: /there was a problem with your request/i)
   end
 
   def then_a_taxon_is_created

--- a/spec/forms/taxon_form_spec.rb
+++ b/spec/forms/taxon_form_spec.rb
@@ -12,6 +12,32 @@ RSpec.describe TaxonForm do
     end
   end
 
+  describe '#create!' do
+    let(:taxon_form) { described_class.new(title: 'A Title') }
+
+    context 'with an unprocessable entity error from the API' do
+      let(:error) do
+        GdsApi::HTTPUnprocessableEntity.new(
+          422,
+          "An internal error message",
+          'error' => { 'message' => 'Some backend error' }
+        )
+      end
+
+      before do
+        allow(Services.publishing_api).to receive(:put_content).and_raise(error)
+      end
+
+      it 'raises an error with a generic message and notifies Airbrake' do
+        expect(Airbrake).to receive(:notify).with(error)
+        expect { taxon_form.create! }.to raise_error(
+          TaxonForm::InvalidTaxonError,
+          /there was a problem with your request/i
+        )
+      end
+    end
+  end
+
   describe '.build' do
     let(:content_id) { SecureRandom.uuid }
     let(:subject) { described_class.build(content_id: content_id) }

--- a/spec/forms/taxon_form_spec.rb
+++ b/spec/forms/taxon_form_spec.rb
@@ -12,6 +12,13 @@ RSpec.describe TaxonForm do
     end
   end
 
+  it 'generates unique base paths for the same title' do
+    taxon_form_1 = described_class.new(title: 'A Title')
+    taxon_form_2 = described_class.new(title: 'A Title')
+
+    expect(taxon_form_1.base_path).to_not eq(taxon_form_2.base_path)
+  end
+
   describe '#create!' do
     let(:taxon_form) { described_class.new(title: 'A Title') }
 


### PR DESCRIPTION
When the publishing API rejects a taxon with some validation issues, we should display the error to the user rather than a 500 error page.

Furthermore, we should also allow the creation of taxons with the same title (but different base paths).

This PR solves both problems.

More information here:
https://trello.com/c/gwG1mEop/49-handle-existing-base-paths-when-creating-taxons