### PR TITLE
Handle errors whilst fetching the Google Spreadsheet

### DIFF
--- a/app/services/tag_importer/fetch_remote_data.rb
+++ b/app/services/tag_importer/fetch_remote_data.rb
@@ -3,33 +3,60 @@ require 'csv'
 module TagImporter
   class FetchRemoteData
     attr_reader :tagging_spreadsheet
+    attr_accessor :errors
 
     def initialize(tagging_spreadsheet)
       @tagging_spreadsheet = tagging_spreadsheet
+      @errors = []
     end
 
     def run
-      errors = []
-      begin
-        parsed_data = CSV.parse(sheet_data, col_sep: "\t", headers: true)
-        parsed_data.each do |row|
-          tagging_spreadsheet.tag_mappings.build(
-            content_base_path:  row["content_base_path"],
-            link_title:         row["link_title"],
-            link_content_id:    row["link_content_id"],
-            link_type:          row["link_type"],
-          ).save
-        end
-      rescue => e
-        errors << e
+      unless valid_response?
+        Airbrake.notify(RuntimeError.new(response.body))
+        return [spreadsheet_download_error]
       end
+
+      process_spreadsheet
       errors
     end
 
   private
 
+    def process_spreadsheet
+      parsed_data.each do |row|
+        save_row(row)
+      end
+    rescue => e
+      errors << e
+    end
+
+    def save_row(row)
+      tagging_spreadsheet.tag_mappings.build(
+        content_base_path:  row["content_base_path"],
+        link_title:         row["link_title"],
+        link_content_id:    row["link_content_id"],
+        link_type:          row["link_type"],
+      ).save
+    end
+
+    def parsed_data
+      CSV.parse(sheet_data, col_sep: "\t", headers: true)
+    end
+
+    def spreadsheet_download_error
+      I18n.t('errors.spreadsheet_download_error')
+    end
+
+    def valid_response?
+      response.code == '200'
+    end
+
+    def response
+      @response ||= Net::HTTP.get_response(URI(tagging_spreadsheet.url))
+    end
+
     def sheet_data
-      @sheet_data ||= Net::HTTP.get URI(tagging_spreadsheet.url)
+      response.body
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,3 +5,4 @@ en:
     invalid_path: Does not have the expected public path /spreadsheets/d/<id>/pub
     missing_gid: Is missing a Google Spreadsheet ID parameter (gid)
     missing_output: Is missing the parameter output as TSV
+    spreadsheet_download_error: There is a problem downloading the spreadsheet, please make sure the URL works.

--- a/spec/features/tag_importer_spec.rb
+++ b/spec/features/tag_importer_spec.rb
@@ -54,7 +54,7 @@ RSpec.feature "Tag importer", type: :feature do
 
   def given_tagging_data_is_present_in_a_google_spreadsheet
     stub_request(:get, google_sheet_url(key: SHEET_KEY, gid: SHEET_GID))
-      .to_return(body: google_sheet_fixture)
+      .to_return(status: 200, body: google_sheet_fixture)
   end
 
   def then_i_see_an_error_summary_instead_of_a_tagging_preview
@@ -64,7 +64,7 @@ RSpec.feature "Tag importer", type: :feature do
 
   def given_no_tagging_data_is_available_at_a_spreadsheet_url
     stub_request(:get, google_sheet_url(key: SHEET_KEY, gid: SHEET_GID))
-      .to_return(status: 404)
+      .to_return(status: 404, body: 'uh-oh')
   end
 
   def when_i_provide_the_public_uri_of_this_spreadsheet
@@ -135,7 +135,7 @@ RSpec.feature "Tag importer", type: :feature do
       link_type: "organisation",
     )
     stub_request(:get, google_sheet_url(key: SHEET_KEY, gid: SHEET_GID))
-      .to_return(body: google_sheet_fixture([extra_row]))
+      .to_return(status: 200, body: google_sheet_fixture([extra_row]))
   end
 
   def and_refetch_the_tags

--- a/spec/services/tag_importer/fetch_remote_data_spec.rb
+++ b/spec/services/tag_importer/fetch_remote_data_spec.rb
@@ -4,24 +4,52 @@ RSpec.describe TagImporter::FetchRemoteData do
   include GoogleSheetHelper
 
   describe "#run" do
-    let(:url) { URI "https://remote-data/path" }
+    let(:url) { URI("https://remote-data/path") }
     let(:tagging_spreadsheet) { TaggingSpreadsheet.new(url: url) }
 
-    before do
-      allow(Net::HTTP).to receive(:get).with(url).and_return(google_sheet_fixture)
+    context 'with a valid response' do
+      before do
+        good_response = double(code: '200', body: google_sheet_fixture)
+        allow(Net::HTTP).to receive(:get_response).with(url).and_return(good_response)
+      end
+
+      it "retrieves data from the tagging spreadsheet URL" do
+        expect(Net::HTTP).to receive(:get_response).with(url)
+
+        TagImporter::FetchRemoteData.new(tagging_spreadsheet).run
+      end
+
+      it "creates tag mappings based on the retrieved data" do
+        TagImporter::FetchRemoteData.new(tagging_spreadsheet).run
+
+        expect(TagMapping.all.map(&:content_base_path)).to eq(%w(/content-1/ /content-1/ /content-1/ /content-2/))
+        expect(TagMapping.all.map(&:link_type)).to eq(%w(taxons taxons organisations taxons))
+      end
     end
 
-    it "retrieves data from the tagging spreadsheet URL" do
-      expect(Net::HTTP).to receive(:get).with(url)
+    context 'with an invalid response' do
+      before do
+        bad_response = double(code: '400', body: "<html>a long page</html>")
+        allow(Net::HTTP).to receive(:get_response).with(url).and_return(bad_response)
+      end
 
-      TagImporter::FetchRemoteData.new(tagging_spreadsheet).run
-    end
+      it 'does not create any taggings' do
+        expect { described_class.new(tagging_spreadsheet).run }.to_not change {
+          tagging_spreadsheet.tag_mappings
+        }
+      end
 
-    it "creates tag mappings based on the retrieved data" do
-      TagImporter::FetchRemoteData.new(tagging_spreadsheet).run
+      it 'returns the error message' do
+        expect(described_class.new(tagging_spreadsheet).run).to include(
+          /there is a problem downloading the spreadsheet/i
+        )
+      end
 
-      expect(TagMapping.all.map(&:content_base_path)).to eq(%w(/content-1/ /content-1/ /content-1/ /content-2/))
-      expect(TagMapping.all.map(&:link_type)).to eq(%w(taxons taxons organisations taxons))
+      it 'notifies airbrake of the error' do
+        expect(Airbrake).to receive(:notify)
+
+        described_class.new(tagging_spreadsheet).run
+      end
     end
   end
 end


### PR DESCRIPTION
Some links stop working (we get a 400 BadRequest from the link). Instead of
showing errors like `#<TypeError: can't dup NilClass>` or `invalid quoting on
line 1`, we should show an error message the user can read and at the same time
show the actual body of the request in Airbrake.

Trello: https://trello.com/c/zDnYubD6/91-validation-of-the-spreadsheet-s-structure-with-more-informative-errors-currently-we-see-errors-like-typeerror-can-t-dup-nilclass