### PR TITLE
Add visual differences to new and edit taxon pages

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -70,3 +70,7 @@ table {
     @extend .btn-default;
   }
 }
+
+.callout {
+  overflow: auto;
+}

--- a/app/helpers/header_helper.rb
+++ b/app/helpers/header_helper.rb
@@ -1,7 +1,7 @@
 module HeaderHelper
   # Generates a header with `title` and `breadcrumbs`. Last item in the
   # breadcrumbs array should be a string for the "active" entry.
-  def display_header(title:, breadcrumbs:, page_title: nil)
+  def display_header(title:, breadcrumbs:, page_title: nil, page_type: nil)
     breadcrumbs = breadcrumbs.compact
     active_item = breadcrumbs.pop
 
@@ -9,7 +9,8 @@ module HeaderHelper
       title: title,
       breadcrumbs: breadcrumbs,
       page_title: page_title || title,
-      active_item: active_item.try(:title) || active_item
+      active_item: active_item.try(:title) || active_item,
+      callout_presenter: CalloutPresenter.new(title: title, page_type: page_type)
     }
 
     render layout: 'shared/header', locals: locals do

--- a/app/presenters/callout_presenter.rb
+++ b/app/presenters/callout_presenter.rb
@@ -1,0 +1,27 @@
+class CalloutPresenter
+  attr_reader :title, :page_type, :callout_class, :callout_title
+
+  def initialize(title:, page_type:nil)
+    @title = title
+    @page_type = page_type
+
+    configure_callout
+  end
+
+  def should_render?
+    page_type.present?
+  end
+
+private
+
+  def configure_callout
+    case page_type
+    when :new
+      @callout_class = 'callout-info'
+      @callout_title = I18n.t('views.callout_new')
+    when :edit
+      @callout_class = 'callout-warning'
+      @callout_title = I18n.t('views.callout_edit')
+    end
+  end
+end

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -9,7 +9,11 @@
     <li class="active"><%= active_item %></li>
   </ol>
 
-  <h1><%= raw title %></h1>
+  <% if callout_presenter.should_render? %>
+    <%= render 'shared/title', callout_presenter: callout_presenter %>
+  <% else %>
+    <h1><%= raw title %></h1>
+  <% end %>
 
   <% if block_given? %>
     <nav class="actions">

--- a/app/views/shared/_title.html.erb
+++ b/app/views/shared/_title.html.erb
@@ -1,0 +1,8 @@
+<div class="callout <%= callout_presenter.callout_class %>">
+  <div class="callout-title">
+    <%= callout_presenter.callout_title %>
+  </div>
+  <div class="callout-body">
+    <h1><%= raw callout_presenter.title %></h1>
+  </div>
+</div>

--- a/app/views/taxons/edit.html.erb
+++ b/app/views/taxons/edit.html.erb
@@ -1,4 +1,4 @@
-<%= display_header title: taxon.title, breadcrumbs: [:taxons, taxon] %>
+<%= display_header title: taxon.title, breadcrumbs: [:taxons, taxon], page_type: :edit %>
 
 <%= simple_form_for taxon, url: taxon_path(taxon.content_id), method: :patch do |f| %>
   <%= f.hidden_field :content_id, value: taxon.content_id %>
@@ -9,5 +9,5 @@
   <%= f.input :parent_taxons, collection: taxons_for_select,
       input_html: { class: :select2, multiple: true, include_blank: true } %>
 
-  <%= f.submit "Save", class: "btn btn-lg btn-success" %>
+  <%= f.submit I18n.t('views.taxons.edit_button'), class: "btn btn-lg btn-success" %>
 <% end %>

--- a/app/views/taxons/new.html.erb
+++ b/app/views/taxons/new.html.erb
@@ -1,4 +1,5 @@
-<%= display_header title: "Taxons", breadcrumbs: [:taxons, "New taxon"] %>
+<%= display_header title: I18n.t('views.taxons.new_title'),
+  breadcrumbs: [:taxons, I18n.t('views.taxons.new_breadcrumb')], page_type: :new %>
 
 <%= simple_form_for taxon, url: taxons_path do |f| %>
   <% if flash[:error].present? %>
@@ -11,5 +12,5 @@
   <%= f.input :parent_taxons, collection: taxons_for_select,
       input_html: { class: :select2, multiple: true, include_blank: true } %>
 
-  <%= f.submit "Save", class: "btn btn-lg btn-success" %>
+  <%= f.submit I18n.t('views.taxons.new_button'), class: "btn btn-lg btn-success" %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -15,6 +15,14 @@ en:
       invalid_content_id: We could not find this URL on GOV.UK.
       invalid_link_types: Invalid link types found - only taxons are allowed.
       invalid_taxons_found: Invalid taxons found - please make sure you only use existing taxons when tagging.
+  views:
+    callout_new: Creating
+    callout_edit: Editing
+    taxons:
+      new_title: New taxon
+      new_breadcrumb: New taxon
+      new_button: Create taxon
+      edit_button: Update taxon
   messages:
     controller:
       taxons:

--- a/spec/features/taxonomy_manager_spec.rb
+++ b/spec/features/taxonomy_manager_spec.rb
@@ -35,7 +35,7 @@ RSpec.feature "Managing taxonomies" do
     given_there_are_taxons
     when_i_visit_the_taxonomy_page
     and_i_click_on_the_edit_taxon_link
-    when_i_submit_the_taxon_with_a_title_and_parents
+    when_i_update_the_taxons_title_and_parents
     then_my_taxon_is_updated
   end
 
@@ -49,6 +49,7 @@ RSpec.feature "Managing taxonomies" do
 
   def and_i_click_on_the_edit_taxon_link
     first('a', text: 'Edit taxon').click
+    expect(page).to have_selector('.callout-warning', text: /editing/i)
   end
 
   def given_there_are_taxons
@@ -71,9 +72,10 @@ RSpec.feature "Managing taxonomies" do
 
   def and_i_click_on_the_new_taxon_button
     click_on "Add a taxon"
+    expect(page).to have_selector('.callout-info', text: /creating/i)
   end
 
-  def when_i_submit_the_taxon_with_a_title_and_parents
+  def fill_in_taxon_form
     fill_in :taxon_title, with: "My Lovely Taxon"
 
     select @taxon_1[:title]
@@ -81,8 +83,16 @@ RSpec.feature "Managing taxonomies" do
 
     select @taxon_2[:title]
     expect(find('select').value).to include(@taxon_2[:content_id])
+  end
 
-    click_on "Save"
+  def when_i_update_the_taxons_title_and_parents
+    fill_in_taxon_form
+    click_on "Update taxon"
+  end
+
+  def when_i_submit_the_taxon_with_a_title_and_parents
+    fill_in_taxon_form
+    click_on "Create taxon"
   end
 
   def when_i_submit_the_taxon_with_a_taxon_with_semantic_issues
@@ -91,7 +101,7 @@ RSpec.feature "Managing taxonomies" do
     stub_request(:put, %r{https://publishing-api.test.gov.uk/v2/content*})
       .to_return(status: 422, body: {}.to_json)
 
-    click_on "Save"
+    click_on "Create taxon"
   end
 
   def then_i_can_see_an_error_message

--- a/spec/presenters/callout_presenter_spec.rb
+++ b/spec/presenters/callout_presenter_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.describe CalloutPresenter do
+  context 'with an :edit page type' do
+    let(:callout_presenter) do
+      described_class.new(title: 'A title', page_type: :edit)
+    end
+
+    it 'should render' do
+      expect(callout_presenter.should_render?).to be_truthy
+    end
+
+    it 'has a callout class set' do
+      expect(callout_presenter.callout_class).to eq('callout-warning')
+    end
+
+    it 'has a callout title set' do
+      expect(callout_presenter.callout_title).to match(/editing/i)
+    end
+  end
+
+  context 'with a :new page type' do
+    let(:callout_presenter) do
+      described_class.new(title: 'A title', page_type: :new)
+    end
+
+    it 'should render' do
+      expect(callout_presenter.should_render?).to be_truthy
+    end
+
+    it 'has a callout class set' do
+      expect(callout_presenter.callout_class).to eq('callout-info')
+    end
+
+    it 'has a callout title set' do
+      expect(callout_presenter.callout_title).to match(/creating/i)
+    end
+  end
+
+  context 'without a page type' do
+    let(:callout_presenter) do
+      described_class.new(title: 'A title')
+    end
+
+    it 'should not render' do
+      expect(callout_presenter.should_render?).to be_falsy
+    end
+
+    it 'does not have a callout class set' do
+      expect(callout_presenter.callout_class).to be_nil
+    end
+
+    it 'does not have a callout title set' do
+      expect(callout_presenter.callout_title).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
It is not clear if we are creating or editing a taxon from a user perspective.
This commit makes sure we have callout divs on the page with color and text
indications, making sure we differentiate between the 2 pages.

Trello: https://trello.com/c/CMul4Ru3/112-improve-how-we-differentiate-between-the-new-taxon-and-edit-taxon-forms-s

The new page looks like this:

<img width="1422" alt="screen shot 2016-08-31 at 10 26 34" src="https://cloud.githubusercontent.com/assets/416701/18123414/993c4474-6f65-11e6-93bb-3bc746fa2eca.png">

The edit page looks like this:

<img width="1418" alt="screen shot 2016-08-31 at 10 26 44" src="https://cloud.githubusercontent.com/assets/416701/18123625/a72d1012-6f66-11e6-86f5-11a14e83e69c.png">
