### PR TITLE
Move taxon delete button

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,6 +1,7 @@
 @import 'select2';
 @import 'select2-bootstrap';
 @import 'govuk_admin_template';
+@import 'heading';
 @import 'import-preview';
 @import 'forms';
 @import 'taxonomy-viz';
@@ -41,22 +42,6 @@ $red: #b10e1e;
   // Remove this once we've migrated to using `simple_form`.
   label {
     display: none;
-  }
-}
-
-.heading-with-actions {
-  margin: 10px 0 20px;
-  overflow: hidden;
-
-  h1,
-  h2 {
-    float: left;
-    line-height: 1.4;
-    margin: 0;
-  }
-
-  .btn-group {
-    float: right;
   }
 }
 

--- a/app/assets/stylesheets/heading.scss
+++ b/app/assets/stylesheets/heading.scss
@@ -1,0 +1,16 @@
+.heading-with-actions {
+  margin: 10px 0 20px;
+  overflow: hidden;
+
+  h1,
+  h2 {
+    float: left;
+    line-height: 1.4;
+    margin: 0;
+  }
+
+  .btn-group {
+    float: right;
+  }
+}
+

--- a/app/views/taxons/index.html.erb
+++ b/app/views/taxons/index.html.erb
@@ -19,7 +19,6 @@
       <th></th>
       <th></th>
       <th></th>
-      <th></th>
     </tr>
 
     <%= render partial: 'shared/table_filter' %>
@@ -33,11 +32,6 @@
         <td><%= link_to 'View taxonomy', taxonomy_path(taxon.content_id) %></td>
         <td><%= link_to 'View tagged content', taxon_path(taxon.content_id), class: 'view-tagged-content' %></td>
         <td><%= link_to 'Edit taxon', edit_taxon_path(taxon.content_id) %></td>
-        <td><%= link_to 'Delete', taxon_path(taxon.content_id),
-            method: :delete,
-            data: { confirm: I18n.t('messages.views.confirm') },
-            class: 'btn btn-danger' %>
-        </td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -1,5 +1,7 @@
 <%= display_header title: taxon.title, breadcrumbs: [:taxons, taxon] do %>
-  <%= link_to taxon_path(taxon.content_id), method: :delete, data: { confirm: I18n.t('messages.views.confirm') } do %>
+  <%= link_to taxon_path(taxon.content_id), method: :delete,
+    class: 'btn btn-md btn-default',
+    data: { confirm: I18n.t('messages.views.confirm') } do %>
     <i class="glyphicon glyphicon-trash"></i>
       <%= I18n.t('views.taxons.delete_taxon') %>
     </i>

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -1,4 +1,13 @@
-<%= display_header title: taxon.title, breadcrumbs: [:taxons, taxon] %>
+<%= display_header title: taxon.title, breadcrumbs: [:taxons, taxon] do %>
+  <%= link_to taxon_path(taxon.content_id), method: :delete, data: { confirm: I18n.t('messages.views.confirm') } do %>
+    <i class="glyphicon glyphicon-trash"></i>
+      <%= I18n.t('views.taxons.delete_taxon') %>
+    </i>
+  <% end %>
+<% end %>
+
+<br/>
+<br/>
 
 <% if parent_taxons.any? %>
   <table class="table queries-list table-bordered table-striped" data-module="filterable-table">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,6 +21,7 @@ en:
     taxons:
       add_taxon: Add a taxon
       copy_taxon: Copy taxons
+      delete_taxon: Delete taxon
       new_title: New taxon
       new_breadcrumb: New taxon
       new_button: Create taxon


### PR DESCRIPTION
- Remove the button from the index page - was serving no real purpose
  being this prominent and made it a little too easy to delete a taxon.
- Add a delete button to taxon edit and show pages instead.

**Index page**

![taxons](https://cloud.githubusercontent.com/assets/519250/18135046/6827e748-6f98-11e6-8364-9bdced79e80e.png)

**Edit page**
![14_to_19_years](https://cloud.githubusercontent.com/assets/519250/18135098/9267a598-6f98-11e6-8b34-94a9ea78e97e.png)

**Show page**
![early_years_funding](https://cloud.githubusercontent.com/assets/519250/18135113/a604d8a0-6f98-11e6-81fa-4cfb39fcb50a.png)

