### PR TITLE
Add button to download any taxonomy visualisation as a CSV file

### DIFF
--- a/app/assets/stylesheets/taxonomy-viz.scss
+++ b/app/assets/stylesheets/taxonomy-viz.scss
@@ -45,3 +45,9 @@ $taxon-level-font-size-sm: 13px;
     margin-bottom: 0rem;
   }
 }
+
+.taxonomy-csv-download-btn {
+  @extend .btn;
+  @extend .btn-default;
+  @extend .btn-sm;
+}

--- a/app/controllers/taxonomies_controller.rb
+++ b/app/controllers/taxonomies_controller.rb
@@ -2,5 +2,16 @@ class TaxonomiesController < ApplicationController
   def show
     taxon_content_id = params[:content_id]
     @taxonomy = ExpandedTaxonomy.new(taxon_content_id).build
+
+    respond_to do |format|
+      format.html
+
+      format.csv do
+        send_data(
+          CsvTreePresenter.new(@taxonomy).present,
+          filename: @taxonomy.tree.first.title + ".csv"
+        )
+      end
+    end
   end
 end

--- a/app/presenters/csv_tree_presenter.rb
+++ b/app/presenters/csv_tree_presenter.rb
@@ -1,0 +1,17 @@
+require 'csv'
+
+class CsvTreePresenter
+  def initialize(tree)
+    @tree = tree
+  end
+
+  def present
+    CSV.generate do |csv|
+      @tree.each do |node|
+        row = [node.title]
+        node.node_depth.times { row.unshift nil }
+        csv << row
+      end
+    end
+  end
+end

--- a/app/views/taxonomies/show.html.erb
+++ b/app/views/taxonomies/show.html.erb
@@ -1,4 +1,9 @@
 <%= display_header title: '', breadcrumbs: [:taxons, @taxonomy.tree.first.title] do %>
+  <%= link_to taxonomy_path(@taxonomy.tree.first.content_id, format: :csv), class: "taxonomy-csv-download-btn" do %>
+    <i class="glyphicon glyphicon-download-alt"></i>
+      Download as CSV
+    </i>
+  <% end %>
 <% end %>
 
 <% @taxonomy.each do |tree_node| %>

--- a/spec/features/taxonomy_visualisation_spec.rb
+++ b/spec/features/taxonomy_visualisation_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe "Taxonomy visualisation" do
     then_i_see_the_entire_taxonomy
     when_i_view_one_of_the_children
     then_i_see_the_taxonomy_from_the_child_downwards
+    and_i_can_download_the_taxonomy_in_csv_form
   end
 
   scenario "Navigating multiple parents" do
@@ -113,5 +114,12 @@ RSpec.describe "Taxonomy visualisation" do
     within rendered_titles.first do
       expect(page).to have_content round_things["title"]
     end
+  end
+
+  def and_i_can_download_the_taxonomy_in_csv_form
+    click_link "Download as CSV"
+    expect(page.response_headers['Content-Type']).to match(/csv/)
+    expect(page.response_headers['Content-Disposition']).to match(/attachment/)
+    expect(page.response_headers['Content-Disposition']).to match(/Fruits.*.csv/)
   end
 end

--- a/spec/presenters/csv_tree_presenter_spec.rb
+++ b/spec/presenters/csv_tree_presenter_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe CsvTreePresenter do
+  describe "#present" do
+    let(:root_node) { TreeNode.new(title: "Root", content_id: "root-id") }
+    let(:child_node_1) { TreeNode.new(title: "Child-1", content_id: "child-1-id") }
+    let(:child_node_2) { TreeNode.new(title: "Child-2", content_id: "child-2-id") }
+    let(:child_node_3) { TreeNode.new(title: "Child-3", content_id: "child-3-id") }
+
+    before do
+      root_node << child_node_1
+      child_node_1 << child_node_2
+      child_node_1 << child_node_3
+    end
+
+    it "presents the tree in CSV form" do
+      presented = CsvTreePresenter.new(root_node).present
+
+      expect(presented.split("\n")).to eq %w(Root ,Child-1 ,,Child-2 ,,Child-3)
+    end
+  end
+end


### PR DESCRIPTION
Outputs a CSV in the format expected by TreeJack.

Shout out to @carvil for the feature spec code which tests CSV download. Basically just stole this from one of his PRs.

![content_tagger](https://cloud.githubusercontent.com/assets/519250/18131146/aae577bc-6f89-11e6-9aea-341b5fda7d7a.png)



![screen_shot_2016-08-31_at_14_14_37](https://cloud.githubusercontent.com/assets/519250/18130262/3862cb16-6f86-11e6-9043-55887a047ad4.png)
