### PR TITLE
Allow taxons to be deleted

### DIFF
--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -48,7 +48,21 @@ class TaxonsController < ApplicationController
     redirect_to taxons_path
   end
 
+  def destroy
+    response_code = Services.publishing_api.unpublish(params[:id], type: "gone").code
+
+    redirect_to taxons_path, flash: destroy_flash_message(response_code)
+  end
+
 private
+
+  def destroy_flash_message(response_code)
+    if response_code == 200
+      { success: I18n.t('messages.controller.taxons.success') }
+    else
+      { alert: I18n.t('messages.controller.taxons.alert') }
+    end
+  end
 
   def taxons_for_select
     taxon_fetcher.taxons_for_select

--- a/app/views/taxons/index.html.erb
+++ b/app/views/taxons/index.html.erb
@@ -9,6 +9,7 @@
       <th>Content ID</th>
       <th></th>
       <th></th>
+      <th></th>
     </tr>
 
     <%= render partial: 'shared/table_filter' %>
@@ -21,6 +22,11 @@
         <td><%= taxon['content_id'] %></td>
         <td><%= link_to 'View tagged content', taxon_path(taxon['content_id']), class: 'view-tagged-content' %></td>
         <td><%= link_to 'Edit taxon', edit_taxon_path(taxon['content_id']) %></td>
+        <td><%= link_to 'Delete', taxon_path(taxon['content_id']),
+            method: :delete,
+            data: { confirm: I18n.t('messages.views.confirm') },
+            class: 'btn btn-danger' %>
+        </td>
       </tr>
     <% end %>
   </tbody>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,3 +12,11 @@ en:
     import_refetched: The import will be imported again.
     import_started: The tagging import has started. It can take a few minutes for the tags to be published.
     import_removed: Import has been removed.
+
+  messages:
+    controller:
+      taxons:
+        success: You have sucessfully deleted the taxon
+        alert: It was not possible to delete the taxon
+    views:
+      confirm: Are you sure?

--- a/spec/controllers/taxons_controller_spec.rb
+++ b/spec/controllers/taxons_controller_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe TaxonsController, type: :controller do
+  describe "#index" do
+    it "renders index" do
+      linkables = [
+        { "title" => "foo", "base_path" => "/foo", "content_id" => SecureRandom.uuid },
+        { "title" => "bar", "base_path" => "/bar", "content_id" => SecureRandom.uuid },
+        { "title" => "aha", "base_path" => "/aha", "content_id" => SecureRandom.uuid },
+      ]
+
+      publishing_api_has_linkables(
+        linkables,
+        document_type: "taxon",
+      )
+
+      get :index
+
+      expect(response.code).to eql "200"
+    end
+  end
+
+  describe "#index" do
+    it "renders index" do
+      linkables = [
+        { "title" => "foo", "base_path" => "/foo", "content_id" => SecureRandom.uuid },
+        { "title" => "bar", "base_path" => "/bar", "content_id" => SecureRandom.uuid },
+      ]
+
+      foo_linkable_content_id = linkables.first["content_id"]
+
+      stub_request(:post, "https://publishing-api.test.gov.uk/v2/content/#{foo_linkable_content_id}/unpublish")
+        .with(body: "{\"type\":\"gone\"}")
+        .to_return(status: 200, body: "", headers: {})
+
+      publishing_api_has_linkables(
+        linkables,
+        document_type: "taxon",
+      )
+
+      delete :destroy, id: foo_linkable_content_id
+      expect(WebMock).to have_requested(:post, "https://publishing-api.test.gov.uk/v2/content/#{foo_linkable_content_id}/unpublish")
+    end
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/vBJSZakA/93-allow-taxons-to-be-deleted

Flow:

When the user presses the `Delete` button, and the taxon is a Parent taxon, the children of that taxon no longer have that taxon as parent. Also documents with such taxon no longer will have the taxon tagged to them.

This is all possible by requesting Publishing API to unpublish a given taxon, with the type "gone"

### Look & Feel

<img width="1401" alt="screen shot 2016-08-16 at 15 46 09" src="https://cloud.githubusercontent.com/assets/136777/17703191/c16124d6-63c8-11e6-9d64-da40568bbae5.png">

