### PR TITLE
Allow taxon export

### DIFF
--- a/app/controllers/export_taxons_controller.rb
+++ b/app/controllers/export_taxons_controller.rb
@@ -1,0 +1,17 @@
+class ExportTaxonsController < ApplicationController
+  def create
+    respond_to do |format|
+      format.csv { send_data exporter.data, filename: exporter.filename }
+    end
+  end
+
+private
+
+  def exporter
+    @exporter ||= Taxonomy::Exporter.new(content_ids)
+  end
+
+  def content_ids
+    params[:content_ids]
+  end
+end

--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -1,5 +1,11 @@
 class Taxon
-  attr_accessor :title, :parent_taxons, :content_id, :base_path
+  attr_accessor :title,
+                :parent_taxons,
+                :content_id,
+                :base_path,
+                :publication_state,
+                :internal_name
+
   include ActiveModel::Model
 
   validates_presence_of :title
@@ -14,5 +20,9 @@ class Taxon
 
   def base_path
     @base_path ||= '/alpha-taxonomy/' + SecureRandom.uuid + '-' + title.parameterize
+  end
+
+  def link_type
+    'taxons'
   end
 end

--- a/app/services/taxonomy/exporter.rb
+++ b/app/services/taxonomy/exporter.rb
@@ -1,0 +1,44 @@
+require 'csv'
+
+module Taxonomy
+  class Exporter
+    attr_reader :content_ids
+
+    def initialize(content_ids)
+      @content_ids = content_ids
+    end
+
+    def filename
+      "content-id-lookup-#{Time.current.to_formatted_s(:number)}.csv"
+    end
+
+    def data
+      CSV.generate(headers: true) do |csv|
+        csv << title_headers
+
+        filtered_taxons.each do |taxon|
+          csv << [taxon.title, taxon.content_id, taxon.link_type]
+        end
+      end
+    end
+
+  private
+
+    def content_ids
+      @content_ids ||= []
+    end
+
+    def title_headers
+      ['Title', 'Taxon Content ID', 'Link Type']
+    end
+
+    def filtered_taxons
+      taxons.select { |taxon| content_ids.include?(taxon.content_id) }
+    end
+
+    def taxons
+      @taxons ||=
+        Taxonomy::TaxonFetcher.new.taxons.map { |taxon| Taxon.new(taxon) }
+    end
+  end
+end

--- a/app/services/taxonomy/taxon_builder.rb
+++ b/app/services/taxonomy/taxon_builder.rb
@@ -15,6 +15,8 @@ module Taxonomy
         content_id: content_id,
         title: content_item["title"],
         base_path: content_item["base_path"],
+        publication_state: content_item['publication_state'],
+        internal_name: content_item['internal_name'],
         parent_taxons: parent_taxons
       )
     end

--- a/app/views/taxons/index.html.erb
+++ b/app/views/taxons/index.html.erb
@@ -1,35 +1,45 @@
-<%= display_header title: 'Taxons', breadcrumbs: ['Taxons'] do %>
-  <%= link_to 'Add a taxon', new_taxon_path, class: 'btn btn-lg btn-default' %>
-<% end %>
-
-<table class="table queries-list table-bordered" data-module="filterable-table">
-  <thead>
-    <tr class="table-header">
-      <th>Title</th>
-      <th>Content ID</th>
-      <th></th>
-      <th></th>
-      <th></th>
-      <th></th>
-    </tr>
-
-    <%= render partial: 'shared/table_filter' %>
-  </thead>
-
-  <tbody>
-    <% taxons.each do |taxon| %>
-      <tr>
-        <td><%= taxon['title'] %></td>
-        <td><%= link_to taxon['content_id'], "#{website_url('/api/content' + taxon['base_path'])}" %></td>
-        <td><%= link_to 'View taxonomy', taxonomy_path(taxon['content_id']) %></td>
-        <td><%= link_to 'View tagged content', taxon_path(taxon['content_id']), class: 'view-tagged-content' %></td>
-        <td><%= link_to 'Edit taxon', edit_taxon_path(taxon['content_id']) %></td>
-        <td><%= link_to 'Delete', taxon_path(taxon['content_id']),
-            method: :delete,
-            data: { confirm: I18n.t('messages.views.confirm') },
-            class: 'btn btn-danger' %>
-        </td>
-      </tr>
+<%= form_tag export_taxons_path(format: :csv), method: :post do %>
+  <%= display_header title: 'Taxons', breadcrumbs: ['Taxons'] do %>
+    <%= link_to new_taxon_path, class: 'btn btn-lg btn-default' do %>
+      <i class="glyphicon glyphicon-plus"></i>
+      Add a taxon
     <% end %>
-  </tbody>
+    <%= button_tag type: :submit, class: 'btn btn-default' do %>
+      <i class="glyphicon glyphicon-download-alt"></i>
+      Export selected taxons
+    <% end %>
+  <% end %>
+
+  <table class="table queries-list table-bordered" data-module="filterable-table">
+    <thead>
+      <tr class="table-header">
+        <th></th>
+        <th>Title</th>
+        <th>Content ID</th>
+        <th></th>
+        <th></th>
+        <th></th>
+        <th></th>
+      </tr>
+
+      <%= render partial: 'shared/table_filter' %>
+    </thead>
+    <tbody>
+      <% taxons.each do |taxon| %>
+        <tr>
+          <td><%= check_box_tag 'content_ids[]', taxon['content_id'] %></td>
+          <td><%= taxon['title'] %></td>
+          <td><%= link_to taxon['content_id'], "#{website_url('/api/content' + taxon['base_path'])}" %></td>
+          <td><%= link_to 'View taxonomy', taxonomy_path(taxon['content_id']) %></td>
+          <td><%= link_to 'View tagged content', taxon_path(taxon['content_id']), class: 'view-tagged-content' %></td>
+          <td><%= link_to 'Edit taxon', edit_taxon_path(taxon['content_id']) %></td>
+          <td><%= link_to 'Delete', taxon_path(taxon['content_id']),
+              method: :delete,
+              data: { confirm: I18n.t('messages.views.confirm') },
+              class: 'btn btn-danger' %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  <% end %>
 </table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   root to: 'taggings#lookup'
 
   resources :taxons
+  resource :export_taxons, only: [:create]
 
   resources :taggings, only: %i(show update), param: :content_id do
     get '/lookup', action: 'lookup', on: :collection

--- a/spec/features/taxonomy_manager_spec.rb
+++ b/spec/features/taxonomy_manager_spec.rb
@@ -47,6 +47,13 @@ RSpec.feature "Managing taxonomies" do
     then_i_see_tagged_content
   end
 
+  scenario "Exporting taxons" do
+    given_there_are_taxons
+    when_i_visit_the_taxonomy_page
+    and_i_export_the_first_taxon
+    then_i_downloaded_a_csv_file_with_the_taxon
+  end
+
   def and_i_click_on_the_edit_taxon_link
     first('a', text: 'Edit taxon').click
   end
@@ -119,5 +126,17 @@ RSpec.feature "Managing taxonomies" do
 
   def then_i_see_tagged_content
     expect(page).to have_content "Tagged Item"
+  end
+
+  def and_i_export_the_first_taxon
+    first_checkbox = first('table tbody tr td input[type=checkbox]')
+    first_checkbox.set(true)
+    find_button('Export selected taxons').click
+  end
+
+  def then_i_downloaded_a_csv_file_with_the_taxon
+    expect(page.response_headers['Content-Type']).to match(/csv/)
+    expect(page.response_headers['Content-Disposition']).to match(/attachment/)
+    expect(page.response_headers['Content-Disposition']).to match(/content-id-lookup.*.csv/)
   end
 end

--- a/spec/services/taxonomy/exporter_spec.rb
+++ b/spec/services/taxonomy/exporter_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe Taxonomy::Exporter do
+  before do
+    linkables = [
+      { "title" => "Taxon 1", "base_path" => "/taxon-1", "content_id" => "taxon-1" },
+      { "title" => "Taxon 2", "base_path" => "/taxon-2", "content_id" => "taxon-2" },
+      { "title" => "Taxon 3", "base_path" => "/taxon-3", "content_id" => "taxon-3" },
+    ]
+    publishing_api_has_linkables(linkables, document_type: 'taxon')
+  end
+
+  it 'has a filename' do
+    exporter = described_class.new([])
+    time = Time.parse('2015-01-10 22:15:24')
+    expect(Time).to receive(:current).and_return(time)
+
+    expect(exporter.filename).to eq('content-id-lookup-20150110221524.csv')
+  end
+
+  it 'includes only the expected taxons in the data and the headers' do
+    exporter = described_class.new(['taxon-1', 'taxon-3'])
+    csv_data = CSV.parse(exporter.data)
+
+    expect(csv_data.count).to eq(3)
+
+    expect(csv_data[0]).to eq(["Title", "Taxon Content ID", "Link Type"])
+    expect(csv_data[1]).to eq(["Taxon 1", "taxon-1", "taxons"])
+    expect(csv_data[2]).to eq(["Taxon 3", "taxon-3", "taxons"])
+
+    expect(exporter.data).to_not include('Taxon 2')
+    expect(exporter.data).to_not include('taxon-2')
+  end
+
+  it 'returns just the headers with no content ids' do
+    exporter = described_class.new(nil)
+    csv_data = CSV.parse(exporter.data)
+
+    expect(csv_data.count).to eq(1)
+    expect(csv_data[0]).to eq(["Title", "Taxon Content ID", "Link Type"])
+  end
+end

--- a/spec/services/taxonomy/taxon_builder_spec.rb
+++ b/spec/services/taxonomy/taxon_builder_spec.rb
@@ -9,7 +9,9 @@ RSpec.describe Taxonomy::TaxonBuilder do
       {
         content_id: content_id,
         title: 'A title',
-        base_path: 'A base path'
+        base_path: 'A base path',
+        publication_state: 'State',
+        internal_name: 'Internal name'
       }
     end
     let(:taxon) { builder.build }
@@ -43,6 +45,14 @@ RSpec.describe Taxonomy::TaxonBuilder do
 
     it 'assigns the base_path correctly' do
       expect(taxon.base_path).to eq(content[:base_path])
+    end
+
+    it 'assigns the publication state correctly' do
+      expect(taxon.publication_state).to eq(content[:publication_state])
+    end
+
+    it 'assigns the internal_name correctly' do
+      expect(taxon.internal_name).to eq(content[:internal_name])
     end
 
     context 'without taxon parents' do


### PR DESCRIPTION
We would like to allow users to export taxons in order to make it easier to
create tagging spreadsheets.

Those spreadsheets need a mapping between taxon names and their content IDs. The
CSV file we are generating gives us exactly that, together with the link type.
This way, we can download a list of user-selected taxons into a format expected
by the tagging spreadsheet.

More information in trello: https://trello.com/c/gRoOrJoo/121-spike-build-functionality-into-content-tagger-which-makes-creating-a-tag-importer-spreadsheet-easier

It looks like this:

![export-taxons](https://cloud.githubusercontent.com/assets/416701/17976495/af24751a-6ae5-11e6-9bdb-fe36f2d9e5f8.gif)


@mobaig thoughts?
