### PR TITLE
Remove URL column and use link on title

### DIFF
--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -26,7 +26,6 @@
   <thead>
     <tr class="table-header">
       <th>Title</th>
-      <th>URL</th>
       <th>Format</th>
       <th>Actions</th>
     </tr>
@@ -37,8 +36,7 @@
   <tbody>
     <% tagged.each do |content_item| %>
       <tr>
-        <td><%= content_item["title"] %></td>
-        <td><%= link_to content_item["base_path"], website_url(content_item["base_path"]) %></td>
+        <td><%= link_to content_item["title"], website_url(content_item["base_path"]) %></td>
         <td><%= content_item["document_type"] %></td>
         <td><%= link_to 'Update tags', tagging_url(content_item["content_id"]) %></td>
       </tr>


### PR DESCRIPTION
Trello: https://trello.com/c/XWhRJclr/79-content-tagger-remove-url-column-and-make-the-title-a-link-on-the-tagged-pages-in-the-taxon-show-page

## Look & Feel

<img width="748" alt="screen shot 2016-08-17 at 14 05 04" src="https://cloud.githubusercontent.com/assets/136777/17737215/e87ff9e6-6483-11e6-8be7-bd9e5370c90a.png">
