### PR TITLE
Let the JS poll the server even when we didn't start

### DIFF
--- a/app/assets/javascripts/import-progress.js
+++ b/app/assets/javascripts/import-progress.js
@@ -11,11 +11,6 @@
         var currentProgress = element.find('.progress-bar').attr("aria-valuenow");
         var maxProgress = element.find('.progress-bar').attr("aria-valuemax");
 
-        // Don't poll for progress if the counter sits at zero - means you have to
-        // refresh the page a couple of times to see progress but avoids pointless
-        // network requests in cases where an import hasn't begun yet.
-        if (currentProgress == 0) { return; }
-
         if (maxProgress - currentProgress != 0) {
           var progressPath = element.find('.js-import-progress').data('progress-path');
           var updatedProgress = $.get(progressPath).done(


### PR DESCRIPTION
The commit 13f8b0 makes the initial tag importer start asynchronously, meaning
that we wouldn't be querying the server for long anymore.
By removing this we can see the live updates after the first click on Create
Tags.

Trello: https://trello.com/c/7tcrUgcz/66-initial-round-of-improvements-to-error-handling-in-tag-importer