### PR TITLE
Strip leading and trailing spaces from google spreadsheet url

### DIFF
--- a/app/controllers/tagging_spreadsheets_controller.rb
+++ b/app/controllers/tagging_spreadsheets_controller.rb
@@ -82,6 +82,9 @@ private
   end
 
   def tagging_spreadsheet_params
-    params.require(:tagging_spreadsheet).permit(:url, :description)
+    taggging_params = params.require(:tagging_spreadsheet).permit(:url, :description)
+    taggging_params["url"] = taggging_params["url"].strip
+
+    taggging_params
   end
 end

--- a/spec/validators/google_url_validator_spec.rb
+++ b/spec/validators/google_url_validator_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe GoogleUrlValidator do
 
   it 'does not add validation errors for a correct URL' do
     valid_url = google_sheet_url(key: 'mykey', gid: 'mygid')
+
     record = double(url: valid_url, errors: { url: [] })
 
     GoogleUrlValidator.new.validate(record)


### PR DESCRIPTION
Trello: https://trello.com/c/giDY8odT/135-s-remove-white-spaces-on-spreadsheet-url