### PR TITLE
Add description and user to TaggingSpreadsheet index page

### DIFF
--- a/app/controllers/tagging_spreadsheets_controller.rb
+++ b/app/controllers/tagging_spreadsheets_controller.rb
@@ -56,6 +56,6 @@ class TaggingSpreadsheetsController < ApplicationController
 private
 
   def tagging_spreadsheet_params
-    params.require(:tagging_spreadsheet).permit(:url)
+    params.require(:tagging_spreadsheet).permit(:url, :description)
   end
 end

--- a/app/controllers/tagging_spreadsheets_controller.rb
+++ b/app/controllers/tagging_spreadsheets_controller.rb
@@ -1,6 +1,6 @@
 class TaggingSpreadsheetsController < ApplicationController
   def index
-    @tagging_spreadsheets = TaggingSpreadsheet.active.newest_first
+    @tagging_spreadsheets = TaggingSpreadsheet.active.newest_first.includes(:added_by)
   end
 
   def new
@@ -9,7 +9,7 @@ class TaggingSpreadsheetsController < ApplicationController
 
   def create
     tagging_spreadsheet = TaggingSpreadsheet.new(tagging_spreadsheet_params)
-    tagging_spreadsheet.added_by = current_user.uid
+    tagging_spreadsheet.user_uid = current_user.uid
     tagging_spreadsheet.state = "uploaded"
 
     if tagging_spreadsheet.valid?

--- a/app/models/tagging_spreadsheet.rb
+++ b/app/models/tagging_spreadsheet.rb
@@ -4,6 +4,8 @@ class TaggingSpreadsheet < ActiveRecord::Base
   validates_inclusion_of :state, in: %w(uploaded errored ready_to_import imported)
 
   has_many :tag_mappings, dependent: :delete_all
+  has_one :added_by, class_name: "User", primary_key: :user_uid, foreign_key: :uid
+
   scope :newest_first, -> { order(created_at: :desc) }
   scope :active, -> { where(deleted_at: nil) }
 

--- a/app/views/tagging_spreadsheets/index.html.erb
+++ b/app/views/tagging_spreadsheets/index.html.erb
@@ -8,6 +8,7 @@
       <th>Google Sheet URL</th>
       <th>Description</th>
       <th>Date added</th>
+      <th>Added by</th>
       <th></th>
       <th></th>
     </tr>
@@ -22,6 +23,7 @@
             <%= distance_of_time_in_words_to_now(spreadsheet.created_at) %>
           </time>
         </td>
+        <td><%= spreadsheet.added_by.name %></td>
         <td>
           <%= link_to "Preview", tagging_spreadsheet_path(spreadsheet) %>
         </td>

--- a/app/views/tagging_spreadsheets/index.html.erb
+++ b/app/views/tagging_spreadsheets/index.html.erb
@@ -6,6 +6,7 @@
   <thead>
     <tr>
       <th>Google Sheet URL</th>
+      <th>Description</th>
       <th>Date added</th>
       <th></th>
       <th></th>
@@ -15,6 +16,7 @@
     <% @tagging_spreadsheets.each do |spreadsheet| %>
       <tr>
         <td><%= spreadsheet.url %></td>
+        <td><%= spreadsheet.description %></td>
         <td>
           <time data-toggle="tooltip" data-original-title="<%= spreadsheet.created_at.to_s %>">
             <%= distance_of_time_in_words_to_now(spreadsheet.created_at) %>
@@ -28,5 +30,5 @@
         </td>
       </tr>
     <% end %>
-    </tbody>
+  </tbody>
 </table>

--- a/app/views/tagging_spreadsheets/new.html.erb
+++ b/app/views/tagging_spreadsheets/new.html.erb
@@ -3,10 +3,11 @@
 <%= simple_form_for @tagging_spreadsheet, url: tagging_spreadsheets_path do |f| %>
   <div class="form-group">
     <%= f.input :url, label: "Spreadsheet URL" %>
+    <%= f.input :description, label: "Spreadsheet URL" %>
     <p class='explain'>
       See the <%= link_to "example spreadsheet",
-          "https://docs.google.com/spreadsheets/d/1BB4mAcaf0pfCUUxrt3pmFvebiPv0yUAkfLEeEJjIT0M/pub?gid=386284585&single=true&output=tsv" %>
-          for the correct format.
+        "https://docs.google.com/spreadsheets/d/1BB4mAcaf0pfCUUxrt3pmFvebiPv0yUAkfLEeEJjIT0M/pub?gid=386284585&single=true&output=tsv" %>
+        for the correct format.
     </p>
 
     <%= f.submit "Upload", class: "btn btn-lg btn-primary" %>

--- a/app/views/tagging_spreadsheets/new.html.erb
+++ b/app/views/tagging_spreadsheets/new.html.erb
@@ -2,8 +2,9 @@
 
 <%= simple_form_for @tagging_spreadsheet, url: tagging_spreadsheets_path do |f| %>
   <div class="form-group">
-    <%= f.input :url, label: "Spreadsheet URL" %>
-    <%= f.input :description, label: "Spreadsheet URL" %>
+    <%= f.input :url, input_html: { type: :text}, label: "Spreadsheet URL" %>
+    <%= f.input :description %>
+
     <p class='explain'>
       See the <%= link_to "example spreadsheet",
         "https://docs.google.com/spreadsheets/d/1BB4mAcaf0pfCUUxrt3pmFvebiPv0yUAkfLEeEJjIT0M/pub?gid=386284585&single=true&output=tsv" %>

--- a/db/migrate/20160805142727_add_description_to_tagging_spreadsheet.rb
+++ b/db/migrate/20160805142727_add_description_to_tagging_spreadsheet.rb
@@ -1,0 +1,5 @@
+class AddDescriptionToTaggingSpreadsheet < ActiveRecord::Migration
+  def change
+    add_column :tagging_spreadsheets, :description, :string
+  end
+end

--- a/db/migrate/20160810153418_rename_added_by_to_user_uid_on_tagging_spreadsheets.rb
+++ b/db/migrate/20160810153418_rename_added_by_to_user_uid_on_tagging_spreadsheets.rb
@@ -1,0 +1,5 @@
+class RenameAddedByToUserUidOnTaggingSpreadsheets < ActiveRecord::Migration
+  def change
+    rename_column :tagging_spreadsheets, :added_by, :user_uid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160810070419) do
+ActiveRecord::Schema.define(version: 20160810153418) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,7 +34,7 @@ ActiveRecord::Schema.define(version: 20160810070419) do
     t.string   "url",               null: false
     t.datetime "created_at",        null: false
     t.datetime "updated_at",        null: false
-    t.string   "added_by"
+    t.string   "user_uid"
     t.string   "last_published_by"
     t.datetime "last_published_at"
     t.string   "description"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -37,6 +37,7 @@ ActiveRecord::Schema.define(version: 20160810070419) do
     t.string   "added_by"
     t.string   "last_published_by"
     t.datetime "last_published_at"
+    t.string   "description"
     t.string   "state",             null: false
     t.text     "error_message"
     t.datetime "deleted_at"

--- a/spec/features/tag_importer_spec.rb
+++ b/spec/features/tag_importer_spec.rb
@@ -7,6 +7,10 @@ RSpec.feature "Tag importer", type: :feature do
 
   before do
     Sidekiq::Testing.inline!
+
+    # We need the gds sso test user to be identifiable by uid in this spec to
+    # find the user who added the spreadsheet.
+    User.first.update(uid: "some-value", name: "Barry Allen")
   end
 
   scenario "Importing tags" do
@@ -69,6 +73,8 @@ RSpec.feature "Tag importer", type: :feature do
     click_link "Upload spreadsheet"
     fill_in "Spreadsheet URL", with: google_sheet_url(key: SHEET_KEY, gid: SHEET_GID)
     click_button "Upload"
+    expect(TaggingSpreadsheet.count).to eq 1
+    expect(TaggingSpreadsheet.first.added_by.name).to eq "Barry Allen"
   end
 
   def then_i_can_preview_which_taggings_will_be_imported


### PR DESCRIPTION
- The description is useful for easily distinguishing between multiple
  spreadsheets.
- The user who added the spreadsheet is already recorded - this commit
  merely surfaces this info in the table.