### PR TITLE
Add format information of tagged documents

### DIFF
--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -84,7 +84,7 @@ private
     Services.publishing_api.get_linked_items(
       taxon.content_id,
       link_type: "taxons",
-      fields: %w(title content_id base_path)
+      fields: %w(title content_id base_path document_type)
     )
   end
 end

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -27,6 +27,7 @@
     <tr class="table-header">
       <th>Title</th>
       <th>URL</th>
+      <th>Format</th>
       <th>Actions</th>
     </tr>
 
@@ -38,6 +39,7 @@
       <tr>
         <td><%= content_item["title"] %></td>
         <td><%= link_to content_item["base_path"], website_url(content_item["base_path"]) %></td>
+        <td><%= content_item["document_type"] %></td>
         <td><%= link_to 'Update tags', tagging_url(content_item["content_id"]) %></td>
       </tr>
     <% end %>

--- a/spec/controllers/taxons_controller_spec.rb
+++ b/spec/controllers/taxons_controller_spec.rb
@@ -20,8 +20,8 @@ RSpec.describe TaxonsController, type: :controller do
     end
   end
 
-  describe "#index" do
-    it "renders index" do
+  describe "#destroy" do
+    it "sends a request to Publishing API to mark the taxon as 'gone'" do
       linkables = [
         { "title" => "foo", "base_path" => "/foo", "content_id" => SecureRandom.uuid },
         { "title" => "bar", "base_path" => "/bar", "content_id" => SecureRandom.uuid },

--- a/spec/features/taxonomy_manager_spec.rb
+++ b/spec/features/taxonomy_manager_spec.rb
@@ -109,7 +109,7 @@ RSpec.feature "Managing taxonomies" do
   end
 
   def and_theres_content_tagged_to_the_taxons
-    stub_request(:get, "https://publishing-api.test.gov.uk/v2/linked/ID-1?fields%5B%5D=base_path&fields%5B%5D=content_id&fields%5B%5D=title&link_type=taxons")
+    stub_request(:get, "https://publishing-api.test.gov.uk/v2/linked/ID-1?fields%5B%5D=base_path&fields%5B%5D=content_id&fields%5B%5D=document_type&fields%5B%5D=title&link_type=taxons")
       .to_return(body: [{ content_id: 'ID', title: 'Tagged Item', base_path: '/my/item' }].to_json)
   end
 


### PR DESCRIPTION
Trello: https://trello.com/c/K6w1Mydr/97-add-format-of-item-in-tagged-content

## Look & Feel

<img width="1498" alt="screen shot 2016-08-17 at 11 47 27" src="https://cloud.githubusercontent.com/assets/136777/17733861/b30ea81a-6470-11e6-904b-100da268267e.png">
