### PR TITLE
User Taxon objects as opposed to Hashes

### DIFF
--- a/app/controllers/copy_taxons_controller.rb
+++ b/app/controllers/copy_taxons_controller.rb
@@ -1,12 +1,11 @@
 class CopyTaxonsController < ApplicationController
   def index
-    taxons = taxon_fetcher.taxons.map { |taxon| Taxon.new(taxon) }
     render :index, locals: { taxons: taxons }
   end
 
 private
 
-  def taxon_fetcher
-    @taxon_fetcher ||= Taxonomy::TaxonFetcher.new
+  def taxons
+    @taxons ||= Taxonomy::TaxonFetcher.new.taxons
   end
 end

--- a/app/services/taxonomy/taxon_fetcher.rb
+++ b/app/services/taxonomy/taxon_fetcher.rb
@@ -4,20 +4,21 @@ module Taxonomy
     def taxons
       @taxons ||=
         Services.publishing_api.get_linkables(document_type: 'taxon')
-          .sort_by { |taxon| taxon["title"] }
+          .map { |taxon_hash| Taxon.new(taxon_hash) }
+          .sort_by(&:title)
     end
 
     def taxon_content_ids
-      taxons.map { |taxon| taxon['content_id'] }
+      taxons.map(&:content_id)
     end
 
     def taxons_for_select
-      taxons.map { |taxon| [taxon['title'], taxon['content_id']] }
+      taxons.map { |taxon| [taxon.title, taxon.content_id] }
     end
 
-    def parents_for_taxon(taxon)
-      taxons.select do |taxon_hash|
-        taxon.parent_taxons.include?(taxon_hash['content_id'])
+    def parents_for_taxon(taxon_child)
+      taxons.select do |taxon|
+        taxon_child.parent_taxons.include?(taxon.content_id)
       end
     end
   end

--- a/app/views/taxons/index.html.erb
+++ b/app/views/taxons/index.html.erb
@@ -28,12 +28,12 @@
   <tbody>
     <% taxons.each do |taxon| %>
       <tr>
-        <td><%= taxon['title'] %></td>
-        <td><%= link_to taxon['content_id'], "#{website_url('/api/content' + taxon['base_path'])}" %></td>
-        <td><%= link_to 'View taxonomy', taxonomy_path(taxon['content_id']) %></td>
-        <td><%= link_to 'View tagged content', taxon_path(taxon['content_id']), class: 'view-tagged-content' %></td>
-        <td><%= link_to 'Edit taxon', edit_taxon_path(taxon['content_id']) %></td>
-        <td><%= link_to 'Delete', taxon_path(taxon['content_id']),
+        <td><%= taxon.title %></td>
+        <td><%= link_to taxon.content_id, "#{website_url('/api/content' + taxon.base_path)}" %></td>
+        <td><%= link_to 'View taxonomy', taxonomy_path(taxon.content_id) %></td>
+        <td><%= link_to 'View tagged content', taxon_path(taxon.content_id), class: 'view-tagged-content' %></td>
+        <td><%= link_to 'Edit taxon', edit_taxon_path(taxon.content_id) %></td>
+        <td><%= link_to 'Delete', taxon_path(taxon.content_id),
             method: :delete,
             data: { confirm: I18n.t('messages.views.confirm') },
             class: 'btn btn-danger' %>

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -14,8 +14,8 @@
     <tbody>
       <% parent_taxons.each do |parent_taxon| %>
         <tr>
-          <td><%= link_to parent_taxon['title'], taxon_path(parent_taxon['content_id']) %></td>
-          <td><%= link_to parent_taxon['base_path'], "#{website_url('/api/content' + parent_taxon['base_path'])}" %></td>
+          <td><%= link_to parent_taxon.title, taxon_path(parent_taxon.content_id) %></td>
+          <td><%= link_to parent_taxon.base_path, "#{website_url('/api/content' + parent_taxon.base_path)}" %></td>
         </tr>
       <% end %>
     </tbody>

--- a/spec/matchers/taxon_matcher.rb
+++ b/spec/matchers/taxon_matcher.rb
@@ -1,0 +1,11 @@
+RSpec::Matchers.define :taxon_with_attributes do |expected|
+  match do |actual|
+    actual.title == expected[:title] &&
+      actual.base_path == expected[:base_path] &&
+      actual.content_id == expected[:content_id]
+  end
+
+  description do
+    "an object with attributes #{expected}"
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -14,6 +14,7 @@ require 'rspec/rails'
 require 'govuk_sidekiq/testing'
 
 Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
+Dir[Rails.root.join('spec/matchers/**/*.rb')].each { |f| require f }
 
 PUBLISHING_API = "https://publishing-api.test.gov.uk".freeze
 

--- a/spec/services/taxonomy/taxon_fetcher_spec.rb
+++ b/spec/services/taxonomy/taxon_fetcher_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe Taxonomy::TaxonFetcher do
 
       result = described_class.new.taxons
 
-      expect(result.first["title"]).to eq("aha")
-      expect(result.last["title"]).to eq("foo")
+      expect(result.first.title).to eq("aha")
+      expect(result.last.title).to eq("foo")
     end
   end
 
@@ -45,13 +45,13 @@ RSpec.describe Taxonomy::TaxonFetcher do
       instance_double(Taxon, parent_taxons: [taxon_id_1, taxon_id_2])
     end
     let(:link_1) do
-      { "title" => "foo", "base_path" => "/foo", "content_id" => taxon_id_1 }
+      { title: "foo", base_path: "/foo", content_id: taxon_id_1 }
     end
     let(:link_2) do
-      { "title" => "bar", "base_path" => "/bar", "content_id" => taxon_id_2 }
+      { title: "bar", base_path: "/bar", content_id: taxon_id_2 }
     end
     let(:link_3) do
-      { "title" => "aha", "base_path" => "/aha", "content_id" => SecureRandom.uuid }
+      { title: "aha", base_path: "/aha", content_id: SecureRandom.uuid }
     end
     let(:linkables) { [link_1, link_2, link_3] }
 
@@ -60,8 +60,8 @@ RSpec.describe Taxonomy::TaxonFetcher do
       result = described_class.new.parents_for_taxon(taxon)
 
       expect(result.count).to eq(2)
-      expect(result).to include(link_1)
-      expect(result).to include(link_2)
+      expect(result).to include(taxon_with_attributes(link_1))
+      expect(result).to include(taxon_with_attributes(link_2))
     end
   end
 end


### PR DESCRIPTION
We already have a model to represent a Taxon. Currently, we sometimes use the
model (e.g. from the TaxonBuilder service class), but in other situations (when
fetching taxons via the TaxonFetcher service class) we use Hashes.

This commit makes sure the method `taxons` in TaxonFetcher returns instances of
Taxons instead of hashes.