### PR TITLE
Delete old TagMapping values

### DIFF
--- a/db/migrate/20160815093345_add_state_and_message_to_tag_mappings.rb
+++ b/db/migrate/20160815093345_add_state_and_message_to_tag_mappings.rb
@@ -1,5 +1,6 @@
 class AddStateAndMessageToTagMappings < ActiveRecord::Migration
   def change
+    TagMapping.delete_all
     add_column :tag_mappings, :state, :string, null: false
     add_column :tag_mappings, :message, :string
   end


### PR DESCRIPTION
The existing records don't have a state. Therefore the migration fail with
errors. More info here:
https://deploy.integration.publishing.service.gov.uk/job/Deploy_App/5847/console

```
*** [err :: backend-1.backend.integration.publishing.service.gov.uk] ActiveRecord::StatementInvalid: PG::NotNullViolation: ERROR:  column "state" contains null values
*** [err :: backend-1.backend.integration.publishing.service.gov.uk] : ALTER TABLE "tag_mappings" ADD "state" character varying NOT NULL
```