### PR TITLE
Remove `state` column from schema.db

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -26,7 +26,6 @@ ActiveRecord::Schema.define(version: 20160811160752) do
     t.datetime "updated_at",             null: false
     t.datetime "publish_requested_at"
     t.datetime "publish_completed_at"
-    t.string   "state"
   end
 
   add_index "tag_mappings", ["tagging_spreadsheet_id"], name: "index_tag_mappings_on_tagging_spreadsheet_id", using: :btree


### PR DESCRIPTION
`TagMapping` records don't have a state (yet); It looks like this field ended up in the schema.rb even though there isn't a migration associated with it.

I need to create this field in another PR and found the issue there.