### PR TITLE
Show help panel on how to create a Google Spreadsheet public URL

### DIFF
--- a/app/views/tagging_spreadsheets/_help.html.erb
+++ b/app/views/tagging_spreadsheets/_help.html.erb
@@ -1,0 +1,22 @@
+<div class="panel panel-default">
+  <div class="panel-heading">
+    <div class="panel-title">
+      <i class="glyphicon glyphicon-info-sign"></i>
+      <%= I18n.t('panels.tagging_spreadsheets.title') %>
+    </div>
+  </div>
+  <div class="panel-body">
+    <p><%= I18n.t('panels.tagging_spreadsheets.subheading') %></p>
+    <ul>
+      <li><%= I18n.t('panels.tagging_spreadsheets.step_1') %></li>
+      <li><%= I18n.t('panels.tagging_spreadsheets.step_2') %></li>
+      <li><%= I18n.t('panels.tagging_spreadsheets.step_3') %></li>
+      <li><%= I18n.t('panels.tagging_spreadsheets.step_4') %></li>
+    </ul>
+    <p class='explain'>
+      See the <%= link_to "example spreadsheet",
+        "https://docs.google.com/spreadsheets/d/1Qjs6oGL3MC-kuwBJSeDdM9dDqImtM-xTSxkSrGk3TlA/pub?gid=0&single=true&output=tsv" %>
+        for the correct format.
+    </p>
+  </div>
+</div>

--- a/app/views/tagging_spreadsheets/new.html.erb
+++ b/app/views/tagging_spreadsheets/new.html.erb
@@ -1,16 +1,17 @@
 <%= display_header title: 'Upload spreadsheet', breadcrumbs: [:tagging_spreadsheets, "Upload"] %>
 
-<%= simple_form_for tagging_spreadsheet, url: tagging_spreadsheets_path do |f| %>
-  <div class="form-group">
-    <%= f.input :url, input_html: { type: :text}, label: "Spreadsheet URL" %>
-    <%= f.input :description %>
+<div class="row">
+  <div class="col-md-8">
+    <%= simple_form_for tagging_spreadsheet, url: tagging_spreadsheets_path do |f| %>
+      <div class="form-group">
+        <%= f.input :url, input_html: { type: :text}, label: "Spreadsheet URL" %>
+        <%= f.input :description %>
 
-    <p class='explain'>
-      See the <%= link_to "example spreadsheet",
-        "https://docs.google.com/spreadsheets/d/1Qjs6oGL3MC-kuwBJSeDdM9dDqImtM-xTSxkSrGk3TlA/pub?gid=0&single=true&output=tsv" %>
-        for the correct format.
-    </p>
-
-    <%= f.submit "Upload", class: "btn btn-lg btn-primary" %>
+        <%= f.submit "Upload", class: "btn btn-lg btn-primary" %>
+      </div>
+    <% end %>
   </div>
-<% end %>
+  <div class="col-md-4">
+    <%= render 'tagging_spreadsheets/help' %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,4 +22,11 @@ en:
         alert: It was not possible to delete the taxon
     views:
       confirm: Are you sure?
-
+  panels:
+    tagging_spreadsheets:
+      title: How to generate a Google Spreadsheet URL
+      subheading: 'In order to create a publicly available Google Spreadsheet URL, follow these instructions:'
+      step_1: Find your spreadsheet in Google Drive;
+      step_2: Click in the File menu and select the Publish to the web option;
+      step_3: In the Link tab, select the the sheet you want to make public in the first dropdown and tab-separated values in the second dropdown;
+      step_4: Finalise by clicking Publish and copying the link.

--- a/spec/features/tag_importer_spec.rb
+++ b/spec/features/tag_importer_spec.rb
@@ -72,6 +72,7 @@ RSpec.feature "Tag importer", type: :feature do
     visit root_path
     click_link "Tag Importer"
     click_link "Upload spreadsheet"
+    expect(page).to have_text(/how to generate a google spreadsheet url/i)
     fill_in "Spreadsheet URL", with: google_sheet_url(key: SHEET_KEY, gid: SHEET_GID)
     click_button "Upload"
     expect(TaggingSpreadsheet.count).to eq 1


### PR DESCRIPTION
We should show instructions on how to generate a publicly avaliable Google
Spreadsheet URL so users know how to use the form.


Trello: https://trello.com/c/pUwdVThc/113-add-google-drive-publish-to-web-steps-in-the-tag-importer-ui-s

Are there any other examples of how we show information panels in admin apps? I did it like this, but I'm not sure if there is a standard way.

It now looks like this:

<img width="1419" alt="screen shot 2016-08-24 at 14 01 11" src="https://cloud.githubusercontent.com/assets/416701/17931413/43599c8a-6a03-11e6-88d9-98e4d9ec438c.png">
