### PR TITLE
Upgrade to new gds-api-adapters

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'plek', '~> 1.10'
 gem 'gds-sso', '~> 11.1'
 gem 'govuk_admin_template', '~> 4.1.1'
 gem 'generic_form_builder', '~> 0.13.0'
-gem 'gds-api-adapters', '~> 30.0'
+gem 'gds-api-adapters', '~> 32.3'
 
 gem 'airbrake', '~> 4.3.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,7 +73,7 @@ GEM
     execjs (2.7.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
-    gds-api-adapters (30.9.0)
+    gds-api-adapters (32.3.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -323,7 +323,7 @@ PLATFORMS
 DEPENDENCIES
   airbrake (~> 4.3.1)
   capybara
-  gds-api-adapters (~> 30.0)
+  gds-api-adapters (~> 32.3)
   gds-sso (~> 11.1)
   generic_form_builder (~> 0.13.0)
   govuk-content-schema-test-helpers (~> 1.4)

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -13,9 +13,10 @@ class ContentItem
 
   def self.find!(content_id)
     content_item = Services.publishing_api.get_content(content_id)
-    raise ItemNotFoundError unless content_item
-    raise ItemNotFoundError if content_item.document_type.in?(%w(redirect gone))
+    raise ItemNotFoundError if content_item['document_type'].in?(%w(redirect gone))
     new(content_item.to_h)
+  rescue GdsApi::HTTPNotFound
+    raise ItemNotFoundError
   end
 
   def link_set

--- a/app/services/taxonomy/taxon_builder.rb
+++ b/app/services/taxonomy/taxon_builder.rb
@@ -13,8 +13,8 @@ module Taxonomy
     def build
       Taxon.new(
         content_id: content_id,
-        title: content_item.title,
-        base_path: content_item.base_path,
+        title: content_item["title"],
+        base_path: content_item["base_path"],
         parent_taxons: parent_taxons
       )
     end
@@ -22,8 +22,7 @@ module Taxonomy
   private
 
     def parent_taxons
-      return [] unless links.present? && links.parent_taxons.present?
-      links.parent_taxons
+      links["parent_taxons"] || []
     end
 
     def content_item
@@ -31,7 +30,7 @@ module Taxonomy
     end
 
     def links
-      @links ||= Services.publishing_api.get_links(content_id).try(:links)
+      @links ||= Services.publishing_api.get_links(content_id)['links'].to_h
     end
   end
 end

--- a/config/initializers/gds_api_adapters.rb
+++ b/config/initializers/gds_api_adapters.rb
@@ -1,0 +1,7 @@
+GdsApi.configure do |config|
+  # Never return nil when a server responds with 404 or 410.
+  config.always_raise_for_not_found = true
+
+  # Return a hash, not an OpenStruct from a request.
+  config.hash_response_for_requests = true
+end


### PR DESCRIPTION
This version allows us to get rid of openstructs and nil-returning methods.

For more context:

https://github.com/alphagov/gds-api-adapters/pull/545
https://github.com/alphagov/gds-api-adapters/pull/544