### PR TITLE
Display state information on tag importer

### DIFF
--- a/app/controllers/tagging_spreadsheets_controller.rb
+++ b/app/controllers/tagging_spreadsheets_controller.rb
@@ -1,6 +1,6 @@
 class TaggingSpreadsheetsController < ApplicationController
   def index
-    @tagging_spreadsheets = TaggingSpreadsheet.active.newest_first.includes(:added_by)
+    render :index, locals: { tagging_spreadsheets: presented_tagging_spreadsheets }
   end
 
   def new
@@ -54,6 +54,16 @@ class TaggingSpreadsheetsController < ApplicationController
   end
 
 private
+
+  def tagging_spreadsheets
+    TaggingSpreadsheet.active.newest_first.includes(:added_by)
+  end
+
+  def presented_tagging_spreadsheets
+    tagging_spreadsheets.map do |tagging_spreadsheet|
+      TaggingSpreadsheetPresenter.new(tagging_spreadsheet)
+    end
+  end
 
   def tagging_spreadsheet_params
     params.require(:tagging_spreadsheet).permit(:url, :description)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,4 +6,15 @@ module ApplicationHelper
       title
     end
   end
+
+  def time_tag_for(date)
+    data_attributes = {
+      'toggle': 'tooltip',
+      'original-title': date,
+    }
+
+    content_tag :time, data: data_attributes do
+      distance_of_time_in_words_to_now(date)
+    end
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,9 @@
 module ApplicationHelper
+  def state_label_for(label_type:, title:, data_attributes:)
+    css_class = ['label', label_type].join(' ')
+
+    content_tag :span, class: css_class, data: data_attributes do
+      title
+    end
+  end
 end

--- a/app/presenters/tagging_spreadsheet_presenter.rb
+++ b/app/presenters/tagging_spreadsheet_presenter.rb
@@ -1,0 +1,21 @@
+class TaggingSpreadsheetPresenter < SimpleDelegator
+  def label_type
+    {
+      errored: 'label-danger',
+      imported: 'label-success'
+    }.fetch(state.to_sym, 'label-warning')
+  end
+
+  def state_title
+    state.humanize
+  end
+
+  def data_attributes
+    return {} unless state == 'errored'
+
+    {
+      'toggle': 'tooltip',
+      'original-title': error_message
+    }
+  end
+end

--- a/app/views/tagging_spreadsheets/index.html.erb
+++ b/app/views/tagging_spreadsheets/index.html.erb
@@ -23,9 +23,7 @@
         <td><%= spreadsheet.url %></td>
         <td><%= spreadsheet.description %></td>
         <td>
-          <time data-toggle="tooltip" data-original-title="<%= spreadsheet.created_at.to_s %>">
-            <%= distance_of_time_in_words_to_now(spreadsheet.created_at) %>
-          </time>
+          <%= time_tag_for(spreadsheet.created_at) %>
         </td>
         <td><%= spreadsheet.added_by.name %></td>
         <td>

--- a/app/views/tagging_spreadsheets/index.html.erb
+++ b/app/views/tagging_spreadsheets/index.html.erb
@@ -5,6 +5,7 @@
 <table>
   <thead>
     <tr>
+      <th>State</th>
       <th>Google Sheet URL</th>
       <th>Description</th>
       <th>Date added</th>
@@ -14,8 +15,11 @@
     </tr>
   </thead>
   <tbody>
-    <% @tagging_spreadsheets.each do |spreadsheet| %>
+    <% tagging_spreadsheets.each do |spreadsheet| %>
       <tr>
+        <td><%= state_label_for(label_type: spreadsheet.label_type,
+                                title: spreadsheet.state_title,
+                                data_attributes: spreadsheet.data_attributes) %></td>
         <td><%= spreadsheet.url %></td>
         <td><%= spreadsheet.description %></td>
         <td>

--- a/spec/presenters/tagging_spreadsheet_presenter_spec.rb
+++ b/spec/presenters/tagging_spreadsheet_presenter_spec.rb
@@ -1,0 +1,70 @@
+require 'rails_helper'
+
+RSpec.describe TaggingSpreadsheetPresenter do
+  let(:tagging_spreadsheet) { TaggingSpreadsheet.new }
+  let(:presenter) { described_class.new(tagging_spreadsheet) }
+
+  describe 'label_type' do
+    it 'returns a label css class indicting an error for the errored state' do
+      tagging_spreadsheet.state = 'errored'
+
+      expect(presenter.label_type).to eq('label-danger')
+    end
+
+    it 'returns a label css class indicting a success for the imported state' do
+      tagging_spreadsheet.state = 'imported'
+
+      expect(presenter.label_type).to eq('label-success')
+    end
+
+    it 'returns a label css class indicting a warning for the ready_to_import state' do
+      tagging_spreadsheet.state = 'ready_to_import'
+
+      expect(presenter.label_type).to eq('label-warning')
+    end
+
+    it 'returns a label css class indicting a warning for the uploaded state' do
+      tagging_spreadsheet.state = 'uploaded'
+
+      expect(presenter.label_type).to eq('label-warning')
+    end
+  end
+
+  describe '#state_title' do
+    it 'humanizes the state' do
+      tagging_spreadsheet.state = 'errored'
+
+      expect(presenter.state_title).to eq('Errored')
+    end
+  end
+
+  describe '#data_attributes' do
+    it 'returns the tooltip data attributes with the error message for the errored state' do
+      tagging_spreadsheet.state = 'errored'
+      tagging_spreadsheet.error_message = 'an error message'
+
+      expect(presenter.data_attributes).to include('toggle': 'tooltip')
+      expect(presenter.data_attributes).to include(
+        'original-title': tagging_spreadsheet.error_message
+      )
+    end
+
+    it 'does not return data attributes for the imported state' do
+      tagging_spreadsheet.state = 'imported'
+
+      expect(presenter.data_attributes).to be_empty
+    end
+
+    it 'does not return data attributes for the ready_to_import state' do
+      tagging_spreadsheet.state = 'ready_to_import'
+
+      expect(presenter.data_attributes).to be_empty
+    end
+
+    it 'does not return data attributes for the uploaded state' do
+      tagging_spreadsheet.state = 'uploaded'
+
+      expect(presenter.data_attributes).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
For each of the spreadsheet taggings in the system, we should display the state
information so we are aware of the progress of each of the imports.

In case there is an error, we should also display an error message as a tooltip
in the label.

This PR also adds an experimental Facade. It works pretty much like a decorator, but it has no view context, so it can't access view helpers. Its responsibility is to hold logic specific to the object in the context of its presentation in the view. Are people ok with this approach? 

This change looks like this:

1) With an error:

<img width="1190" alt="screen shot 2016-08-10 at 17 12 25" src="https://cloud.githubusercontent.com/assets/416701/17561402/a2ccddda-5f1d-11e6-89d8-25fc720d4777.png">

2) With success:

<img width="1197" alt="screen shot 2016-08-10 at 17 13 51" src="https://cloud.githubusercontent.com/assets/416701/17561441/d5063b3e-5f1d-11e6-839a-344840e6ba7c.png">

3) With other states (`ready_to_import` and `uploaded`):

<img width="1203" alt="screen shot 2016-08-10 at 17 11 41" src="https://cloud.githubusercontent.com/assets/416701/17561368/868f32da-5f1d-11e6-866d-b482eecb30bb.png">
