### PR TITLE
Mark tagging spreadsheets as deleted

### DIFF
--- a/app/controllers/tagging_spreadsheets_controller.rb
+++ b/app/controllers/tagging_spreadsheets_controller.rb
@@ -1,6 +1,6 @@
 class TaggingSpreadsheetsController < ApplicationController
   def index
-    @tagging_spreadsheets = TaggingSpreadsheet.all.newest_first
+    @tagging_spreadsheets = TaggingSpreadsheet.active.newest_first
   end
 
   def new
@@ -49,7 +49,7 @@ class TaggingSpreadsheetsController < ApplicationController
 
   def destroy
     tagging_spreadsheet = TaggingSpreadsheet.find(params[:id])
-    tagging_spreadsheet.destroy!
+    tagging_spreadsheet.mark_as_deleted
     redirect_to tagging_spreadsheets_path
   end
 

--- a/app/models/tagging_spreadsheet.rb
+++ b/app/models/tagging_spreadsheet.rb
@@ -5,4 +5,8 @@ class TaggingSpreadsheet < ActiveRecord::Base
 
   has_many :tag_mappings, dependent: :delete_all
   scope :newest_first, -> { order(created_at: :desc) }
+
+  def mark_as_deleted
+    update(deleted_at: DateTime.current)
+  end
 end

--- a/app/models/tagging_spreadsheet.rb
+++ b/app/models/tagging_spreadsheet.rb
@@ -5,6 +5,7 @@ class TaggingSpreadsheet < ActiveRecord::Base
 
   has_many :tag_mappings, dependent: :delete_all
   scope :newest_first, -> { order(created_at: :desc) }
+  scope :active, -> { where(deleted_at: nil) }
 
   def mark_as_deleted
     update(deleted_at: DateTime.current)

--- a/app/views/tagging_spreadsheets/index.html.erb
+++ b/app/views/tagging_spreadsheets/index.html.erb
@@ -3,22 +3,26 @@
 <% end %>
 
 <table>
-  <tr>
-    <th>Google Sheet URL</th>
-    <th>Date added</th>
-    <th></th>
-    <th></th>
-  </tr>
-  <% @tagging_spreadsheets.each do |spreadsheet| %>
+  <thead>
     <tr>
-      <td><%= spreadsheet.url %></td>
-      <td><%= spreadsheet.created_at %></td>
-      <td>
-        <%= link_to "Preview", tagging_spreadsheet_path(spreadsheet) %>
-      </td>
-      <td>
-        <%= link_to "Delete", tagging_spreadsheet_path(spreadsheet), method: :delete, class: "btn btn-danger btn-sm" %>
-      </td>
+      <th>Google Sheet URL</th>
+      <th>Date added</th>
+      <th></th>
+      <th></th>
     </tr>
-  <% end %>
+  </thead>
+  <tbody>
+    <% @tagging_spreadsheets.each do |spreadsheet| %>
+      <tr>
+        <td><%= spreadsheet.url %></td>
+        <td><%= spreadsheet.created_at %></td>
+        <td>
+          <%= link_to "Preview", tagging_spreadsheet_path(spreadsheet) %>
+        </td>
+        <td>
+          <%= link_to "Delete", tagging_spreadsheet_path(spreadsheet), method: :delete, class: "btn btn-danger btn-sm" %>
+        </td>
+      </tr>
+    <% end %>
+    </tbody>
 </table>

--- a/db/migrate/20160810070419_add_deleted_at_to_tagging_spreadsheets.rb
+++ b/db/migrate/20160810070419_add_deleted_at_to_tagging_spreadsheets.rb
@@ -1,0 +1,5 @@
+class AddDeletedAtToTaggingSpreadsheets < ActiveRecord::Migration
+  def change
+    add_column :tagging_spreadsheets, :deleted_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160808210736) do
+ActiveRecord::Schema.define(version: 20160810070419) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -39,6 +39,7 @@ ActiveRecord::Schema.define(version: 20160808210736) do
     t.datetime "last_published_at"
     t.string   "state",             null: false
     t.text     "error_message"
+    t.datetime "deleted_at"
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/features/tag_importer_spec.rb
+++ b/spec/features/tag_importer_spec.rb
@@ -31,6 +31,14 @@ RSpec.feature "Tag importer", type: :feature do
     then_i_can_preview_which_taggings_will_be_imported
   end
 
+  scenario "Deleting tagging spreadsheets" do
+    given_tagging_data_is_present_in_a_google_spreadsheet
+    when_i_provide_the_public_uri_of_this_spreadsheet
+    and_i_delete_the_tagging_spreadsheet
+    then_it_is_no_longer_available
+    and_it_has_been_marked_as_deleted
+  end
+
   SHEET_KEY = "THE-KEY-123".freeze
   SHEET_GID = "123456".freeze
 
@@ -130,5 +138,21 @@ RSpec.feature "Tag importer", type: :feature do
 
   def then_i_should_see_an_updated_preview
     expect_page_to_contain_details_of(tag_mappings: TagMapping.all)
+  end
+
+  def and_i_delete_the_tagging_spreadsheet
+    delete_button = first('table tbody a', text: 'Delete')
+
+    expect { delete_button.click }.to_not change { TaggingSpreadsheet.count }
+  end
+
+  def then_it_is_no_longer_available
+    rows = all('table tbody tr')
+    expect(rows.count).to eq(0)
+  end
+
+  def and_it_has_been_marked_as_deleted
+    tagging_spreadsheet = TaggingSpreadsheet.first
+    expect(tagging_spreadsheet.deleted_at).to_not be_nil
   end
 end

--- a/spec/models/tagging_spreadsheet_spec.rb
+++ b/spec/models/tagging_spreadsheet_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe TaggingSpreadsheet do
+  describe '#mark_as_deleted' do
+    it 'updates the deleted_at date' do
+      tagging_spreadsheet = described_class.new
+      expect(tagging_spreadsheet.deleted_at).to be_nil
+
+      tagging_spreadsheet.mark_as_deleted
+      expect(tagging_spreadsheet.deleted_at).to_not be_nil
+    end
+  end
+end


### PR DESCRIPTION
Instead of deleting TaggingSpreadsheets, we should mark them as deleted and keep
a record of them in the backend for audit purposes. As they perform actions on
content items, we should probably keep a record of them in case something goes
wrong.

This change makes sure we don't perform a hard-delete on those spreadsheets. We
instead mark them as deleted and remove those ones from the index page.

Trello: https://trello.com/c/dAR3TgV2/84-instead-of-allowing-a-user-to-delete-a-tagging-spreadsheet-we-should-probably-just-mark-it-as-deleted-in-order-to-keep-a-record-

Part of a bigger task: https://trello.com/c/7tcrUgcz/66-initial-round-of-improvements-to-error-handling-in-tag-importer