### PR TITLE
Improve error handling markup

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -6,18 +6,7 @@
 
 @import 'govuk_admin_template';
 @import 'import-preview';
-
-.select2 {
-  width: 100%;
-}
-
-form label {
-  display: block;
-
-  .error {
-    color: $state-danger-text;
-  }
-}
+@import 'forms';
 
 .view-on-site {
   font-size: 20px;
@@ -79,8 +68,4 @@ table {
     @extend .btn;
     @extend .btn-default;
   }
-}
-
-input[type='text'] {
-  @extend .form-control;
 }

--- a/app/assets/stylesheets/forms.css.scss
+++ b/app/assets/stylesheets/forms.css.scss
@@ -1,0 +1,17 @@
+.select2 {
+  width: 100%;
+}
+
+form label {
+  display: block;
+}
+
+form {
+  .help-inline {
+    color: $state-danger-text;
+  }
+}
+
+input[type='text'] {
+  @extend .form-control;
+}

--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -14,13 +14,17 @@ class TaxonsController < ApplicationController
     new_taxon = Taxon.new(params[:taxon])
     if new_taxon.valid?
       Taxonomy::Publisher.publish(taxon: new_taxon)
-      redirect_to taxons_path
+      redirect_to(taxons_path)
     else
       error_messages = new_taxon.errors.full_messages.join('; ')
-      redirect_to new_taxon_path, flash: { error: error_messages }
+      locals = {
+        taxon: new_taxon,
+        taxons_for_select: taxons_for_select
+      }
+      render :new, locals: locals, flash: { error: error_messages }
     end
   rescue Taxonomy::Publisher::InvalidTaxonError => e
-    redirect_to new_taxon_path, flash: { error: e.message }
+    redirect_to(new_taxon_path, flash: { error: e.message })
   end
 
   def show

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -38,10 +38,10 @@ SimpleForm.setup do |config|
     b.use :error, wrap_with: { tag: :span, class: :error }
   end
 
-  config.wrappers :bootstrap, tag: 'div', class: 'form-group', error_class: 'error' do |b|
+  config.wrappers :bootstrap, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
     b.use :html5
     b.use :placeholder
-    b.use :label
+    b.use :label, class: 'control-label'
     b.wrapper tag: 'div' do |ba|
       ba.use :input
       ba.use :error, wrap_with: { tag: 'span', class: 'help-inline' }
@@ -49,7 +49,7 @@ SimpleForm.setup do |config|
     end
   end
 
-  config.wrappers :prepend, tag: 'div', class: "form-group", error_class: 'error' do |b|
+  config.wrappers :prepend, tag: 'div', class: "form-group", error_class: 'has-error' do |b|
     b.use :html5
     b.use :placeholder
     b.use :label
@@ -62,7 +62,7 @@ SimpleForm.setup do |config|
     end
   end
 
-  config.wrappers :append, tag: 'div', class: "form-group", error_class: 'error' do |b|
+  config.wrappers :append, tag: 'div', class: "form-group", error_class: 'has-error' do |b|
     b.use :html5
     b.use :placeholder
     b.use :label


### PR DESCRIPTION
This PR adds bootstrap-specific error states to forms.

So instead of this:

<img width="684" alt="screen shot 2016-08-11 at 11 30 57" src="https://cloud.githubusercontent.com/assets/416701/17586069/66d6461e-5fb7-11e6-878f-2b3b1c089694.png">

We will see this:

<img width="559" alt="screen shot 2016-08-11 at 11 30 33" src="https://cloud.githubusercontent.com/assets/416701/17586075/6d5baf7e-5fb7-11e6-9b1f-26efb64e7653.png">

Trello: https://trello.com/c/bTJv2BDq/90-show-error-states-on-forms-in-content-tagger

Part of: https://trello.com/c/7tcrUgcz/66-initial-round-of-improvements-to-error-handling-in-tag-importer