### PR TITLE
Add taxonomy visualisation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,8 +19,6 @@ gem 'select2-rails', '~> 3.5.9'
 
 gem 'govuk_sidekiq', '~> 0.0.4'
 
-gem 'rubytree'
-
 group :development, :test do
   gem 'quiet_assets'
   gem 'pry-byebug'

--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,8 @@ gem 'select2-rails', '~> 3.5.9'
 
 gem 'govuk_sidekiq', '~> 0.0.4'
 
+gem 'rubytree'
+
 group :development, :test do
   gem 'quiet_assets'
   gem 'pry-byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -246,9 +246,6 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.8.1)
-    rubytree (0.9.7)
-      json (~> 1.8)
-      structured_warnings (~> 0.2)
     safe_yaml (1.0.4)
     sass (3.4.22)
     sass-rails (5.0.5)
@@ -296,7 +293,6 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     statsd-ruby (1.3.0)
-    structured_warnings (0.2.0)
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.5)
@@ -348,7 +344,6 @@ DEPENDENCIES
   quiet_assets
   rails (= 4.2.7.1)
   rspec-rails (~> 3.3)
-  rubytree
   sass-rails (~> 5.0)
   select2-rails (~> 3.5.9)
   simple_form (~> 3.2, >= 3.2.1)
@@ -360,4 +355,4 @@ DEPENDENCIES
   webmock (~> 1.22)
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -246,6 +246,9 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.8.1)
+    rubytree (0.9.7)
+      json (~> 1.8)
+      structured_warnings (~> 0.2)
     safe_yaml (1.0.4)
     sass (3.4.22)
     sass-rails (5.0.5)
@@ -293,6 +296,7 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     statsd-ruby (1.3.0)
+    structured_warnings (0.2.0)
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.5)
@@ -344,6 +348,7 @@ DEPENDENCIES
   quiet_assets
   rails (= 4.2.7.1)
   rspec-rails (~> 3.3)
+  rubytree
   sass-rails (~> 5.0)
   select2-rails (~> 3.5.9)
   simple_form (~> 3.2, >= 3.2.1)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7,6 +7,7 @@
 @import 'govuk_admin_template';
 @import 'import-preview';
 @import 'forms';
+@import 'taxonomy-viz';
 
 .view-on-site {
   font-size: 20px;

--- a/app/assets/stylesheets/taxonomy-viz.scss
+++ b/app/assets/stylesheets/taxonomy-viz.scss
@@ -1,3 +1,7 @@
+// A set of classes governing the degree of indent depending on the depth of a
+// given node in the taxonomy. 20 has no special significance. It's large
+// enough that we're unlikely to ever need to update this rule, but small
+// enough that we don't end up creating large amounts of unnecessary CSS.
 @for $i from 1 through 20 {
   .taxon-depth-#{$i} {
     margin-left: 4rem * $i;

--- a/app/assets/stylesheets/taxonomy-viz.scss
+++ b/app/assets/stylesheets/taxonomy-viz.scss
@@ -1,0 +1,43 @@
+@for $i from 1 through 20 {
+  .taxon-depth-#{$i} {
+    margin-left: 4rem * $i;
+  }
+}
+
+$taxon-level-font-size-lg: 16px;
+$taxon-level-font-size-sm: 13px;
+
+.taxon-level {
+  padding: 0.5rem;
+  border-left: 1px solid #bfc1c3;
+  border-bottom: 1px solid #bfc1c3;
+  margin-bottom: 1rem;
+  max-width: 40%;
+
+  a.btn {
+    padding: 1px 4px;
+    margin-bottom: 0.5rem;
+  }
+}
+
+.taxon-level-title {
+  font-size: $taxon-level-font-size-lg;
+  margin-right: 0.5rem;
+  margin-left: 0.5rem;
+}
+
+.taxon-level-edit {
+  font-size: $taxon-level-font-size-sm;
+}
+
+.taxon-level-parent-links {
+  font-size: $taxon-level-font-size-sm;
+
+  span {
+    margin-bottom: 0.8rem;
+  }
+
+  p {
+    margin-bottom: 0rem;
+  }
+}

--- a/app/controllers/taxonomies_controller.rb
+++ b/app/controllers/taxonomies_controller.rb
@@ -1,0 +1,6 @@
+class TaxonomiesController < ApplicationController
+  def show
+    taxon_content_id = params[:content_id]
+    @taxonomy = ExpandedTaxonomy.new(taxon_content_id).build
+  end
+end

--- a/app/models/expanded_taxonomy.rb
+++ b/app/models/expanded_taxonomy.rb
@@ -1,0 +1,47 @@
+class ExpandedTaxonomy
+  def initialize(content_id)
+    @content_id = content_id
+  end
+
+  def build
+    root_content_item = Services.publishing_api.get_content(@content_id)
+    root_node = tree_node_based_on(root_content_item)
+    expand_tree_from(root_node)
+    root_node
+  end
+
+private
+
+  def expand_tree_from(node)
+    expanded_links = Services.publishing_api.get_expanded_links(
+      node.content[:content_id]
+    )["expanded_links"]
+
+    add_parent_details(node, expanded_links)
+    add_children(node, expanded_links)
+  end
+
+  def add_parent_details(node, expanded_links)
+    # Collect identifying info about the node's parent taxons and store this on
+    # the node itself.
+    list_of_parents = Array(expanded_links["parent_taxons"]).map do |parent_taxon|
+      { title: parent_taxon["title"], content_id: parent_taxon["content_id"] }
+    end
+
+    node.content[:parent_taxons] = list_of_parents
+  end
+
+  def add_children(node, expanded_links)
+    # Derive a tree node from each child taxon, attach it to the parent, and
+    # recursively expand from the child node downwards.
+    Array(expanded_links["child_taxons"]).each do |child_taxon|
+      child_node = tree_node_based_on(child_taxon)
+      node << child_node
+      expand_tree_from(child_node)
+    end
+  end
+
+  def tree_node_based_on(content_item)
+    Tree::TreeNode.new(content_item["title"], content_id: content_item["content_id"])
+  end
+end

--- a/app/models/expanded_taxonomy.rb
+++ b/app/models/expanded_taxonomy.rb
@@ -34,13 +34,12 @@ private
     # recursively expand from the child node downwards.
     Array(expanded_links["child_taxons"]).each do |child_taxon|
       child_node = tree_node_based_on(child_taxon)
-      child_node.parent = node
-      node.add_children(child_node)
+      node << child_node
       expand_tree_from(child_node)
     end
   end
 
   def tree_node_based_on(content_item)
-    TreeNode.new(content_item.to_hash.slice('title', 'content_id'))
+    TreeNode.new(title: content_item["title"], content_id: content_item["content_id"])
   end
 end

--- a/app/models/tree_node.rb
+++ b/app/models/tree_node.rb
@@ -1,0 +1,47 @@
+class TreeNode
+  attr_reader :taxon, :children, :node_depth
+  attr_accessor :parent
+  delegate :title, :content_id, :parent_taxons, :parent_taxons=, to: :taxon
+  delegate :map, :each, to: :children
+
+  def initialize(taxon_hash)
+    @taxon = Taxon.new(taxon_hash)
+    @children = []
+  end
+
+  def add_children(children)
+    @children << children
+  end
+
+  def children
+    return [self] if @children.empty?
+
+    _children = [self]
+    @children.each do |ch|
+      _children.concat(ch.children)
+    end
+
+     _children
+  end
+
+  def first
+    children.first
+  end
+
+  def root?
+    parent.nil?
+  end
+
+  def name
+    title
+  end
+
+  def node_depth
+    return 0 if root?
+    1 + parent.node_depth
+  end
+
+  def count
+    children.count
+  end
+end

--- a/app/models/tree_node.rb
+++ b/app/models/tree_node.rb
@@ -1,47 +1,37 @@
 class TreeNode
-  attr_reader :taxon, :children, :node_depth
+  attr_reader :taxon
   attr_accessor :parent
   delegate :title, :content_id, :parent_taxons, :parent_taxons=, to: :taxon
-  delegate :map, :each, to: :children
+  delegate :map, :each, to: :tree
 
-  def initialize(taxon_hash)
-    @taxon = Taxon.new(taxon_hash)
+  def initialize(title:, content_id:)
+    @taxon = Taxon.new(title: title, content_id: content_id)
     @children = []
   end
 
-  def add_children(children)
-    @children << children
+  def <<(child_node)
+    child_node.parent = self
+    @children << child_node
   end
 
-  def children
+  def tree
     return [self] if @children.empty?
 
-    _children = [self]
-    @children.each do |ch|
-      _children.concat(ch.children)
+    @children.each_with_object([self]) do |child, tree|
+      tree.concat(child.tree)
     end
-
-     _children
   end
 
-  def first
-    children.first
+  def count
+    tree.count
   end
 
   def root?
     parent.nil?
   end
 
-  def name
-    title
-  end
-
   def node_depth
     return 0 if root?
     1 + parent.node_depth
-  end
-
-  def count
-    children.count
   end
 end

--- a/app/services/taxonomy/taxon_fetcher.rb
+++ b/app/services/taxonomy/taxon_fetcher.rb
@@ -3,9 +3,8 @@ module Taxonomy
     # Return a list of taxons from the publishing API with links included.
     def taxons
       @taxons ||=
-        Services.publishing_api.get_linkables(
-          document_type: 'taxon'
-        ).sort_by { |taxon| taxon["title"] }
+        Services.publishing_api.get_linkables(document_type: 'taxon')
+          .sort_by { |taxon| taxon["title"] }
     end
 
     def taxon_content_ids

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,7 +8,7 @@
   <li class='<%= active_navigation_item == 'taggings' ? 'active' : nil %>'>
     <%= link_to 'Tagging', lookup_taggings_path %>
   </li>
-  <li class='<%= active_navigation_item == 'taxons' ? 'active' : nil %>'>
+  <li class='<%= (active_navigation_item == 'taxons' || active_navigation_item == 'taxonomies') ? 'active' : nil %>'>
     <%= link_to 'Taxons', taxons_path %>
   </li>
   <li class='<%= active_navigation_item == 'tagging_spreadsheets' ? 'active' : nil %>'>

--- a/app/views/taxonomies/show.html.erb
+++ b/app/views/taxonomies/show.html.erb
@@ -1,11 +1,11 @@
-<%= display_header title: '', breadcrumbs: [:taxons, @taxonomy.first.name] do %>
+<%= display_header title: '', breadcrumbs: [:taxons, @taxonomy.tree.first.title] do %>
 <% end %>
 
 <% @taxonomy.each do |tree_node| %>
 
   <div class="taxon-level taxon-depth-<%= tree_node.node_depth %>">
     <span class="taxon-level-title">
-      <%= "#{(tree_node.node_depth + 1)} -" %> <%= link_to "#{tree_node.name}", taxonomy_path(tree_node.content_id) %>
+      <%= "#{(tree_node.node_depth + 1)} -" %> <%= link_to "#{tree_node.title}", taxonomy_path(tree_node.content_id) %>
     </span>
 
     <%= link_to edit_taxon_path(tree_node.content_id), class: "taxon-level-edit" do %>
@@ -17,7 +17,7 @@
       <div class="taxon-level-parent-links">
         <% parent_taxons.each do |parent_taxon| %>
           <p>
-            ↰ <%= link_to parent_taxon.title, taxonomy_path(parent_taxon.content_id ) %>
+            ↰ <%= link_to parent_taxon.title, taxonomy_path(parent_taxon.content_id) %>
           </p>
         <% end %>
       </div>

--- a/app/views/taxonomies/show.html.erb
+++ b/app/views/taxonomies/show.html.erb
@@ -1,19 +1,19 @@
 <%= display_header title: '', breadcrumbs: [:taxons, @taxonomy.first.name] do %>
 <% end %>
 
-<% @taxonomy.each do |taxon| %>
+<% @taxonomy.each do |tree_node| %>
 
-  <div class="taxon-level taxon-depth-<%= taxon.node_depth %>">
+  <div class="taxon-level taxon-depth-<%= tree_node.node_depth %>">
     <span class="taxon-level-title">
-      <%= "#{(taxon.node_depth + 1)} -" %> <%= link_to "#{taxon.name}", taxonomy_path(taxon.content[:content_id]) %>
+      <%= "#{(tree_node.node_depth + 1)} -" %> <%= link_to "#{tree_node.name}", taxonomy_path(tree_node.content[:content_id]) %>
     </span>
 
-    <%= link_to edit_taxon_path(taxon.content[:content_id]), class: "taxon-level-edit" do %>
+    <%= link_to edit_taxon_path(tree_node.content[:content_id]), class: "taxon-level-edit" do %>
       <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
     <% end %>
 
-    <% parent_taxons = taxon.content[:parent_taxons] %>
-    <% if parent_taxons.present? && (parent_taxons.count > 1 || taxon.node_depth == 0) %>
+    <% parent_taxons = tree_node.content[:parent_taxons] %>
+    <% if parent_taxons.present? && (parent_taxons.count > 1 || tree_node.node_depth == 0) %>
       <div class="taxon-level-parent-links">
         <% parent_taxons.each do |parent_taxon| %>
           <p>

--- a/app/views/taxonomies/show.html.erb
+++ b/app/views/taxonomies/show.html.erb
@@ -1,0 +1,27 @@
+<%= display_header title: '', breadcrumbs: [:taxons, @taxonomy.first.name] do %>
+<% end %>
+
+<% @taxonomy.each do |taxon| %>
+
+  <div class="taxon-level taxon-depth-<%= taxon.node_depth %>">
+    <span class="taxon-level-title">
+      <%= "#{(taxon.node_depth + 1)} -" %> <%= link_to "#{taxon.name}", taxonomy_path(taxon.content[:content_id]) %>
+    </span>
+
+    <%= link_to edit_taxon_path(taxon.content[:content_id]), class: "taxon-level-edit" do %>
+      <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
+    <% end %>
+
+    <% parent_taxons = taxon.content[:parent_taxons] %>
+    <% if parent_taxons.present? && (parent_taxons.count > 1 || taxon.node_depth == 0) %>
+      <div class="taxon-level-parent-links">
+        <% parent_taxons.each do |parent_taxon| %>
+          <p>
+            ↰ <%= link_to parent_taxon[:title], taxonomy_path(parent_taxon[:content_id] ) %>
+          </p>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+
+<% end %>

--- a/app/views/taxonomies/show.html.erb
+++ b/app/views/taxonomies/show.html.erb
@@ -5,19 +5,19 @@
 
   <div class="taxon-level taxon-depth-<%= tree_node.node_depth %>">
     <span class="taxon-level-title">
-      <%= "#{(tree_node.node_depth + 1)} -" %> <%= link_to "#{tree_node.name}", taxonomy_path(tree_node.content[:content_id]) %>
+      <%= "#{(tree_node.node_depth + 1)} -" %> <%= link_to "#{tree_node.name}", taxonomy_path(tree_node.content_id) %>
     </span>
 
-    <%= link_to edit_taxon_path(tree_node.content[:content_id]), class: "taxon-level-edit" do %>
+    <%= link_to edit_taxon_path(tree_node.content_id), class: "taxon-level-edit" do %>
       <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
     <% end %>
 
-    <% parent_taxons = tree_node.content[:parent_taxons] %>
+    <% parent_taxons = tree_node.parent_taxons %>
     <% if parent_taxons.present? && (parent_taxons.count > 1 || tree_node.node_depth == 0) %>
       <div class="taxon-level-parent-links">
         <% parent_taxons.each do |parent_taxon| %>
           <p>
-            ↰ <%= link_to parent_taxon[:title], taxonomy_path(parent_taxon[:content_id] ) %>
+            ↰ <%= link_to parent_taxon.title, taxonomy_path(parent_taxon.content_id ) %>
           </p>
         <% end %>
       </div>

--- a/app/views/taxons/index.html.erb
+++ b/app/views/taxons/index.html.erb
@@ -10,6 +10,7 @@
       <th></th>
       <th></th>
       <th></th>
+      <th></th>
     </tr>
 
     <%= render partial: 'shared/table_filter' %>
@@ -20,6 +21,7 @@
       <tr>
         <td><%= taxon['title'] %></td>
         <td><%= link_to taxon['content_id'], "#{website_url('/api/content' + taxon['base_path'])}" %></td>
+        <td><%= link_to 'View taxonomy', taxonomy_path(taxon['content_id']) %></td>
         <td><%= link_to 'View tagged content', taxon_path(taxon['content_id']), class: 'view-tagged-content' %></td>
         <td><%= link_to 'Edit taxon', edit_taxon_path(taxon['content_id']) %></td>
         <td><%= link_to 'Delete', taxon_path(taxon['content_id']),

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,8 @@ Rails.application.routes.draw do
 
   get '/healthcheck', to: proc { [200, {}, ['OK']] }
 
+  resources :taxonomies, only: %i(show), param: :content_id
+
   if Rails.env.development?
     mount GovukAdminTemplate::Engine, at: '/style-guide'
 

--- a/spec/features/taxonomy_visualisation_spec.rb
+++ b/spec/features/taxonomy_visualisation_spec.rb
@@ -1,0 +1,117 @@
+require "rails_helper"
+
+RSpec.describe "Taxonomy visualisation" do
+  let(:food)   { fake_taxon("Food") }
+  let(:fruits) { fake_taxon("Fruits") }
+  let(:apples) { fake_taxon("Apples") }
+  let(:round_things) { fake_taxon("Round things") }
+
+  scenario "Viewing a taxonomy" do
+    given_a_taxonomy
+    when_i_view_the_top_level_taxon
+    then_i_see_the_entire_taxonomy
+    when_i_view_one_of_the_children
+    then_i_see_the_taxonomy_from_the_child_downwards
+  end
+
+  scenario "Navigating multiple parents" do
+    given_a_taxonomy
+    and_a_taxon_with_multiple_parents
+    when_i_view_the_top_level_taxon
+    then_i_can_see_the_multi_parent_taxon
+    and_can_navigate_to_the_other_parent
+  end
+
+  def fake_taxon(title)
+    { "title" => title, "content_id" => "#{title.parameterize}-id" }
+  end
+
+  def given_a_taxonomy
+    publishing_api_has_item(food)
+    publishing_api_has_item(fruits)
+
+    publishing_api_has_expanded_links(
+      content_id: food["content_id"],
+      expanded_links: { child_taxons: [fruits] },
+    )
+    publishing_api_has_expanded_links(
+      content_id: fruits["content_id"],
+      expanded_links: {
+        parent_taxons: [food],
+        child_taxons: [apples]
+      },
+    )
+    publishing_api_has_expanded_links(
+      content_id: apples["content_id"],
+      expanded_links: { parent_taxons: [fruits] },
+    )
+  end
+
+  def and_a_taxon_with_multiple_parents
+    publishing_api_has_expanded_links(
+      content_id: apples["content_id"],
+      expanded_links: { parent_taxons: [fruits, round_things] },
+    )
+    publishing_api_has_item(round_things)
+    publishing_api_has_expanded_links(
+      content_id: round_things["content_id"],
+      expanded_links: { child_taxons: [apples] },
+    )
+  end
+
+  def when_i_view_the_top_level_taxon
+    visit taxonomy_path(food["content_id"])
+  end
+
+  def then_i_see_the_entire_taxonomy
+    expected_titles = [
+      food["title"],
+      fruits["title"],
+      apples["title"],
+    ]
+    rendered_titles = all(".taxon-level-title")
+
+    expect(rendered_titles.count).to eq 3
+    rendered_titles.zip(expected_titles).each do |rendered, expected|
+      within rendered do
+        expect(page).to have_content expected
+      end
+    end
+  end
+
+  def when_i_view_one_of_the_children
+    within ".taxon-depth-1" do
+      click_link fruits["title"]
+    end
+  end
+
+  def then_i_see_the_taxonomy_from_the_child_downwards
+    rendered_titles = all(".taxon-level-title")
+
+    expect(rendered_titles.count).to eq 2
+    expect(rendered_titles.first).to have_content fruits["title"]
+  end
+
+  def then_i_can_see_the_multi_parent_taxon
+    rendered_taxons = all(".taxon-level")
+
+    within rendered_taxons.last do
+      within ".taxon-level-parent-links" do
+        expect(page).to have_content("Round things")
+        expect(page).to have_content("Fruits")
+      end
+    end
+  end
+
+  def and_can_navigate_to_the_other_parent
+    rendered_taxons = all(".taxon-level")
+    within rendered_taxons.last do
+      click_link "Round things"
+    end
+
+    rendered_titles = all(".taxon-level-title")
+    within rendered_titles.first do
+      expect(page).to have_content round_things["title"]
+    end
+  end
+end

--- a/spec/models/expanded_taxonomy_spec.rb
+++ b/spec/models/expanded_taxonomy_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe ExpandedTaxonomy do
+  describe "#build" do
+    def fake_taxon(title)
+      { "title" => title, "content_id" => "#{title.parameterize}-id" }
+    end
+
+    let(:food)   { fake_taxon("Food") }
+    let(:fruits) { fake_taxon("Fruits") }
+    let(:apples) { fake_taxon("Apples") }
+
+    before do
+      publishing_api_has_item(food)
+
+      publishing_api_has_expanded_links(
+        content_id: food["content_id"],
+        expanded_links: {
+          child_taxons: [fruits]
+        },
+      )
+      publishing_api_has_expanded_links(
+        content_id: fruits["content_id"],
+        expanded_links: {
+          parent_taxons: [food],
+          child_taxons: [apples]
+        },
+      )
+      publishing_api_has_expanded_links(
+        content_id: apples["content_id"],
+        expanded_links: {
+          parent_taxons: [fruits]
+        },
+      )
+    end
+
+    context "given a starting taxon" do
+      let(:taxonomy) { ExpandedTaxonomy.new(food["content_id"]).build }
+
+      it "returns a tree object representing the taxonomy from the starting taxon down" do
+        expect(taxonomy.count).to eq 3
+        expect(taxonomy.map(&:name)).to eq %w( Food Fruits Apples )
+      end
+    end
+  end
+end

--- a/spec/models/expanded_taxonomy_spec.rb
+++ b/spec/models/expanded_taxonomy_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe ExpandedTaxonomy do
     let(:food)   { fake_taxon("Food") }
     let(:fruits) { fake_taxon("Fruits") }
     let(:apples) { fake_taxon("Apples") }
+    let(:pears)  { fake_taxon("Pears") }
 
     before do
       publishing_api_has_item(food)
@@ -23,7 +24,13 @@ RSpec.describe ExpandedTaxonomy do
         content_id: fruits["content_id"],
         expanded_links: {
           parent_taxons: [food],
-          child_taxons: [apples]
+          child_taxons: [apples, pears]
+        },
+      )
+      publishing_api_has_expanded_links(
+        content_id: pears["content_id"],
+        expanded_links: {
+          parent_taxons: [fruits],
         },
       )
       publishing_api_has_expanded_links(
@@ -38,8 +45,9 @@ RSpec.describe ExpandedTaxonomy do
       let(:taxonomy) { ExpandedTaxonomy.new(food["content_id"]).build }
 
       it "returns a tree object representing the taxonomy from the starting taxon down" do
-        expect(taxonomy.count).to eq 3
-        expect(taxonomy.map(&:name)).to eq %w( Food Fruits Apples )
+        expect(taxonomy.count).to eq 4
+        expect(taxonomy.map(&:title)).to eq %w( Food Fruits Apples Pears)
+        expect(taxonomy.map(&:node_depth)).to eq [0, 1, 2, 2]
       end
     end
   end

--- a/spec/models/tree_node_spec.rb
+++ b/spec/models/tree_node_spec.rb
@@ -1,0 +1,73 @@
+require "rails_helper"
+
+RSpec.describe TreeNode do
+  let(:root_node) { TreeNode.new(title: "Root", content_id: "root-id") }
+  let(:child_node_1) { TreeNode.new(title: "Child-1", content_id: "child-1-id") }
+
+  describe "#<<(child_node)" do
+    it "makes one node the child of another node" do
+      root_node << child_node_1
+
+      expect(root_node.tree).to include child_node_1
+      expect(child_node_1.parent).to eq root_node
+    end
+  end
+
+  describe "#tree" do
+    context "given a node with a tree of successors" do
+      it "returns an array representing a pre-order traversal of the tree" do
+        child_node_2 = TreeNode.new(title: "Child-2", content_id: "child-2-id")
+        child_node_3 = TreeNode.new(title: "Child-3", content_id: "child-3-id")
+
+        root_node << child_node_1
+        child_node_1 << child_node_3
+        child_node_1 << child_node_2
+
+        expect(root_node.tree.count).to eq 4
+        expect(root_node.tree.first).to eq root_node
+        expect(root_node.tree.map(&:title)).to eq %w(Root Child-1 Child-3 Child-2)
+        expect(child_node_1.tree.map(&:title)).to eq %w(Child-1 Child-3 Child-2)
+      end
+    end
+
+    context "given a single node" do
+      it "returns an array containing only that node" do
+        expect(root_node.tree.map(&:title)).to eq %w(Root)
+      end
+    end
+  end
+
+  describe "#root?" do
+    before do
+      root_node << child_node_1
+    end
+
+    it "returns true when a node is the root" do
+      expect(root_node.root?).to be
+    end
+
+    it "returns false when a node is not the root" do
+      expect(child_node_1.root?).to_not be
+    end
+  end
+
+  describe "#node_depth" do
+    it "returns the depth of the node in its tree" do
+      child_node_2 = TreeNode.new(title: "Child-2", content_id: "child-2-id")
+      root_node << child_node_1
+      child_node_1 << child_node_2
+
+      expect(root_node.node_depth).to eq 0
+      expect(child_node_1.node_depth).to eq 1
+      expect(child_node_2.node_depth).to eq 2
+    end
+  end
+
+  describe "#count" do
+    it "returns the total number of nodes in the tree" do
+      root_node << child_node_1
+
+      expect(root_node.count).to eq 2
+    end
+  end
+end


### PR DESCRIPTION
View the descendants of any taxon, displayed as a tree.

- Adds an ExpandedTaxonomy class to fetch required data from the
  publishing API and use it to construct a tree.
- Uses the ruby-tree gem to provide a convenient interface for tree
  traversal and determining node depth.
- Some basic styling to visually distinguish different levels of the
  taxonomy.

![screen shot 2016-08-26 at 13 54 56](https://cloud.githubusercontent.com/assets/519250/18005905/cac66d32-6b94-11e6-873b-67d6ee8214dd.png)
