### PR TITLE
Use the same naming on both the nav link and URL

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
     post '/content/taggings', action: :update_links, as: :content_update_links
   end
 
-  resources :tagging_spreadsheets, except: [:update, :edit] do
+  resources :tagging_spreadsheets, except: [:update, :edit], path: '/tag-importer' do
     post 'refetch'
     post 'publish_tags'
     get  'import_progress'


### PR DESCRIPTION
Before we had a link called "Tag Importer" and a matching URL of
/tagging-spreadsheets. This change makes the naming consistent.

Trello: https://trello.com/c/RRqvi0UC/86-make-the-nav-link-text-and-the-url-match-tag-importer-vs-tagging-spreadsheets

Part of: https://trello.com/c/7tcrUgcz/66-initial-round-of-improvements-to-error-handling-in-tag-importer