### PR TITLE
Remove auto-linting in specs

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -4,6 +4,4 @@ export REPO_NAME=${REPO_NAME:-"alphagov/content-tagger"}
 export CONTEXT_MESSAGE=${CONTEXT_MESSAGE:-"default"}
 export GH_STATUS_GIT_COMMIT=${SCHEMA_GIT_COMMIT:-${GIT_COMMIT}}
 
-export SKIP_LINT_IN_SPECS=1
-
 curl https://raw.githubusercontent.com/alphagov/govuk-ci-scripts/master/rails-app.sh | bash

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,11 +30,4 @@ RSpec.configure do |config|
   config.before(:each) do
     WebMock.reset!
   end
-
-  config.after :suite do
-    unless ENV["SKIP_LINT_IN_SPECS"]
-      require "govuk/lint/cli"
-      Govuk::Lint::CLI.new.run([])
-    end
-  end
 end


### PR DESCRIPTION
I find this behaviour more annoying than having the build occasionally fail on CI.