### PR TITLE
Make initial tagging import action asynchronous

### DIFF
--- a/app/models/tagging_spreadsheet.rb
+++ b/app/models/tagging_spreadsheet.rb
@@ -1,5 +1,8 @@
 class TaggingSpreadsheet < ActiveRecord::Base
   validates :url, presence: true
+  validates_presence_of :state
+  validates_inclusion_of :state, in: %w(uploaded errored ready_to_import imported)
+
   has_many :tag_mappings, dependent: :delete_all
   scope :newest_first, -> { order(created_at: :desc) }
 end

--- a/app/services/tag_importer/publish_tags.rb
+++ b/app/services/tag_importer/publish_tags.rb
@@ -12,8 +12,12 @@ module TagImporter
 
     def run
       ActiveRecord::Base.transaction do
-        tagging_spreadsheet.update(last_published_at: Time.zone.now)
-        tagging_spreadsheet.update(last_published_by: user.uid)
+        tagging_spreadsheet.update!(
+          last_published_at: Time.zone.now,
+          last_published_by: user.uid,
+          state: "imported"
+        )
+
         tag_mappings.update_all(publish_requested_at: Time.zone.now)
 
         links_grouped_by_base_path.each do |base_path, links_update|

--- a/app/views/tagging_spreadsheets/_import_preview.html.erb
+++ b/app/views/tagging_spreadsheets/_import_preview.html.erb
@@ -2,7 +2,9 @@
   <br/>
 
   <div data-module="import-progress">
-    <%= render partial: "import_progress_bar", locals: { tag_mappings: tag_mappings } %>
+    <% if tag_mappings.any? %>
+      <%= render partial: "import_progress_bar", locals: { tag_mappings: tag_mappings } %>
+    <% end %>
   </div>
 
   <table>

--- a/app/views/tagging_spreadsheets/show.html.erb
+++ b/app/views/tagging_spreadsheets/show.html.erb
@@ -3,16 +3,12 @@
   <%= link_to "Refresh import", tagging_spreadsheet_refetch_path(@tagging_spreadsheet), method: :post, class: "btn btn-md btn-default" %>
 <% end %>
 
-<% if @fetch_errors.present? %>
+<% if @tagging_spreadsheet.state == "errored" %>
   <p>
-    This import broke. The following error happened when attempting to read
-    the spreadsheet.
+    An error occured when attempting to read the spreadsheet:
+
+    <%= @tagging_spreadsheet.error_message %>
   </p>
-
-  <div class="well">
-    <%= @fetch_errors.first.inspect %>
-  </div>
-
 <% else %>
   <div class='view-on-site'>
     View: <%= link_to "inspect spreadsheet", @tagging_spreadsheet.url, target: "_blank" %>

--- a/app/workers/initial_tagging_import.rb
+++ b/app/workers/initial_tagging_import.rb
@@ -1,0 +1,14 @@
+class InitialTaggingImport
+  include Sidekiq::Worker
+
+  def perform(tagging_spreadsheet_id)
+    tagging_spreadsheet = TaggingSpreadsheet.find(tagging_spreadsheet_id)
+    errors = TagImporter::FetchRemoteData.new(tagging_spreadsheet).run
+
+    if errors.any?
+      tagging_spreadsheet.update_attributes!(state: "errored", error_message: errors.join("\n"))
+    else
+      tagging_spreadsheet.update_attributes!(state: "ready_to_import")
+    end
+  end
+end

--- a/db/migrate/20160808210736_add_state_to_tagging_spreadsheets.rb
+++ b/db/migrate/20160808210736_add_state_to_tagging_spreadsheets.rb
@@ -1,0 +1,9 @@
+class AddStateToTaggingSpreadsheets < ActiveRecord::Migration
+  def change
+    # At this point in development we can just clear out all the spreadsheets
+    # so we don't have to bother with setting an initial state.
+    TaggingSpreadsheet.delete_all
+    add_column :tagging_spreadsheets, :state, :string, null: false
+    add_column :tagging_spreadsheets, :error_message, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160729134317) do
+ActiveRecord::Schema.define(version: 20160808210736) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -37,6 +37,8 @@ ActiveRecord::Schema.define(version: 20160729134317) do
     t.string   "added_by"
     t.string   "last_published_by"
     t.datetime "last_published_at"
+    t.string   "state",             null: false
+    t.text     "error_message"
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/features/tag_importer_spec.rb
+++ b/spec/features/tag_importer_spec.rb
@@ -5,6 +5,10 @@ RSpec.feature "Tag importer", type: :feature do
   include GdsApi::TestHelpers::PublishingApiV2
   include GoogleSheetHelper
 
+  before do
+    Sidekiq::Testing.inline!
+  end
+
   scenario "Importing tags" do
     given_tagging_data_is_present_in_a_google_spreadsheet
     when_i_provide_the_public_uri_of_this_spreadsheet
@@ -43,7 +47,7 @@ RSpec.feature "Tag importer", type: :feature do
 
   def then_i_see_an_error_summary_instead_of_a_tagging_preview
     click_link "Preview"
-    expect(page).to have_content "This import broke."
+    expect(page).to have_content "An error occured"
   end
 
   def given_no_tagging_data_is_available_at_a_spreadsheet_url
@@ -97,12 +101,10 @@ RSpec.feature "Tag importer", type: :feature do
       }
     )
 
-    Sidekiq::Testing.inline! do
-      click_link "Create tags"
-      expect(link_update_1).to have_been_requested
-      expect(link_update_2).to have_been_requested
-      expect_tag_mapping_statuses_to_be("Yes")
-    end
+    click_link "Create tags"
+    expect(link_update_1).to have_been_requested
+    expect(link_update_2).to have_been_requested
+    expect_tag_mapping_statuses_to_be("Yes")
   end
 
   def given_some_imported_tags

--- a/spec/services/tag_importer/publish_tags_spec.rb
+++ b/spec/services/tag_importer/publish_tags_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe TagImporter::PublishTags do
-  let(:tagging_spreadsheet) { TaggingSpreadsheet.create(url: "https://tagging/spreadsheet/") }
+  let(:tagging_spreadsheet) { TaggingSpreadsheet.create!(state: "uploaded", url: "https://tagging/spreadsheet/") }
   let(:user) { double(uid: "user-123") }
 
   before do


### PR DESCRIPTION
At the moment, when the user creates a new spreadsheet import by submitting a URL, the application will start the initial import step (parsing the CSV, creating records for each row) in the request cycle.

This is slow and does not allow us to add more expensive validation to this step.

This commit is the minimum we have to do to move the initial import action to a Sidekiq worker.

- It adds a very crude state thing, which could perhaps be replaced by a real state machine.
- The workflow is a bit clunky now. For example, it's not clear to the user what state the spreadsheet is in. We'll address this in follow up PRs (https://trello.com/c/7tcrUgcz).

Trello: https://trello.com/c/xi83pGTZ