### PR TITLE
State and validation for tag mappings

### DIFF
--- a/app/controllers/tagging_spreadsheets_controller.rb
+++ b/app/controllers/tagging_spreadsheets_controller.rb
@@ -4,7 +4,7 @@ class TaggingSpreadsheetsController < ApplicationController
   end
 
   def new
-    @tagging_spreadsheet = TaggingSpreadsheet.new
+    render :new, locals: { tagging_spreadsheet: TaggingSpreadsheet.new }
   end
 
   def create
@@ -17,8 +17,7 @@ class TaggingSpreadsheetsController < ApplicationController
       InitialTaggingImport.perform_async(tagging_spreadsheet.id)
       redirect_to tagging_spreadsheet, success: I18n.t('tag_import.import_created')
     else
-      @tagging_spreadsheet = tagging_spreadsheet
-      render :new
+      render :new, locals: { tagging_spreadsheet: tagging_spreadsheet }
     end
   end
 

--- a/app/controllers/tagging_spreadsheets_controller.rb
+++ b/app/controllers/tagging_spreadsheets_controller.rb
@@ -25,14 +25,14 @@ class TaggingSpreadsheetsController < ApplicationController
     render :show, locals: {
       tagging_spreadsheet: tagging_spreadsheet,
       tag_mappings: presented_tag_mappings,
-      confirmed: tag_mappings.publish_confirmed.count,
+      confirmed: tag_mappings.completed.count,
     }
   end
 
   def import_progress
     render partial: "import_progress_bar", formats: :html, locals: {
       tag_mappings: tag_mappings,
-      confirmed: tag_mappings.publish_confirmed.count
+      confirmed: tag_mappings.completed.count
     }
   end
 

--- a/app/models/links_update.rb
+++ b/app/models/links_update.rb
@@ -1,0 +1,39 @@
+class LinksUpdate
+  include ActiveModel::Model
+  include ActiveModel::Validations
+
+  validates_with ContentIdValidator
+  validates_with LinkTypeValidator
+  validates_with TaxonsValidator
+
+  attr_accessor :base_path, :links, :tag_mappings
+  attr_reader :content_id
+
+  def content_id
+    @content_id ||= Services.publishing_api.lookup_content_id(base_path: base_path)
+  end
+
+  def links_to_update
+    links
+  end
+
+  def link_types
+    links.keys
+  end
+
+  def taxons
+    links.fetch('taxons', [])
+  end
+
+  def mark_as_tagged
+    tag_mappings.update_all(
+      state: 'tagged',
+      publish_completed_at: Time.current
+    )
+  end
+
+  def mark_as_errored
+    message = errors.full_messages.join(' ')
+    tag_mappings.update_all(state: :errored, message: message)
+  end
+end

--- a/app/models/tag_mapping.rb
+++ b/app/models/tag_mapping.rb
@@ -3,6 +3,12 @@ class TagMapping < ActiveRecord::Base
   scope :by_content_base_path, -> { order(content_base_path: :asc) }
   scope :by_link_title, -> { order(link_title: :asc) }
 
+  validates(
+    :state,
+    presence: true,
+    inclusion: { in: %w(ready_to_tag tagged errored) }
+  )
+
   def self.publish_confirmed
     where("publish_requested_at < publish_completed_at")
   end

--- a/app/models/tag_mapping.rb
+++ b/app/models/tag_mapping.rb
@@ -1,5 +1,6 @@
 class TagMapping < ActiveRecord::Base
   belongs_to :tagging_spreadsheet
+  scope :completed, -> { where(state: %w(tagged errored)) }
   scope :by_content_base_path, -> { order(content_base_path: :asc) }
   scope :by_link_title, -> { order(link_title: :asc) }
 
@@ -8,13 +9,4 @@ class TagMapping < ActiveRecord::Base
     presence: true,
     inclusion: { in: %w(ready_to_tag tagged errored) }
   )
-
-  def self.publish_confirmed
-    where("publish_requested_at < publish_completed_at")
-  end
-
-  def publish_confirmed?
-    return false unless publish_requested_at
-    publish_requested_at <= (publish_completed_at || DateTime.new(0))
-  end
 end

--- a/app/models/tag_mapping.rb
+++ b/app/models/tag_mapping.rb
@@ -3,10 +3,6 @@ class TagMapping < ActiveRecord::Base
   scope :by_content_base_path, -> { order(content_base_path: :asc) }
   scope :by_link_title, -> { order(link_title: :asc) }
 
-  def self.update_publish_completed_at(tag_mapping_ids)
-    where(id: Array(tag_mapping_ids)).update_all(publish_completed_at: Time.zone.now)
-  end
-
   def self.publish_confirmed
     where("publish_requested_at < publish_completed_at")
   end

--- a/app/presenters/tag_mapping_presenter.rb
+++ b/app/presenters/tag_mapping_presenter.rb
@@ -1,0 +1,21 @@
+class TagMappingPresenter < SimpleDelegator
+  def label_type
+    {
+      errored: 'label-danger',
+      tagged: 'label-success'
+    }.fetch(state.to_sym, 'label-warning')
+  end
+
+  def state_title
+    state.humanize
+  end
+
+  def data_attributes
+    return {} unless state == 'errored'
+
+    {
+      'toggle': 'tooltip',
+      'original-title': message
+    }
+  end
+end

--- a/app/services/tag_importer/fetch_remote_data.rb
+++ b/app/services/tag_importer/fetch_remote_data.rb
@@ -36,6 +36,7 @@ module TagImporter
         link_title:         row["link_title"],
         link_content_id:    row["link_content_id"],
         link_type:          row["link_type"],
+        state:              'ready_to_tag'
       ).save
     end
 

--- a/app/services/tag_importer/links_publisher.rb
+++ b/app/services/tag_importer/links_publisher.rb
@@ -1,0 +1,80 @@
+module TagImporter
+  class LinksPublisher
+    attr_reader :base_path, :tag_mappings, :links
+    attr_accessor :reason
+
+    def self.publish(base_path:, tag_mappings:, links:)
+      new(
+        base_path: base_path,
+        tag_mappings: tag_mappings,
+        links: links,
+      ).publish
+    end
+
+    def initialize(base_path:, tag_mappings:, links:)
+      @base_path = base_path
+      @tag_mappings = tag_mappings
+      @links = links
+    end
+
+    def publish
+      if valid?
+        tag_mappings.update_all(
+          state: 'tagged',
+          publish_completed_at: Time.current
+        )
+
+        Services.publishing_api.patch_links(target_content_id, links: links)
+        return true
+      else
+        tag_mappings.update_all(state: :errored, message: reason)
+        return false
+      end
+    end
+
+    def valid?
+      tag_mappings.count > 0 &&
+        valid_content_id? &&
+        valid_link_type? &&
+        valid_taxons?
+    end
+
+  private
+
+    def reason
+      return if tag_mappings.empty?
+      return I18n.t('tag_import.errors.invalid_content_id') unless valid_content_id?
+      return I18n.t('tag_import.errors.invalid_link_types') unless valid_link_type?
+      return I18n.t('tag_import.errors.invalid_taxons_found') unless valid_taxons?
+
+      nil
+    end
+
+    def valid_link_type?
+      links.keys == ['taxons']
+    end
+
+    def valid_content_id?
+      !target_content_id.blank?
+    end
+
+    def valid_taxons?
+      return true if taxons.empty?
+
+      (taxons - known_taxon_content_ids).empty?
+    end
+
+    def target_content_id
+      @target_content_id ||=
+        Services.publishing_api.lookup_content_id(base_path: base_path)
+    end
+
+    def known_taxon_content_ids
+      Taxonomy::TaxonFetcher.new.taxon_content_ids
+    end
+
+    def taxons
+      @taxons ||= links.fetch('taxons', [])
+    end
+  end
+end

--- a/app/services/tag_importer/links_publisher.rb
+++ b/app/services/tag_importer/links_publisher.rb
@@ -1,80 +1,25 @@
 module TagImporter
   class LinksPublisher
-    attr_reader :base_path, :tag_mappings, :links
-    attr_accessor :reason
+    attr_reader :links_update
 
-    def self.publish(base_path:, tag_mappings:, links:)
-      new(
-        base_path: base_path,
-        tag_mappings: tag_mappings,
-        links: links,
-      ).publish
+    def self.publish(links_update:)
+      new(links_update: links_update).publish
     end
 
-    def initialize(base_path:, tag_mappings:, links:)
-      @base_path = base_path
-      @tag_mappings = tag_mappings
-      @links = links
+    def initialize(links_update:)
+      @links_update = links_update
     end
 
     def publish
-      if valid?
-        tag_mappings.update_all(
-          state: 'tagged',
-          publish_completed_at: Time.current
+      if links_update.valid?
+        Services.publishing_api.patch_links(
+          links_update.content_id,
+          links: links_update.links_to_update
         )
-
-        Services.publishing_api.patch_links(target_content_id, links: links)
-        return true
+        links_update.mark_as_tagged
       else
-        tag_mappings.update_all(state: :errored, message: reason)
-        return false
+        links_update.mark_as_errored
       end
-    end
-
-    def valid?
-      tag_mappings.count > 0 &&
-        valid_content_id? &&
-        valid_link_type? &&
-        valid_taxons?
-    end
-
-  private
-
-    def reason
-      return if tag_mappings.empty?
-      return I18n.t('tag_import.errors.invalid_content_id') unless valid_content_id?
-      return I18n.t('tag_import.errors.invalid_link_types') unless valid_link_type?
-      return I18n.t('tag_import.errors.invalid_taxons_found') unless valid_taxons?
-
-      nil
-    end
-
-    def valid_link_type?
-      links.keys == ['taxons']
-    end
-
-    def valid_content_id?
-      !target_content_id.blank?
-    end
-
-    def valid_taxons?
-      return true if taxons.empty?
-
-      (taxons - known_taxon_content_ids).empty?
-    end
-
-    def target_content_id
-      @target_content_id ||=
-        Services.publishing_api.lookup_content_id(base_path: base_path)
-    end
-
-    def known_taxon_content_ids
-      Taxonomy::TaxonFetcher.new.taxon_content_ids
-    end
-
-    def taxons
-      @taxons ||= links.fetch('taxons', [])
     end
   end
 end

--- a/app/services/taxonomy/taxon_fetcher.rb
+++ b/app/services/taxonomy/taxon_fetcher.rb
@@ -8,6 +8,10 @@ module Taxonomy
         ).sort_by { |taxon| taxon["title"] }
     end
 
+    def taxon_content_ids
+      taxons.map { |taxon| taxon['content_id'] }
+    end
+
     def taxons_for_select
       taxons.map { |taxon| [taxon['title'], taxon['content_id']] }
     end

--- a/app/validators/content_id_validator.rb
+++ b/app/validators/content_id_validator.rb
@@ -1,0 +1,7 @@
+class ContentIdValidator < ActiveModel::Validator
+  def validate(record)
+    if record.content_id.blank?
+      record.errors[:content_id] << I18n.t('tag_import.errors.invalid_content_id')
+    end
+  end
+end

--- a/app/validators/link_type_validator.rb
+++ b/app/validators/link_type_validator.rb
@@ -1,0 +1,7 @@
+class LinkTypeValidator < ActiveModel::Validator
+  def validate(record)
+    if record.link_types != ['taxons']
+      record.errors[:link_types] << I18n.t('tag_import.errors.invalid_link_types')
+    end
+  end
+end

--- a/app/validators/taxons_validator.rb
+++ b/app/validators/taxons_validator.rb
@@ -1,0 +1,15 @@
+class TaxonsValidator < ActiveModel::Validator
+  def validate(record)
+    return if record.taxons.empty?
+
+    unless (record.taxons - known_taxon_content_ids).empty?
+      record.errors[:taxons] << I18n.t('tag_import.errors.invalid_taxons_found')
+    end
+  end
+
+private
+
+  def known_taxon_content_ids
+    Taxonomy::TaxonFetcher.new.taxon_content_ids
+  end
+end

--- a/app/views/shared/_table_filter.html.erb
+++ b/app/views/shared/_table_filter.html.erb
@@ -1,5 +1,5 @@
 <tr class="table-header if-no-js-hide table-header-secondary">
-  <th colspan='6'>
+  <th colspan='7'>
     <form class='table-filter'>
       <input id="table-filter" type="text" class="form-control normal js-filter-table-input" placeholder="Filter table">
     </form>

--- a/app/views/tagging_spreadsheets/_import_preview.html.erb
+++ b/app/views/tagging_spreadsheets/_import_preview.html.erb
@@ -3,7 +3,8 @@
 
   <div data-module="import-progress">
     <% if tag_mappings.any? %>
-      <%= render partial: "import_progress_bar", locals: { tag_mappings: tag_mappings } %>
+      <%= render partial: "import_progress_bar",
+        locals: { tag_mappings: tag_mappings, confirmed: confirmed } %>
     <% end %>
   </div>
 
@@ -24,11 +25,9 @@
           <td><%= link_to tag.content_base_path, website_url(tag.content_base_path) %></td>
           <td><%= link_to tag.link_title, tagging_path(tag.link_content_id) %> (<%= tag.link_type %>)</td>
           <td class="tag-mapping-status">
-            <% if tag.publish_confirmed? %>
-              <span class="label label-success">Yes</span>
-            <% else %>
-              <span class="label label-default">No</span>
-            <% end %>
+            <%= state_label_for(label_type: tag.label_type,
+                                title: tag.state_title,
+                                data_attributes: tag.data_attributes) %>
           </td>
         </tr>
       <% end %>

--- a/app/views/tagging_spreadsheets/_import_progress_bar.html.erb
+++ b/app/views/tagging_spreadsheets/_import_progress_bar.html.erb
@@ -1,4 +1,3 @@
-<% confirmed = tag_mappings.publish_confirmed.count %>
 <% total = tag_mappings.count %>
 <% percentage_complete = Integer((confirmed / total.to_f) * 100) %>
 <div

--- a/app/views/tagging_spreadsheets/new.html.erb
+++ b/app/views/tagging_spreadsheets/new.html.erb
@@ -1,6 +1,6 @@
 <%= display_header title: 'Upload spreadsheet', breadcrumbs: [:tagging_spreadsheets, "Upload"] %>
 
-<%= simple_form_for @tagging_spreadsheet, url: tagging_spreadsheets_path do |f| %>
+<%= simple_form_for tagging_spreadsheet, url: tagging_spreadsheets_path do |f| %>
   <div class="form-group">
     <%= f.input :url, input_html: { type: :text}, label: "Spreadsheet URL" %>
     <%= f.input :description %>

--- a/app/views/tagging_spreadsheets/show.html.erb
+++ b/app/views/tagging_spreadsheets/show.html.erb
@@ -1,18 +1,19 @@
 <%= display_header title: 'Preview import', breadcrumbs: [:tagging_spreadsheets, "Preview"] do %>
-  <%= link_to "Create tags", tagging_spreadsheet_publish_tags_path(@tagging_spreadsheet), method: :post, class: "btn btn-md btn-default" %>
-  <%= link_to "Refresh import", tagging_spreadsheet_refetch_path(@tagging_spreadsheet), method: :post, class: "btn btn-md btn-default" %>
+  <%= link_to "Create tags", tagging_spreadsheet_publish_tags_path(tagging_spreadsheet), method: :post, class: "btn btn-md btn-default" %>
+  <%= link_to "Refresh import", tagging_spreadsheet_refetch_path(tagging_spreadsheet), method: :post, class: "btn btn-md btn-default" %>
 <% end %>
 
-<% if @tagging_spreadsheet.state == "errored" %>
+<% if tagging_spreadsheet.state == "errored" %>
   <p class="alert alert-danger">
     An error occured when attempting to read the spreadsheet:
 
-    <%= @tagging_spreadsheet.error_message %>
+    <%= tagging_spreadsheet.error_message %>
   </p>
 <% else %>
   <div class='view-on-site'>
-    View: <%= link_to "inspect spreadsheet", @tagging_spreadsheet.url, target: "_blank" %>
+    View: <%= link_to "inspect spreadsheet", tagging_spreadsheet.url, target: "_blank" %>
   </div>
 
-  <%= render partial: "import_preview", locals: { tag_mappings: @tag_mappings } %>
+  <%= render partial: "import_preview",
+    locals: { confirmed: confirmed, tag_mappings: tag_mappings } %>
 <% end %>

--- a/app/workers/publish_links_worker.rb
+++ b/app/workers/publish_links_worker.rb
@@ -4,17 +4,13 @@ class PublishLinksWorker
   sidekiq_options retry: 5
 
   def perform(base_path, links_update)
-    tag_mapping_ids = links_update.fetch("tag_mapping_ids")
-    links_update.delete("tag_mapping_ids")
-
-    # Return if the tag mappings have been deleted.
+    tag_mapping_ids = links_update.delete('tag_mapping_ids')
     tag_mappings = TagMapping.where(id: tag_mapping_ids)
-    return if tag_mappings.count.zero?
 
-    target_content_id = Services.publishing_api.lookup_content_id(base_path: base_path)
-    return if target_content_id.blank?
-
-    Services.publishing_api.patch_links(target_content_id, links: links_update)
-    TagMapping.update_publish_completed_at(tag_mapping_ids)
+    TagImporter::LinksPublisher.publish(
+      base_path: base_path,
+      tag_mappings: tag_mappings,
+      links: links_update
+    )
   end
 end

--- a/app/workers/publish_links_worker.rb
+++ b/app/workers/publish_links_worker.rb
@@ -3,14 +3,17 @@ class PublishLinksWorker
 
   sidekiq_options retry: 5
 
-  def perform(base_path, links_update)
-    tag_mapping_ids = links_update.delete('tag_mapping_ids')
+  def perform(base_path, links)
+    tag_mapping_ids = links.delete('tag_mapping_ids')
     tag_mappings = TagMapping.where(id: tag_mapping_ids)
 
-    TagImporter::LinksPublisher.publish(
+    links_update = LinksUpdate.new(
       base_path: base_path,
       tag_mappings: tag_mappings,
-      links: links_update
-    )
+      links: links)
+
+    return if links_update.tag_mappings.empty?
+
+    TagImporter::LinksPublisher.publish(links_update: links_update)
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,13 +6,15 @@ en:
     missing_gid: Is missing a Google Spreadsheet ID parameter (gid)
     missing_output: Is missing the parameter output as TSV
     spreadsheet_download_error: There is a problem downloading the spreadsheet, please make sure the URL works.
-
   tag_import:
     import_created: Spreadsheet uploaded. It will be imported within a few minutes.
     import_refetched: The import will be imported again.
     import_started: The tagging import has started. It can take a few minutes for the tags to be published.
     import_removed: Import has been removed.
-
+    errors:
+      invalid_content_id: We could not find this URL on GOV.UK.
+      invalid_link_types: Invalid link types found - only taxons are allowed.
+      invalid_taxons_found: Invalid taxons found - please make sure you only use existing taxons when tagging.
   messages:
     controller:
       taxons:
@@ -20,3 +22,4 @@ en:
         alert: It was not possible to delete the taxon
     views:
       confirm: Are you sure?
+

--- a/db/migrate/20160815093345_add_state_and_message_to_tag_mappings.rb
+++ b/db/migrate/20160815093345_add_state_and_message_to_tag_mappings.rb
@@ -1,0 +1,6 @@
+class AddStateAndMessageToTagMappings < ActiveRecord::Migration
+  def change
+    add_column :tag_mappings, :state, :string, null: false
+    add_column :tag_mappings, :message, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160811160752) do
+ActiveRecord::Schema.define(version: 20160815093345) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -26,6 +26,8 @@ ActiveRecord::Schema.define(version: 20160811160752) do
     t.datetime "updated_at",             null: false
     t.datetime "publish_requested_at"
     t.datetime "publish_completed_at"
+    t.string   "state",                  null: false
+    t.string   "message"
   end
 
   add_index "tag_mappings", ["tagging_spreadsheet_id"], name: "index_tag_mappings_on_tagging_spreadsheet_id", using: :btree

--- a/spec/factories/links_update.rb
+++ b/spec/factories/links_update.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :links_update do
+    base_path '/a/base/path'
+    links {}
+    tag_mappings TagMapping.none
+  end
+end

--- a/spec/factories/tag_mapping.rb
+++ b/spec/factories/tag_mapping.rb
@@ -4,5 +4,6 @@ FactoryGirl.define do
     link_content_id 'a-content-id'
     link_type 'taxon'
     tagging_spreadsheet
+    state 'ready_to_tag'
   end
 end

--- a/spec/factories/tag_mapping.rb
+++ b/spec/factories/tag_mapping.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :tag_mapping do
+    content_base_path 'a/base/path'
+    link_content_id 'a-content-id'
+    link_type 'taxon'
+    tagging_spreadsheet
+  end
+end

--- a/spec/features/tag_importer_spec.rb
+++ b/spec/features/tag_importer_spec.rb
@@ -105,7 +105,6 @@ RSpec.feature "Tag importer", type: :feature do
       "content-1-cid",
       links: {
         taxons: ["education-content-id", "education-content-id"],
-        organisations: ["cabinet-office-content-id"],
       }
     )
     link_update_2 = stub_publishing_api_patch_links(

--- a/spec/features/tag_importer_spec.rb
+++ b/spec/features/tag_importer_spec.rb
@@ -132,7 +132,7 @@ RSpec.feature "Tag importer", type: :feature do
       content_base_path: "/content-2/",
       link_title: "GDS",
       link_content_id: "gds-content-id",
-      link_type: "organisation",
+      link_type: "taxons",
     )
     stub_request(:get, google_sheet_url(key: SHEET_KEY, gid: SHEET_GID))
       .to_return(status: 200, body: google_sheet_fixture([extra_row]))

--- a/spec/features/tag_importer_spec.rb
+++ b/spec/features/tag_importer_spec.rb
@@ -80,7 +80,7 @@ RSpec.feature "Tag importer", type: :feature do
 
   def then_i_can_preview_which_taggings_will_be_imported
     expect_page_to_contain_details_of(tag_mappings: TagMapping.all)
-    expect_tag_mapping_statuses_to_be("No")
+    expect_tag_mapping_statuses_to_be("Ready to tag")
   end
 
   def expect_tag_mapping_statuses_to_be(string)
@@ -124,7 +124,7 @@ RSpec.feature "Tag importer", type: :feature do
     click_link "Create tags"
     expect(link_update_1).to have_been_requested
     expect(link_update_2).to have_been_requested
-    expect_tag_mapping_statuses_to_be("Yes")
+    expect_tag_mapping_statuses_to_be("Tagged")
   end
 
   def given_some_imported_tags

--- a/spec/features/tag_importer_spec.rb
+++ b/spec/features/tag_importer_spec.rb
@@ -113,6 +113,13 @@ RSpec.feature "Tag importer", type: :feature do
         taxons: ["early-years-content-id"],
       }
     )
+    publishing_api_has_linkables(
+      [
+        { 'title' => 'Early Years', content_id: 'early-years-content-id' },
+        { 'title' => 'Education', content_id: 'education-content-id' }
+      ],
+      document_type: 'taxon'
+    )
 
     click_link "Create tags"
     expect(link_update_1).to have_been_requested

--- a/spec/models/links_udpate_spec.rb
+++ b/spec/models/links_udpate_spec.rb
@@ -1,0 +1,80 @@
+require 'rails_helper'
+
+RSpec.describe LinksUpdate do
+  let(:links_update) do
+    build(:links_update, links: { 'taxons' => ['a-taxon-content-id'] })
+  end
+
+  describe '#taxons' do
+    it 'returns the list of taxons' do
+      expect(links_update.taxons).to eq(['a-taxon-content-id'])
+    end
+  end
+
+  describe '#link_types' do
+    it 'returns the list of link types' do
+      expect(links_update.link_types).to eq(['taxons'])
+    end
+  end
+
+  describe '#content_id' do
+    it 'finds the content id from the base path' do
+      content_id = "content-1-ID"
+      publishing_api_has_lookups(links_update.base_path => content_id)
+
+      expect(links_update.content_id).to eq(content_id)
+    end
+  end
+
+  describe '#mark_as_tagged' do
+    let(:tag_mapping) { create(:tag_mapping) }
+
+    before do
+      links_update.tag_mappings = TagMapping.all
+    end
+
+    it 'marks a number of tag mappings as tagged' do
+      expectation = lambda do
+        links_update.mark_as_tagged
+        tag_mapping.reload
+      end
+
+      expect { expectation.call }.to change { tag_mapping.state }.to('tagged')
+    end
+
+    it 'adds a publish_completed_at date' do
+      expectation = lambda do
+        links_update.mark_as_tagged
+        tag_mapping.reload
+      end
+
+      expect { expectation.call }.to change { tag_mapping.publish_completed_at }
+    end
+  end
+
+  describe '#mark_as_errored' do
+    let(:tag_mapping) { create(:tag_mapping) }
+
+    before do
+      links_update.tag_mappings = TagMapping.all
+    end
+
+    it 'marks a number of tag mappings as errored' do
+      expectation = lambda do
+        links_update.mark_as_errored
+        tag_mapping.reload
+      end
+
+      expect { expectation.call }.to change { tag_mapping.state }.to('errored')
+    end
+
+    it 'adds an error message' do
+      expectation = lambda do
+        links_update.mark_as_errored
+        tag_mapping.reload
+      end
+
+      expect { expectation.call }.to change { tag_mapping.message }
+    end
+  end
+end

--- a/spec/presenters/tag_mapping_presenter_spec.rb
+++ b/spec/presenters/tag_mapping_presenter_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe TagMappingPresenter do
+  let(:tag_mapping) { TagMapping.new }
+  let(:presenter) { described_class.new(tag_mapping) }
+
+  describe 'label_type' do
+    it 'returns a label css class indicting an error for the errored state' do
+      tag_mapping.state = 'errored'
+
+      expect(presenter.label_type).to eq('label-danger')
+    end
+
+    it 'returns a label css class indicting a success for the taggedstate' do
+      tag_mapping.state = 'tagged'
+
+      expect(presenter.label_type).to eq('label-success')
+    end
+
+    it 'returns a label css class indicting a warning for the ready_to_tagstate' do
+      tag_mapping.state = 'ready_to_tag'
+
+      expect(presenter.label_type).to eq('label-warning')
+    end
+  end
+
+  describe '#state_title' do
+    it 'humanizes the state' do
+      tag_mapping.state = 'errored'
+
+      expect(presenter.state_title).to eq('Errored')
+    end
+  end
+
+  describe '#data_attributes' do
+    it 'returns the tooltip data attributes with the error message for the errored state' do
+      tag_mapping.state = 'errored'
+      tag_mapping.message = 'an error message'
+
+      expect(presenter.data_attributes).to include('toggle': 'tooltip')
+      expect(presenter.data_attributes).to include(
+        'original-title': tag_mapping.message
+      )
+    end
+
+    it 'does not return data attributes for the tagged state' do
+      tag_mapping.state = 'tagged'
+
+      expect(presenter.data_attributes).to be_empty
+    end
+
+    it 'does not return data attributes for the ready_to_tagstate' do
+      tag_mapping.state = 'ready_to_tag'
+
+      expect(presenter.data_attributes).to be_empty
+    end
+  end
+end

--- a/spec/services/tag_importer/fetch_remote_data_spec.rb
+++ b/spec/services/tag_importer/fetch_remote_data_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe TagImporter::FetchRemoteData do
       it "creates tag mappings based on the retrieved data" do
         TagImporter::FetchRemoteData.new(tagging_spreadsheet).run
 
-        expect(TagMapping.all.map(&:content_base_path)).to eq(%w(/content-1/ /content-1/ /content-1/ /content-2/))
-        expect(TagMapping.all.map(&:link_type)).to eq(%w(taxons taxons organisations taxons))
+        expect(TagMapping.all.map(&:content_base_path)).to eq(%w(/content-1/ /content-1/ /content-2/))
+        expect(TagMapping.all.map(&:link_type)).to eq(%w(taxons taxons taxons))
       end
     end
 

--- a/spec/services/tag_importer/links_publisher_spec.rb
+++ b/spec/services/tag_importer/links_publisher_spec.rb
@@ -1,152 +1,34 @@
 require 'rails_helper'
 
 RSpec.describe TagImporter::LinksPublisher do
-  shared_examples 'it does not update anything' do
-    it "doesn't patch the links" do
-      expect(Services.publishing_api).to_not receive(:patch_links)
-    end
-
-    it "returns false" do
-      expect(links_publisher.publish).to be_falsy
-    end
-  end
-
   describe '#publish' do
-    context 'without any tag mapping ids' do
-      let(:links_publisher) do
-        described_class.new(
-          base_path: '/a/base/path',
-          tag_mappings: TagMapping.all,
-          links: {
-            'taxons' => ['taxon1-content-id', 'taxon2-content-id']
-          }
-        )
+    context 'with valid link updates' do
+      let(:links_update) do
+        instance_double(LinksUpdate,
+                        valid?: true,
+                        content_id: 'a-content-id',
+                        links_to_update: ['taxon1-content-id'])
       end
 
-      it_behaves_like 'it does not update anything'
-    end
-
-    context 'with an invalid content id' do
-      let(:tag_mapping) { create(:tag_mapping) }
-      let(:links_publisher) do
-        described_class.new(
-          base_path: '/a/base/path',
-          tag_mappings: TagMapping.where(id: tag_mapping.id),
-          links: {
-            'taxons' => ['taxon1-content-id', 'taxon2-content-id']
-          }
-        )
-      end
-
-      before do
-        publishing_api_has_lookups("/a/base/path" => nil)
-      end
-
-      it_behaves_like 'it does not update anything'
-
-      it 'sets the state and message of the tag mappings' do
-        links_publisher.publish
-        tag_mapping.reload
-
-        expect(tag_mapping.state).to eq('errored')
-        expect(tag_mapping.message).to match(/we could not find the associated content id/i)
-      end
-    end
-
-    context 'with invalid link types' do
-      let(:tag_mapping) { create(:tag_mapping) }
-      let(:links_publisher) do
-        described_class.new(
-          base_path: '/content-1',
-          tag_mappings: TagMapping.where(id: tag_mapping.id),
-          links: {
-            'taxons' => ['taxon1-content-id', 'taxon2-content-id'],
-            'organisations' => ['org1-content-id']
-          }
-        )
-      end
-
-      before do
-        publishing_api_has_lookups("/content-1" => "content-1-ID")
-      end
-
-      it_behaves_like 'it does not update anything'
-
-      it 'sets the state and message of the tag mappings' do
-        links_publisher.publish
-        tag_mapping.reload
-
-        expect(tag_mapping.state).to eq('errored')
-        expect(tag_mapping.message).to match(/invalid link types found/i)
-      end
-    end
-
-    context 'with unknown taxons' do
-      let(:tag_mapping) { create(:tag_mapping) }
-      let(:links_publisher) do
-        described_class.new(
-          base_path: '/content-1',
-          tag_mappings: TagMapping.where(id: tag_mapping.id),
-          links: {
-            'taxons' => ['taxon1-content-id', 'taxon2-content-id'],
-          }
-        )
-      end
-
-      before do
-        publishing_api_has_lookups("/content-1" => "content-1-ID")
-        publishing_api_has_linkables(
-          [{
-            'title' => 'A taxon',
-            'content_id' => 'taxon1-content-id',
-          }],
-          document_type: 'taxon'
-        )
-      end
-
-      it_behaves_like 'it does not update anything'
-
-      it 'sets the state and message of the tag mappings' do
-        links_publisher.publish
-        tag_mapping.reload
-
-        expect(tag_mapping.state).to eq('errored')
-        expect(tag_mapping.message).to match(/invalid taxons found/i)
-      end
-    end
-
-    context 'with valid taxons' do
-      let(:tag_mapping) { create(:tag_mapping) }
-      let(:links_publisher) do
-        described_class.new(
-          base_path: '/content-1',
-          tag_mappings: TagMapping.where(id: tag_mapping.id),
-          links: {
-            'taxons' => ['taxon1-content-id'],
-          }
-        )
-      end
-
-      before do
-        publishing_api_has_lookups("/content-1" => "content-1-ID")
-        publishing_api_has_linkables(
-          [{
-            'title' => 'A taxon',
-            'content_id' => 'taxon1-content-id',
-          }],
-          document_type: 'taxon'
-        )
-      end
-
-      it 'allows us to update the links of the given content id' do
+      it 'updates the links via the publishing API and marks the taggings as tagged' do
         expect(Services.publishing_api).to receive(:patch_links).with(
-          'content-1-ID',
-          links: { 'taxons' => ['taxon1-content-id'] }
+          links_update.content_id,
+          links: links_update.links_to_update
         )
+        expect(links_update).to receive(:mark_as_tagged)
 
-        links_publisher.publish
-        tag_mapping.reload
-        expect(tag_mapping.state).to eq('tagged')
+        described_class.new(links_update: links_update).publish
+      end
+    end
+
+    context 'with invalid link updates' do
+      let(:links_update) { instance_double(LinksUpdate, valid?: false) }
+
+      it 'does not call the publishing API and marks the taggings as errored' do
+        expect(Services.publishing_api).to_not receive(:patch_links)
+        expect(links_update).to receive(:mark_as_errored)
+
+        described_class.new(links_update: links_update).publish
       end
     end
   end

--- a/spec/services/tag_importer/links_publisher_spec.rb
+++ b/spec/services/tag_importer/links_publisher_spec.rb
@@ -1,0 +1,153 @@
+require 'rails_helper'
+
+RSpec.describe TagImporter::LinksPublisher do
+  shared_examples 'it does not update anything' do
+    it "doesn't patch the links" do
+      expect(Services.publishing_api).to_not receive(:patch_links)
+    end
+
+    it "returns false" do
+      expect(links_publisher.publish).to be_falsy
+    end
+  end
+
+  describe '#publish' do
+    context 'without any tag mapping ids' do
+      let(:links_publisher) do
+        described_class.new(
+          base_path: '/a/base/path',
+          tag_mappings: TagMapping.all,
+          links: {
+            'taxons' => ['taxon1-content-id', 'taxon2-content-id']
+          }
+        )
+      end
+
+      it_behaves_like 'it does not update anything'
+    end
+
+    context 'with an invalid content id' do
+      let(:tag_mapping) { create(:tag_mapping) }
+      let(:links_publisher) do
+        described_class.new(
+          base_path: '/a/base/path',
+          tag_mappings: TagMapping.where(id: tag_mapping.id),
+          links: {
+            'taxons' => ['taxon1-content-id', 'taxon2-content-id']
+          }
+        )
+      end
+
+      before do
+        publishing_api_has_lookups("/a/base/path" => nil)
+      end
+
+      it_behaves_like 'it does not update anything'
+
+      it 'sets the state and message of the tag mappings' do
+        links_publisher.publish
+        tag_mapping.reload
+
+        expect(tag_mapping.state).to eq('errored')
+        expect(tag_mapping.message).to match(/we could not find the associated content id/i)
+      end
+    end
+
+    context 'with invalid link types' do
+      let(:tag_mapping) { create(:tag_mapping) }
+      let(:links_publisher) do
+        described_class.new(
+          base_path: '/content-1',
+          tag_mappings: TagMapping.where(id: tag_mapping.id),
+          links: {
+            'taxons' => ['taxon1-content-id', 'taxon2-content-id'],
+            'organisations' => ['org1-content-id']
+          }
+        )
+      end
+
+      before do
+        publishing_api_has_lookups("/content-1" => "content-1-ID")
+      end
+
+      it_behaves_like 'it does not update anything'
+
+      it 'sets the state and message of the tag mappings' do
+        links_publisher.publish
+        tag_mapping.reload
+
+        expect(tag_mapping.state).to eq('errored')
+        expect(tag_mapping.message).to match(/invalid link types found/i)
+      end
+    end
+
+    context 'with unknown taxons' do
+      let(:tag_mapping) { create(:tag_mapping) }
+      let(:links_publisher) do
+        described_class.new(
+          base_path: '/content-1',
+          tag_mappings: TagMapping.where(id: tag_mapping.id),
+          links: {
+            'taxons' => ['taxon1-content-id', 'taxon2-content-id'],
+          }
+        )
+      end
+
+      before do
+        publishing_api_has_lookups("/content-1" => "content-1-ID")
+        publishing_api_has_linkables(
+          [{
+            'title' => 'A taxon',
+            'content_id' => 'taxon1-content-id',
+          }],
+          document_type: 'taxon'
+        )
+      end
+
+      it_behaves_like 'it does not update anything'
+
+      it 'sets the state and message of the tag mappings' do
+        links_publisher.publish
+        tag_mapping.reload
+
+        expect(tag_mapping.state).to eq('errored')
+        expect(tag_mapping.message).to match(/invalid taxons found/i)
+      end
+    end
+
+    context 'with valid taxons' do
+      let(:tag_mapping) { create(:tag_mapping) }
+      let(:links_publisher) do
+        described_class.new(
+          base_path: '/content-1',
+          tag_mappings: TagMapping.where(id: tag_mapping.id),
+          links: {
+            'taxons' => ['taxon1-content-id'],
+          }
+        )
+      end
+
+      before do
+        publishing_api_has_lookups("/content-1" => "content-1-ID")
+        publishing_api_has_linkables(
+          [{
+            'title' => 'A taxon',
+            'content_id' => 'taxon1-content-id',
+          }],
+          document_type: 'taxon'
+        )
+      end
+
+      it 'allows us to update the links of the given content id' do
+        expect(Services.publishing_api).to receive(:patch_links).with(
+          'content-1-ID',
+          links: { 'taxons' => ['taxon1-content-id'] }
+        )
+
+        links_publisher.publish
+        tag_mapping.reload
+        expect(tag_mapping.state).to eq('tagged')
+      end
+    end
+  end
+end

--- a/spec/services/tag_importer/publish_tags_spec.rb
+++ b/spec/services/tag_importer/publish_tags_spec.rb
@@ -5,21 +5,40 @@ RSpec.describe TagImporter::PublishTags do
   let(:user) { double(uid: "user-123") }
 
   before do
-    tagging_spreadsheet.tag_mappings.create(
-      content_base_path: "/content-1", link_title: "GDS",
-      link_content_id: "gds-ID", link_type: "organisations"
+    create(
+      :tag_mapping,
+      tagging_spreadsheet: tagging_spreadsheet,
+      content_base_path: "/content-1",
+      link_title: "GDS",
+      link_content_id: "gds-ID",
+      link_type: "organisations"
     )
-    tagging_spreadsheet.tag_mappings.create(
-      content_base_path: "/content-1", link_title: "GDS",
-      link_content_id: "gds-ID", link_type: "organisations"
+
+    create(
+      :tag_mapping,
+      tagging_spreadsheet: tagging_spreadsheet,
+      content_base_path: "/content-1",
+      link_title: "GDS",
+      link_content_id: "gds-ID",
+      link_type: "organisations"
     )
-    tagging_spreadsheet.tag_mappings.create(
-      content_base_path: "/content-1", link_title: "Education",
-      link_content_id: "education-ID", link_type: "taxons"
+
+    create(
+      :tag_mapping,
+      tagging_spreadsheet: tagging_spreadsheet,
+      content_base_path: "/content-1",
+      link_title: "Education",
+      link_content_id: "education-ID",
+      link_type: "taxons"
     )
-    tagging_spreadsheet.tag_mappings.create(
-      content_base_path: "/content-2", link_title: "Education",
-      link_content_id: "education-ID", link_type: "taxons"
+
+    create(
+      :tag_mapping,
+      tagging_spreadsheet: tagging_spreadsheet,
+      content_base_path: "/content-2",
+      link_title: "Education",
+      link_content_id: "education-ID",
+      link_type: "taxons"
     )
   end
 

--- a/spec/services/taxonomy/taxon_fetcher_spec.rb
+++ b/spec/services/taxonomy/taxon_fetcher_spec.rb
@@ -21,6 +21,23 @@ RSpec.describe Taxonomy::TaxonFetcher do
     end
   end
 
+  describe '#taxon_content_ids' do
+    it 'returns the content ids of all taxons' do
+      content_id_1 = SecureRandom.uuid
+      content_id_2 = SecureRandom.uuid
+      linkables = [
+        { "title" => "foo", "base_path" => "/foo", "content_id" => content_id_1 },
+        { "title" => "bar", "base_path" => "/bar", "content_id" => content_id_2 },
+      ]
+      publishing_api_has_linkables(linkables, document_type: 'taxon')
+
+      result = described_class.new.taxon_content_ids
+
+      expect(result).to include(content_id_1)
+      expect(result).to include(content_id_2)
+    end
+  end
+
   describe '#parents_for_taxon' do
     let(:taxon_id_1) { SecureRandom.uuid }
     let(:taxon_id_2) { SecureRandom.uuid }

--- a/spec/support/google_sheet_helper.rb
+++ b/spec/support/google_sheet_helper.rb
@@ -8,7 +8,6 @@ module GoogleSheetHelper
       google_sheet_row(content_base_path: "content_base_path", link_title: "link_title", link_content_id: "link_content_id", link_type: "link_type"),
       google_sheet_row(content_base_path: "/content-1/", link_title: "Education", link_content_id: "education-content-id", link_type: "taxons"),
       google_sheet_row(content_base_path: "/content-1/", link_title: "Education", link_content_id: "education-content-id", link_type: "taxons"),
-      google_sheet_row(content_base_path: "/content-1/", link_title: "Cabinet Office", link_content_id: "cabinet-office-content-id", link_type: "organisations"),
       google_sheet_row(content_base_path: "/content-2/", link_title: "Early Years", link_content_id: "early-years-content-id", link_type: "taxons"),
     ].concat(extra_rows).join("\n")
   end

--- a/spec/validators/content_id_validator_spec.rb
+++ b/spec/validators/content_id_validator_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe ContentIdValidator do
+  it 'validates a missing content id' do
+    record = double(content_id: nil, errors: { content_id: [] })
+    described_class.new.validate(record)
+
+    expect(record.errors[:content_id]).to include(/we could not find this url/i)
+  end
+
+  it 'does not add validation errors when content id exists' do
+    record = double(content_id: 'a-content-ID', errors: {})
+    described_class.new.validate(record)
+
+    expect(record.errors).to be_empty
+  end
+end

--- a/spec/validators/link_type_validator_spec.rb
+++ b/spec/validators/link_type_validator_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe LinkTypeValidator do
+  it 'validates incorrect link types' do
+    record = double(link_types: ['organisations'], errors: { link_types: [] })
+    described_class.new.validate(record)
+
+    expect(record.errors[:link_types]).to include(/invalid link types found/i)
+  end
+
+  it 'does not add validation errors when we have expected link types' do
+    record = double(link_types: ['taxons'], errors: {})
+    described_class.new.validate(record)
+
+    expect(record.errors).to be_empty
+  end
+end

--- a/spec/validators/taxons_validator_spec.rb
+++ b/spec/validators/taxons_validator_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe TaxonsValidator do
+  before do
+    publishing_api_has_linkables(
+      [{
+        'title' => 'A taxon',
+        'content_id' => 'taxon1-content-id',
+      }],
+      document_type: 'taxon'
+    )
+  end
+
+  it 'validates unknown taxons' do
+    record = double(taxons: ['an-unknown-taxon'], errors: { taxons: [] })
+    described_class.new.validate(record)
+
+    expect(record.errors[:taxons]).to include(/invalid taxons found/i)
+  end
+
+  it 'does not add validation errors when we have correct taxons' do
+    record = double(taxons: ['taxon1-content-id'], errors: {})
+    described_class.new.validate(record)
+
+    expect(record.errors).to be_empty
+  end
+end

--- a/spec/workers/publish_links_worker_spec.rb
+++ b/spec/workers/publish_links_worker_spec.rb
@@ -1,20 +1,25 @@
 require "rails_helper"
 
 RSpec.describe PublishLinksWorker do
-  let(:tag_mapping) { create(:tag_mapping) }
-
   describe "#perform" do
-    it 'delegates the work to the links publisher service' do
-      expect(TagImporter::LinksPublisher).to receive(:publish).with(
-        base_path: '/a/base/path',
-        tag_mappings: [tag_mapping],
-        links: { 'taxons' => ['taxon1-content-id', 'taxon2-content-id'] }
+    it 'does not call the links publisher when no taggings are available' do
+      expect(TagImporter::LinksPublisher).to_not receive(:publish)
+
+      described_class.new.perform(
+        '/a/base/path',
+        'tag_mapping_ids' => [],
+        'taxons' => ['taxon1-content-id'],
       )
+    end
+
+    it 'it calls the links publisher service when there are tag mappings' do
+      tag_mapping = create(:tag_mapping)
+      expect(TagImporter::LinksPublisher).to receive(:publish)
 
       described_class.new.perform(
         '/a/base/path',
         'tag_mapping_ids' => [tag_mapping.id],
-        'taxons' => ['taxon1-content-id', 'taxon2-content-id'],
+        'taxons' => ['taxon1-content-id'],
       )
     end
   end


### PR DESCRIPTION
This PR adds `state` and `message` fields into TagMapping objects.

It then validates TagMappings before submitting the links to the Publishing API. The validations are:
- making sure the `content_id` is valid;
- making sure we only submit `taxon` link types for now;
- making sure the taxons already exist in our system.

Finally, it shows the TagMapping states in the import preview screen like this:

<img width="1367" alt="screen shot 2016-08-15 at 23 15 54" src="https://cloud.githubusercontent.com/assets/416701/17693617/b0b4eb8a-6397-11e6-9145-7d4487b25248.png">

Trello: https://trello.com/c/wXQYsPTC/98-adding-state-validations-for-individual-tag-mappings