### PR TITLE
Validate google spreadsheet url

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ group :development, :test do
   gem 'simplecov-rcov', '0.2.3', require: false
   gem 'govuk-content-schema-test-helpers', '~> 1.4'
   gem 'govuk-lint'
+  gem 'factory_girl_rails'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,6 +71,11 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.7.0)
+    factory_girl (4.7.0)
+      activesupport (>= 3.0.0)
+    factory_girl_rails (4.7.0)
+      factory_girl (~> 4.7.0)
+      railties (>= 3.0.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     gds-api-adapters (32.3.0)
@@ -323,6 +328,7 @@ PLATFORMS
 DEPENDENCIES
   airbrake (~> 4.3.1)
   capybara
+  factory_girl_rails
   gds-api-adapters (~> 32.3)
   gds-sso (~> 11.1)
   generic_form_builder (~> 0.13.0)

--- a/app/models/tagging_spreadsheet.rb
+++ b/app/models/tagging_spreadsheet.rb
@@ -2,6 +2,7 @@ class TaggingSpreadsheet < ActiveRecord::Base
   validates :url, presence: true
   validates_presence_of :state
   validates_inclusion_of :state, in: %w(uploaded errored ready_to_import imported)
+  validates_with GoogleUrlValidator
 
   has_many :tag_mappings, dependent: :delete_all
   scope :newest_first, -> { order(created_at: :desc) }

--- a/app/validators/google_url_validator.rb
+++ b/app/validators/google_url_validator.rb
@@ -1,0 +1,34 @@
+class GoogleUrlValidator < ActiveModel::Validator
+  def validate(record)
+    uri = URI.parse(record.url)
+
+    validate_host(uri, record)
+    validate_path(uri, record)
+    validate_parameters(uri, record)
+  end
+
+private
+
+  def validate_host(uri, record)
+    unless uri.host == "docs.google.com"
+      record.errors[:url] << I18n.t('errors.invalid_hostname')
+    end
+  end
+
+  def validate_path(uri, record)
+    unless uri.path =~ %r{spreadsheets\/d\/.+\/pub}
+      record.errors[:url] << I18n.t('errors.invalid_path')
+    end
+  end
+
+  def validate_parameters(uri, record)
+    parameters = CGI.parse(uri.query || "")
+    unless parameters['gid'].present?
+      record.errors[:url] << I18n.t('errors.missing_gid')
+    end
+
+    unless parameters['output'].present? && parameters['output'].include?('tsv')
+      record.errors[:url] << I18n.t('errors.missing_output')
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,3 +1,7 @@
 en:
   errors:
     invalid_taxon: There was a problem with your request and we were notified about it. We will fix this issue as soon as possible
+    invalid_hostname: Is not a Google Docs URL
+    invalid_path: Does not have the expected public path /spreadsheets/d/<id>/pub
+    missing_gid: Is missing a Google Spreadsheet ID parameter (gid)
+    missing_output: Is missing the parameter output as TSV

--- a/spec/factories/tagging_spreadsheet.rb
+++ b/spec/factories/tagging_spreadsheet.rb
@@ -1,0 +1,11 @@
+require_relative '../support/google_sheet_helper.rb'
+
+include GoogleSheetHelper
+
+FactoryGirl.define do
+  factory :tagging_spreadsheet do
+    url google_sheet_url(key: 'mykey', gid: 'mygid')
+
+    state 'uploaded'
+  end
+end

--- a/spec/models/tagging_spreadsheet_spec.rb
+++ b/spec/models/tagging_spreadsheet_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe TaggingSpreadsheet do
   describe '#mark_as_deleted' do
     it 'updates the deleted_at date' do
-      tagging_spreadsheet = described_class.new
+      tagging_spreadsheet = build(:tagging_spreadsheet)
       expect(tagging_spreadsheet.deleted_at).to be_nil
 
       tagging_spreadsheet.mark_as_deleted

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -24,6 +24,7 @@ ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
   config.include GdsApi::TestHelpers::PublishingApiV2
+  config.include FactoryGirl::Syntax::Methods
 
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
   config.use_transactional_fixtures = true

--- a/spec/services/tag_importer/publish_tags_spec.rb
+++ b/spec/services/tag_importer/publish_tags_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe TagImporter::PublishTags do
-  let(:tagging_spreadsheet) { TaggingSpreadsheet.create!(state: "uploaded", url: "https://tagging/spreadsheet/") }
+  let(:tagging_spreadsheet) { create(:tagging_spreadsheet, state: "uploaded") }
   let(:user) { double(uid: "user-123") }
 
   before do

--- a/spec/validators/google_url_validator_spec.rb
+++ b/spec/validators/google_url_validator_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe GoogleUrlValidator do
+  include GoogleSheetHelper
+
+  it 'validates an incorrect host name' do
+    record = double(url: "https://invalid.com", errors: { url: [] })
+    GoogleUrlValidator.new.validate(record)
+
+    expect(record.errors[:url]).to include(/is not a google docs url/i)
+  end
+
+  it 'validates an incorrect path' do
+    record = double(url: "https://docs.google.com/something/else", errors: { url: [] })
+    GoogleUrlValidator.new.validate(record)
+
+    expect(record.errors[:url]).to include(/does not have the expected public path/i)
+  end
+
+  it 'validates missing param gid' do
+    record = double(url: "https://docs.google.com/path?p=1&p=2", errors: { url: [] })
+    GoogleUrlValidator.new.validate(record)
+
+    expect(record.errors[:url]).to include(/is missing a google spreadsheet id/i)
+  end
+
+  it 'validates missing param output' do
+    record = double(url: "https://docs.google.com/path", errors: { url: [] })
+    GoogleUrlValidator.new.validate(record)
+
+    expect(record.errors[:url]).to include(/is missing the parameter output as tsv/i)
+  end
+
+  it 'validates incorrect param output' do
+    record = double(url: "https://docs.google.com/path?output=pdf", errors: { url: [] })
+    GoogleUrlValidator.new.validate(record)
+
+    expect(record.errors[:url]).to include(/is missing the parameter output as tsv/i)
+  end
+
+  it 'does not add validation errors for a correct URL' do
+    valid_url = google_sheet_url(key: 'mykey', gid: 'mygid')
+    record = double(url: valid_url, errors: { url: [] })
+
+    GoogleUrlValidator.new.validate(record)
+
+    expect(record.errors[:url]).to be_empty
+  end
+end


### PR DESCRIPTION
Validate the URL provided to `TaggingSpreadsheet` models in order to make sure only valid Google Spreadsheet URLs are given by the user.

There are 3 validations:
- the hostname (it should be `docs.google.com`)
- the path (it needs to match `/spreadsheets/d/<a key>/pub`
- the params (it needs to include a Google ID param called `gid`)

This PR also adds a factory for building `TaggingSpreadsheet` objects in the tests with the correct URL structure.

Trello: https://trello.com/c/AGgxBxcJ/87-validate-the-data-given-to-the-tag-importer-it-should-be-a-google-spreadsheet-url-currently-it-accepts-anything

Part of: https://trello.com/c/7tcrUgcz/66-initial-round-of-improvements-to-error-handling-in-tag-importer