### PR TITLE
Allow copy of taxons

### DIFF
--- a/app/controllers/copy_taxons_controller.rb
+++ b/app/controllers/copy_taxons_controller.rb
@@ -1,0 +1,12 @@
+class CopyTaxonsController < ApplicationController
+  def index
+    taxons = taxon_fetcher.taxons.map { |taxon| Taxon.new(taxon) }
+    render :index, locals: { taxons: taxons }
+  end
+
+private
+
+  def taxon_fetcher
+    @taxon_fetcher ||= Taxonomy::TaxonFetcher.new
+  end
+end

--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -1,5 +1,11 @@
 class Taxon
-  attr_accessor :title, :parent_taxons, :content_id, :base_path
+  attr_accessor :title,
+                :parent_taxons,
+                :content_id,
+                :base_path,
+                :publication_state,
+                :internal_name
+
   include ActiveModel::Model
 
   validates_presence_of :title
@@ -14,5 +20,9 @@ class Taxon
 
   def base_path
     @base_path ||= '/alpha-taxonomy/' + SecureRandom.uuid + '-' + title.parameterize
+  end
+
+  def link_type
+    'taxons'
   end
 end

--- a/app/services/taxonomy/taxon_builder.rb
+++ b/app/services/taxonomy/taxon_builder.rb
@@ -15,6 +15,8 @@ module Taxonomy
         content_id: content_id,
         title: content_item["title"],
         base_path: content_item["base_path"],
+        publication_state: content_item['publication_state'],
+        internal_name: content_item['internal_name'],
         parent_taxons: parent_taxons
       )
     end

--- a/app/views/copy_taxons/index.html.erb
+++ b/app/views/copy_taxons/index.html.erb
@@ -1,0 +1,21 @@
+<%= display_header title: 'Copy Taxons', breadcrumbs: ['Copy Taxons'] %>
+
+<table class="table queries-list table-bordered" data-module="filterable-table">
+  <thead>
+    <tr class="table-header">
+      <th>Title</th>
+      <th>Content ID</th>
+      <th>Link Type</th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% taxons.each do |taxon| %>
+      <tr>
+        <td><%= taxon.title %></td>
+        <td><%= taxon.content_id %></td>
+        <td><%= taxon.link_type %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/taxons/index.html.erb
+++ b/app/views/taxons/index.html.erb
@@ -1,5 +1,14 @@
 <%= display_header title: 'Taxons', breadcrumbs: ['Taxons'] do %>
-  <%= link_to 'Add a taxon', new_taxon_path, class: 'btn btn-lg btn-default' %>
+  <%= link_to new_taxon_path, class: 'btn btn-lg btn-default' do %>
+    <i class="glyphicon glyphicon-plus"></i>
+      <%= I18n.t('views.taxons.add_taxon') %>
+    </i>
+  <% end %>
+  <%= link_to copy_taxons_path, class: 'btn btn-lg btn-default' do %>
+    <i class="glyphicon glyphicon-download-alt"></i>
+      <%= I18n.t('views.taxons.copy_taxon') %>
+    </i>
+  <% end %>
 <% end %>
 
 <table class="table queries-list table-bordered" data-module="filterable-table">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -19,6 +19,8 @@ en:
     callout_new: Creating
     callout_edit: Editing
     taxons:
+      add_taxon: Add a taxon
+      copy_taxon: Copy taxons
       new_title: New taxon
       new_breadcrumb: New taxon
       new_button: Create taxon

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   root to: 'taggings#lookup'
 
   resources :taxons
+  resources :copy_taxons, only: [:index], path: 'copy-taxons'
 
   resources :taggings, only: %i(show update), param: :content_id do
     get '/lookup', action: 'lookup', on: :collection

--- a/spec/features/taxonomy_manager_spec.rb
+++ b/spec/features/taxonomy_manager_spec.rb
@@ -47,6 +47,13 @@ RSpec.feature "Managing taxonomies" do
     then_i_see_tagged_content
   end
 
+  scenario "Copy taxons" do
+    given_there_are_taxons
+    when_i_visit_the_taxonomy_page
+    and_i_click_to_copy_taxons
+    then_i_can_see_a_table_with_taxons_to_copy
+  end
+
   def and_i_click_on_the_edit_taxon_link
     first('a', text: 'Edit taxon').click
     expect(page).to have_selector('.callout-warning', text: /editing/i)
@@ -129,5 +136,26 @@ RSpec.feature "Managing taxonomies" do
 
   def then_i_see_tagged_content
     expect(page).to have_content "Tagged Item"
+  end
+
+  def and_i_click_to_copy_taxons
+    find_link('Copy taxons').click
+  end
+
+  def then_i_can_see_a_table_with_taxons_to_copy
+    table = find('table')
+    table_head = table.all('thead th').map(&:text)
+    table_body = table.find('tbody').text
+
+    expect(table_head).to include(/title/i)
+    expect(table_head).to include(/content id/i)
+    expect(table_head).to include(/link type/i)
+
+    expect(table_body).to include(@taxon_1[:content_id])
+    expect(table_body).to include(@taxon_1[:title])
+
+    expect(table_body).to include(@taxon_2[:content_id])
+    expect(table_body).to include(@taxon_2[:title])
+    expect(table_body).to include('taxons')
   end
 end

--- a/spec/services/taxonomy/taxon_builder_spec.rb
+++ b/spec/services/taxonomy/taxon_builder_spec.rb
@@ -9,7 +9,9 @@ RSpec.describe Taxonomy::TaxonBuilder do
       {
         content_id: content_id,
         title: 'A title',
-        base_path: 'A base path'
+        base_path: 'A base path',
+        publication_state: 'State',
+        internal_name: 'Internal name'
       }
     end
     let(:taxon) { builder.build }
@@ -43,6 +45,14 @@ RSpec.describe Taxonomy::TaxonBuilder do
 
     it 'assigns the base_path correctly' do
       expect(taxon.base_path).to eq(content[:base_path])
+    end
+
+    it 'assigns the publication state correctly' do
+      expect(taxon.publication_state).to eq(content[:publication_state])
+    end
+
+    it 'assigns the internal_name correctly' do
+      expect(taxon.internal_name).to eq(content[:internal_name])
     end
 
     context 'without taxon parents' do


### PR DESCRIPTION
We would like to allow users to export taxons in order to make it easier to
create tagging spreadsheets.

Those spreadsheets need a mapping between taxon names and their content IDs.
This commit adds a link from the taxons index page into a new view which
contains a table with the necessary columns: title, content ID and link type.

The user can then copy that HTML page into a spreadsheet and it would work as if
we copied CSV data.

From here:

<img width="1410" alt="screen shot 2016-08-31 at 12 18 33" src="https://cloud.githubusercontent.com/assets/416701/18126898/3bc8d7c0-6f75-11e6-90e4-37f7f1f3ec11.png">

We go here:

<img width="1415" alt="screen shot 2016-08-31 at 12 18 43" src="https://cloud.githubusercontent.com/assets/416701/18126901/40989ce0-6f75-11e6-848f-656d9baa4432.png">

Trello ticket: https://trello.com/c/gRoOrJoo/121-spike-build-functionality-into-content-tagger-which-makes-creating-a-tag-importer-spreadsheet-easier
