### PR TITLE
A TaxonPayloadBuilder builds a payload

### DIFF
--- a/app/services/taxonomy/publisher.rb
+++ b/app/services/taxonomy/publisher.rb
@@ -14,7 +14,7 @@ module Taxonomy
     end
 
     def publish
-      Services.publishing_api.put_content(content_id, presenter.payload)
+      Services.publishing_api.put_content(content_id, payload)
       Services.publishing_api.publish(content_id, "minor")
       Services.publishing_api.patch_links(
         content_id,
@@ -27,8 +27,8 @@ module Taxonomy
 
   private
 
-    def presenter
-      Taxonomy::TaxonPayloadBuilder.new(taxon)
+    def payload
+      Taxonomy::TaxonPayloadBuilder.build(taxon: taxon)
     end
   end
 end

--- a/app/services/taxonomy/taxon_payload_builder.rb
+++ b/app/services/taxonomy/taxon_payload_builder.rb
@@ -4,7 +4,11 @@ module Taxonomy
       @taxon = taxon
     end
 
-    def payload
+    def self.build(taxon:)
+      new(taxon).build
+    end
+
+    def build
       {
         base_path: base_path,
         document_type: 'taxon',

--- a/spec/services/taxonomy/taxon_payload_builder_spec.rb
+++ b/spec/services/taxonomy/taxon_payload_builder_spec.rb
@@ -4,10 +4,10 @@ RSpec.describe Taxonomy::TaxonPayloadBuilder do
   let(:taxon) do
     instance_double(Taxon, title: 'My Title', base_path: "/taxons/my-taxon")
   end
-  let(:presenter) { described_class.new(taxon) }
+  let(:builder) { described_class.new(taxon) }
 
-  describe "#payload" do
-    let(:payload) { presenter.payload }
+  describe "#build" do
+    let(:payload) { builder.build }
 
     it "generates a valid payload" do
       expect(payload).to be_valid_against_schema('taxon')


### PR DESCRIPTION
This commit fixes:

- naming issues, where we were calling the TaxonPayloadBuilder a presenter;
- the interface with TaxonPayloadBuilder - instead of having a `payload` method,
  we let the `build` method return a payload, as the class name suggests.