### PR TITLE
Eager load lib directory

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -13,7 +13,7 @@ Bundler.require(*Rails.groups)
 module ContentTagger
   class Application < Rails::Application
     config.active_record.raise_in_transactional_callbacks = true
-    config.autoload_paths += %W(#{config.root}/lib)
+    config.eager_load_paths += %W(#{config.root}/lib)
 
     config.action_view.default_form_builder = GenericFormBuilder
     config.action_view.field_error_proc = proc { |html_tag, _| html_tag }


### PR DESCRIPTION
Add lib to eager_load_paths. This is to resolve a circular dependency
issue when Sidekiq attempts to resolve the Services constant.