### PR TITLE
Add link to content store in taxons list

### DIFF
--- a/app/views/taxons/index.html.erb
+++ b/app/views/taxons/index.html.erb
@@ -19,7 +19,7 @@
     <% taxons.each do |taxon| %>
       <tr>
         <td><%= taxon['title'] %></td>
-        <td><%= taxon['content_id'] %></td>
+        <td><%= link_to taxon['content_id'], "#{website_url('/api/content' + taxon['base_path'])}" %></td>
         <td><%= link_to 'View tagged content', taxon_path(taxon['content_id']), class: 'view-tagged-content' %></td>
         <td><%= link_to 'Edit taxon', edit_taxon_path(taxon['content_id']) %></td>
         <td><%= link_to 'Delete', taxon_path(taxon['content_id']),


### PR DESCRIPTION
It's convenient to see the content store representation for these
taxons. The content ID values aren't currently linked to anything so
let's have them point to the content store until a better alternative
emerges.