### PR TITLE
Enable tagging of publisher-owned pages

### DIFF
--- a/config/blacklisted-tag-types.yml
+++ b/config/blacklisted-tag-types.yml
@@ -28,14 +28,6 @@ whitehall:
   # publishing-api.
   - organisations
 
-publisher:
-  # Publisher is not migrated yet. Its browse pages, topics and parent (breadcrumb)
-  # are set inside publisher. This can be enabled once publisher reads & writes
-  # from the publishing-api.
-  - mainstream_browse_pages
-  - parent
-  - topics
-
 specialist-publisher:
   # Documents owned by specialist-publisher are automatically tagged to organisations
   # via a harcoded list per document type. In the specialist-publisher rebuild

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -50,5 +50,19 @@ RSpec.describe ContentItem do
         expect(content_item.blacklisted_tag_types).to include 'topics'
       end
     end
+
+    context 'for the publisher app' do
+      let(:content_item) do
+        ContentItem.new(
+          content_item_params.merge(
+            'publishing_app' => 'publisher',
+          )
+        )
+      end
+
+      it 'does not blacklist any tag types' do
+        expect(content_item.blacklisted_tag_types).to be_empty
+      end
+    end
   end
 end


### PR DESCRIPTION
Now that `publisher` has been migrated to use the `publishing-api`, we can
enable tagging of `mainstream_browse_pages`, `parent` and `topics` from
`content-tagger`.

Trello: https://trello.com/c/brqM6513/64-make-sure-we-can-tag-publisher-owned-pages-in-content-tagger-small