### PR TITLE
Fix copy for tagging page

### DIFF
--- a/app/views/content/_form_for_topics.html.erb
+++ b/app/views/content/_form_for_topics.html.erb
@@ -10,7 +10,7 @@
   They contain collections of pages on GOV.UK. Example:
   <a href="https://www.gov.uk/topic/business-tax">Business Tax</a> or
   <a href="https://www.gov.uk/topic/animal-welfare/pets">Animal Welfare / Pets</a>.
-  Tagging a page with a topic will send out an
+  Publishing a page with a topic may send out an
   <a href="https://www.gov.uk/topic/business-tax/vat/email-signup">email alert to subscribers</a>.
   Formerly called <i>specialist sectors</i>.
 </p>


### PR DESCRIPTION
This copy was misleading: an email can be sent when the page is published, not when the page is tagged.