### PR TITLE
Fix tests after re-arrangement of redirects for tagging spreadsheets

### DIFF
--- a/spec/features/tag_importer_spec.rb
+++ b/spec/features/tag_importer_spec.rb
@@ -164,14 +164,17 @@ RSpec.feature "Tag importer", type: :feature do
   end
 
   def then_i_can_see_it_is_ready_for_importing
+    visit tagging_spreadsheets_path
     tagging_spreadsheet = TaggingSpreadsheet.first
     state = tagging_spreadsheet.state.humanize
     row = first('table tbody tr')
 
     expect(row).to have_selector('.label-warning', text: state)
+    visit tagging_spreadsheet_path(tagging_spreadsheet)
   end
 
   def then_i_see_the_import_failed
+    visit tagging_spreadsheets_path
     tagging_spreadsheet = TaggingSpreadsheet.first
     state = tagging_spreadsheet.state.humanize
     row = first('table tbody tr')
@@ -181,6 +184,7 @@ RSpec.feature "Tag importer", type: :feature do
     expect(row).to have_selector(
       ".label-danger[data-original-title='#{tagging_spreadsheet.error_message}']"
     )
+    visit tagging_spreadsheet_path(tagging_spreadsheet)
   end
 
   def and_the_state_of_the_import_is_successful


### PR DESCRIPTION
PR #123  changed the redirects of some controller actions in order to improve the user experience. 

Unfortunately, Jenkins didn't run the tests for some reason and I ended up merging the PR too soon.

Some of the tests were broken because they relied on a flow that doesn't exist anymore, so this commit fixes those tests.