### PR TITLE
Show a relative date and leave the timestamp in a tooltip

### DIFF
--- a/app/views/tagging_spreadsheets/index.html.erb
+++ b/app/views/tagging_spreadsheets/index.html.erb
@@ -15,7 +15,11 @@
     <% @tagging_spreadsheets.each do |spreadsheet| %>
       <tr>
         <td><%= spreadsheet.url %></td>
-        <td><%= spreadsheet.created_at %></td>
+        <td>
+          <time data-toggle="tooltip" data-original-title="<%= spreadsheet.created_at.to_s %>">
+            <%= distance_of_time_in_words_to_now(spreadsheet.created_at) %>
+          </time>
+        </td>
         <td>
           <%= link_to "Preview", tagging_spreadsheet_path(spreadsheet) %>
         </td>


### PR DESCRIPTION
This adds a relative date to the table (e.g. 2 days ago), leaving the full date
in a tooptip.

It looks like this:

<img width="224" alt="screen shot 2016-08-10 at 14 58 15" src="https://cloud.githubusercontent.com/assets/416701/17557242/542f525c-5f0e-11e6-8b32-31666d5d1232.png">

Trello: https://trello.com/c/9gTRsczJ/88-in-tagging-spreadsheets-add-a-timeago-string-e-g-2-days-ago-keep-created-at-accessible-via-title-attribute-or-something

Part of: https://trello.com/c/7tcrUgcz/66-initial-round-of-improvements-to-error-handling-in-tag-importer