### PR TITLE
Rename Bulk Tagger to Tag Importer

### DIFF
--- a/app/controllers/tagging_spreadsheets_controller.rb
+++ b/app/controllers/tagging_spreadsheets_controller.rb
@@ -22,7 +22,7 @@ class TaggingSpreadsheetsController < ApplicationController
   def show
     @tagging_spreadsheet = TaggingSpreadsheet.find(params[:id])
     if @tagging_spreadsheet.tag_mappings.count.zero?
-      @fetch_errors = BulkTagging::FetchRemoteData.new(@tagging_spreadsheet).run
+      @fetch_errors = TagImporter::FetchRemoteData.new(@tagging_spreadsheet).run
     end
     @tag_mappings = @tagging_spreadsheet.tag_mappings.by_content_base_path.by_link_title
   end
@@ -41,7 +41,7 @@ class TaggingSpreadsheetsController < ApplicationController
 
   def publish_tags
     tagging_spreadsheet = TaggingSpreadsheet.find(params.fetch(:tagging_spreadsheet_id))
-    BulkTagging::PublishTags.new(tagging_spreadsheet, user: current_user).run
+    TagImporter::PublishTags.new(tagging_spreadsheet, user: current_user).run
     redirect_to tagging_spreadsheet_path(tagging_spreadsheet)
   end
 

--- a/app/services/tag_importer/fetch_remote_data.rb
+++ b/app/services/tag_importer/fetch_remote_data.rb
@@ -1,6 +1,6 @@
 require 'csv'
 
-module BulkTagging
+module TagImporter
   class FetchRemoteData
     attr_reader :tagging_spreadsheet
 

--- a/app/services/tag_importer/publish_tags.rb
+++ b/app/services/tag_importer/publish_tags.rb
@@ -1,4 +1,4 @@
-module BulkTagging
+module TagImporter
   class PublishTags
     attr_reader :tagging_spreadsheet
     attr_reader :tag_mappings

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,7 +12,7 @@
     <%= link_to 'Taxons', taxons_path %>
   </li>
   <li class='<%= active_navigation_item == 'tagging_spreadsheets' ? 'active' : nil %>'>
-    <%= link_to 'Bulk Tagging', tagging_spreadsheets_path %>
+    <%= link_to 'Tag Importer', tagging_spreadsheets_path %>
   </li>
 <% end %>
 

--- a/app/views/tagging_spreadsheets/index.html.erb
+++ b/app/views/tagging_spreadsheets/index.html.erb
@@ -1,4 +1,4 @@
-<%= display_header title: 'Import', breadcrumbs: ['Import'] do %>
+<%= display_header title: 'Tagging spreadsheets', breadcrumbs: ['Tag importer'] do %>
   <%= link_to 'Upload spreadsheet', new_tagging_spreadsheet_path, class: 'btn btn-lg btn-default' %>
 <% end %>
 

--- a/app/views/tagging_spreadsheets/new.html.erb
+++ b/app/views/tagging_spreadsheets/new.html.erb
@@ -1,4 +1,4 @@
-<%= display_header title: 'Import', breadcrumbs: [:tagging_spreadsheets, "New import"] %>
+<%= display_header title: 'Upload spreadsheet', breadcrumbs: [:tagging_spreadsheets, "Upload"] %>
 
 <%= form_for @tagging_spreadsheet, url: tagging_spreadsheets_path do |form| %>
   <div class="form-group">
@@ -9,6 +9,6 @@
           for the correct format.
     </p>
 
-    <%= form.submit "Import", class: "btn btn-lg btn-primary" %>
+    <%= form.submit "Upload", class: "btn btn-lg btn-primary" %>
   </div>
 <% end %>

--- a/spec/features/tag_importer_spec.rb
+++ b/spec/features/tag_importer_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Bulk tagging", type: :feature do
+RSpec.feature "Tag importer", type: :feature do
   require 'gds_api/test_helpers/publishing_api_v2'
   include GdsApi::TestHelpers::PublishingApiV2
   include GoogleSheetHelper
@@ -33,7 +33,7 @@ RSpec.feature "Bulk tagging", type: :feature do
   def when_i_correct_the_data_and_reimport
     given_tagging_data_is_present_in_a_google_spreadsheet
     click_link "Refresh import"
-    click_link "Bulk Tagging"
+    click_link "Tag Importer"
   end
 
   def given_tagging_data_is_present_in_a_google_spreadsheet
@@ -53,10 +53,10 @@ RSpec.feature "Bulk tagging", type: :feature do
 
   def when_i_provide_the_public_uri_of_this_spreadsheet
     visit root_path
-    click_link "Bulk Tagging"
+    click_link "Tag Importer"
     click_link "Upload spreadsheet"
     fill_in "Spreadsheet URL", with: google_sheet_url(key: SHEET_KEY, gid: SHEET_GID)
-    click_button "Import"
+    click_button "Upload"
   end
 
   def then_i_can_preview_which_taggings_will_be_imported

--- a/spec/services/tag_importer/fetch_remote_data_spec.rb
+++ b/spec/services/tag_importer/fetch_remote_data_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe BulkTagging::FetchRemoteData do
+RSpec.describe TagImporter::FetchRemoteData do
   include GoogleSheetHelper
 
   describe "#run" do
@@ -14,11 +14,11 @@ RSpec.describe BulkTagging::FetchRemoteData do
     it "retrieves data from the tagging spreadsheet URL" do
       expect(Net::HTTP).to receive(:get).with(url)
 
-      BulkTagging::FetchRemoteData.new(tagging_spreadsheet).run
+      TagImporter::FetchRemoteData.new(tagging_spreadsheet).run
     end
 
     it "creates tag mappings based on the retrieved data" do
-      BulkTagging::FetchRemoteData.new(tagging_spreadsheet).run
+      TagImporter::FetchRemoteData.new(tagging_spreadsheet).run
 
       expect(TagMapping.all.map(&:content_base_path)).to eq(%w(/content-1/ /content-1/ /content-1/ /content-2/))
       expect(TagMapping.all.map(&:link_type)).to eq(%w(taxons taxons organisations taxons))

--- a/spec/services/tag_importer/publish_tags_spec.rb
+++ b/spec/services/tag_importer/publish_tags_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe BulkTagging::PublishTags do
+RSpec.describe TagImporter::PublishTags do
   let(:tagging_spreadsheet) { TaggingSpreadsheet.create(url: "https://tagging/spreadsheet/") }
   let(:user) { double(uid: "user-123") }
 
@@ -39,7 +39,7 @@ RSpec.describe BulkTagging::PublishTags do
       expect(PublishLinksWorker).to receive(:perform_async).with("/content-1", links_payload_1)
       expect(PublishLinksWorker).to receive(:perform_async).with("/content-2", links_payload_2)
 
-      BulkTagging::PublishTags.new(tagging_spreadsheet, user: user).run
+      TagImporter::PublishTags.new(tagging_spreadsheet, user: user).run
 
       expect(tagging_spreadsheet.last_published_by).to eq "user-123"
       expect(tagging_spreadsheet.last_published_at).to eq Time.new(0)


### PR DESCRIPTION
We've renamed this feature to avoid confusion with the concept of 'bulk
tagging' a content item with multiple tags manually via the UI. The
spreadsheet-driven tagging is now referred to as the Tag Importer.