### PR TITLE
Change submit buttons to have class "success"

### DIFF
--- a/app/views/tagging_spreadsheets/new.html.erb
+++ b/app/views/tagging_spreadsheets/new.html.erb
@@ -7,7 +7,7 @@
         <%= f.input :url, input_html: { type: :text}, label: "Spreadsheet URL" %>
         <%= f.input :description %>
 
-        <%= f.submit "Upload", class: "btn btn-lg btn-primary" %>
+        <%= f.submit "Upload", class: "btn btn-lg btn-success" %>
       </div>
     <% end %>
   </div>

--- a/app/views/taggings/_tagging_form.html.erb
+++ b/app/views/taggings/_tagging_form.html.erb
@@ -10,5 +10,5 @@
 
   <hr/>
 
-  <%= f.submit "Update tags", class: "btn btn-lg btn-primary" %>
+  <%= f.submit "Update tags", class: "btn btn-lg btn-success" %>
 <% end %>

--- a/app/views/taggings/lookup.html.erb
+++ b/app/views/taggings/lookup.html.erb
@@ -9,5 +9,5 @@
     <% end %>
   </div>
 
-  <input type='submit' value='Show content item' class='btn btn-primary btn-md' />
+  <input type='submit' value='Show content item' class='btn btn-success btn-md' />
 <% end %>

--- a/app/views/taxons/edit.html.erb
+++ b/app/views/taxons/edit.html.erb
@@ -9,5 +9,5 @@
   <%= f.input :parent_taxons, collection: taxons_for_select,
       input_html: { class: :select2, multiple: true, include_blank: true } %>
 
-  <%= f.submit "Save", class: "btn btn-lg btn-primary" %>
+  <%= f.submit "Save", class: "btn btn-lg btn-success" %>
 <% end %>

--- a/app/views/taxons/new.html.erb
+++ b/app/views/taxons/new.html.erb
@@ -11,5 +11,5 @@
   <%= f.input :parent_taxons, collection: taxons_for_select,
       input_html: { class: :select2, multiple: true, include_blank: true } %>
 
-  <%= f.submit "Save", class: "btn btn-lg btn-primary" %>
+  <%= f.submit "Save", class: "btn btn-lg btn-success" %>
 <% end %>


### PR DESCRIPTION
According to the style guide:
When submitting a form that will create or update items use btn-success.

For everything else:
Buttons should always be the default grey unless there is a good reason
otherwise. Buttons that initiate a user action (ie lead to a form, pop-up a
modal) should be grey.

This commit makes sure that all submit buttons have the correct CSS class.

An example page looks like this:

<img width="1283" alt="screen shot 2016-08-25 at 11 11 45" src="https://cloud.githubusercontent.com/assets/416701/17965485/c6f535a2-6ab4-11e6-8589-52dd1db1fadc.png">

(Now green instead of blue)