### PR TITLE
Display erroneous tag mappings at the top

### DIFF
--- a/app/controllers/tagging_spreadsheets_controller.rb
+++ b/app/controllers/tagging_spreadsheets_controller.rb
@@ -62,7 +62,10 @@ private
   end
 
   def tag_mappings
-    tagging_spreadsheet.tag_mappings.by_content_base_path.by_link_title
+    tagging_spreadsheet.tag_mappings
+      .by_state
+      .by_content_base_path
+      .by_link_title
   end
 
   def presented_tag_mappings

--- a/app/models/tag_mapping.rb
+++ b/app/models/tag_mapping.rb
@@ -3,6 +3,7 @@ class TagMapping < ActiveRecord::Base
   scope :completed, -> { where(state: %w(tagged errored)) }
   scope :by_content_base_path, -> { order(content_base_path: :asc) }
   scope :by_link_title, -> { order(link_title: :asc) }
+  scope :by_state, -> { order(state: :asc) }
 
   validates(
     :state,

--- a/app/views/tagging_spreadsheets/_import_preview.html.erb
+++ b/app/views/tagging_spreadsheets/_import_preview.html.erb
@@ -42,6 +42,6 @@
           </td>
         </tr>
       <% end %>
-    <tbody>
+    </tbody>
   </table>
 </div>


### PR DESCRIPTION
When multiple tag mappings fail for some reason, they are scattered all over the
table, which might contain hundreds of entries. This makes it harder to find out
what spreadsheet rows we need to fix.

This commit groups tag mappings by state, making sure all erroneous tag mappings
appear together and at the top.

It now looks like this:

![screen shot 2016-08-31 at 16 36 13](https://cloud.githubusercontent.com/assets/416701/18135228/19758d0c-6f99-11e6-8ff5-4702b9e87655.png)
