### PR TITLE
Add link from tagged item to tagger

### DIFF
--- a/app/views/taxons/index.html.erb
+++ b/app/views/taxons/index.html.erb
@@ -2,7 +2,7 @@
   <%= link_to 'Add a taxon', new_taxon_path, class: 'btn btn-lg btn-default' %>
 <% end %>
 
-<table class="tags-list">
+<table>
 <tr>
   <th>Title</th>
   <th></th>

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -17,12 +17,13 @@
 <tr>
   <th>Title</th>
   <th>URL</th>
+  <th>Actions</th>
 </tr>
 <% tagged.each do |content_item| %>
   <tr>
     <td><%= content_item["title"] %></td>
-    <% content_item_url = website_url(content_item["base_path"]) %>
-    <td><%= link_to content_item["base_path"], content_item_url %></td>
+    <td><%= link_to content_item["base_path"], website_url(content_item["base_path"]) %></td>
+    <td><%= link_to 'Update tags', content_url(content_item["content_id"]) %></td>
   </tr>
 <% end %>
 </table>

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -1,6 +1,6 @@
 <%= display_header title: taxon_form.title, breadcrumbs: [:taxons, taxon_form] %>
 
-<table class="tags-list">
+<table>
 <tr>
   <th>Parent taxons</th>
   <th>Base path</th>
@@ -13,7 +13,7 @@
 <% end %>
 </table>
 
-<table class="tags-list">
+<table>
 <tr>
   <th>Title</th>
   <th>URL</th>


### PR DESCRIPTION
Since we now have all the functionality in this app, we can create cross-links. This commit adds a link from the "Tagged content" page (content tagged to a certain taxon) to the Tagging page (where the user can update the tags).

## Before

<img width="1180" alt="screen shot 2016-07-29 at 14 59 12" src="https://cloud.githubusercontent.com/assets/233676/17250638/1b9b79c2-559d-11e6-8b67-794192779b39.png">

## After

<img width="1180" alt="screen shot 2016-07-29 at 14 59 04" src="https://cloud.githubusercontent.com/assets/233676/17250639/1ba0b2f2-559d-11e6-9d0d-12717d9f28e4.png">
