### PR TITLE
Add bulk tagging feature

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'plek', '~> 1.10'
 gem 'gds-sso', '~> 11.1'
 gem 'govuk_admin_template', '~> 4.1.1'
 gem 'simple_form', '~> 3.2', '>= 3.2.1'
-gem 'gds-api-adapters', '~> 32.3'
+gem 'gds-api-adapters', '~> 35.0'
 
 gem 'airbrake', '~> 4.3.1'
 

--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ end
 
 group :development do
   gem 'web-console', '~> 2.0'
+  gem "better_errors"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,10 @@ GEM
     ast (2.3.0)
     autoprefixer-rails (6.3.7)
       execjs
+    better_errors (2.1.1)
+      coderay (>= 1.0.0)
+      erubis (>= 2.6.6)
+      rack (>= 0.9.0)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
     bootstrap-sass (3.3.5.1)
@@ -329,6 +333,7 @@ PLATFORMS
 
 DEPENDENCIES
   airbrake (~> 4.3.1)
+  better_errors
   capybara
   factory_girl_rails
   gds-api-adapters (~> 32.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,7 +71,7 @@ GEM
     debug_inspector (0.0.2)
     diff-lcs (1.2.5)
     docile (1.1.5)
-    domain_name (0.5.20160615)
+    domain_name (0.5.20160826)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.7.0)
@@ -82,13 +82,13 @@ GEM
       railties (>= 3.0.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
-    gds-api-adapters (32.3.0)
+    gds-api-adapters (35.0.1)
       link_header
       lrucache (~> 0.1.1)
       null_logger
       plek (>= 1.9.0)
       rack-cache
-      rest-client (~> 1.8.0)
+      rest-client (~> 2.0)
     gds-sso (11.2.1)
       multi_json (~> 1.0)
       oauth2 (~> 1.0)
@@ -141,7 +141,9 @@ GEM
     mail (2.6.4)
       mime-types (>= 1.16, < 4)
     method_source (0.8.2)
-    mime-types (2.99.2)
+    mime-types (3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2016.0521)
     mini_portile2 (2.1.0)
     minitest (5.9.0)
     multi_json (1.12.1)
@@ -222,10 +224,10 @@ GEM
     redis-namespace (1.5.2)
       redis (~> 3.0, >= 3.0.4)
     request_store (1.3.1)
-    rest-client (1.8.0)
+    rest-client (2.0.0)
       http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 3.0)
-      netrc (~> 0.7)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rspec-core (3.5.0)
       rspec-support (~> 3.5.0)
     rspec-expectations (3.5.0)
@@ -336,7 +338,7 @@ DEPENDENCIES
   better_errors
   capybara
   factory_girl_rails
-  gds-api-adapters (~> 32.3)
+  gds-api-adapters (~> 35.0)
   gds-sso (~> 11.1)
   govuk-content-schema-test-helpers (~> 1.4)
   govuk-lint

--- a/README.md
+++ b/README.md
@@ -9,6 +9,19 @@ This is a Ruby on Rails application.
 It interacts with the publishing-api to manage the "links hash" for content on GOV.UK.
 It also allows the creation of new taxons, updating taxons and bulk-tagging.
 
+## Features
+
+### Bulk Tagging
+
+The bulk tagging feature allows us to search for existing content items via
+their collections, and apply taxon links in bulk to them.
+
+Please note that the search functionality has some restrictions. When a user
+searches for a collection, if the search is too broad, we will only show the top
+20 results on the search page. Currently, we do not paginate through the search
+results. Instead, we ask the user to be more specific in the search query in
+order to find the collection they are looking for.
+
 ## Screenshots
 
 ![Homepage](docs/screenshot-homepage.png)

--- a/app/controllers/bulk_tagging/collections_controller.rb
+++ b/app/controllers/bulk_tagging/collections_controller.rb
@@ -1,0 +1,15 @@
+module BulkTagging
+  class CollectionsController < ApplicationController
+    def show
+      expanded_links = ExpandedLinksFetcher.expanded_links(params[:content_id])
+      taxons = Taxonomy::TaxonFetcher.new.taxons
+
+      render :show, locals: {
+        bulk_tagging: TagMigration.new,
+        content_id: params[:content_id],
+        taxons: taxons,
+        expanded_links: expanded_links
+      }
+    end
+  end
+end

--- a/app/controllers/bulk_tagging/update_tags_controller.rb
+++ b/app/controllers/bulk_tagging/update_tags_controller.rb
@@ -1,0 +1,30 @@
+module BulkTagging
+  class UpdateTagsController < ApplicationController
+    def create
+      tag_migration.save!
+      redirect_to tag_migration_path(tag_migration)
+
+    rescue BulkTagging::BuildTagMigration::InvalidArgumentError => e
+      flash[:error] = e.message
+      redirect_to bulk_tagging_collection_path(params[:collection_content_id])
+    end
+
+  private
+
+    def tag_migration
+      @tag_migration ||= BulkTagging::BuildTagMigration.perform(
+        original_link_content_id: params[:collection_content_id],
+        taxon_content_ids: taxon_content_ids,
+        content_base_paths: content_base_paths
+      )
+    end
+
+    def taxon_content_ids
+      params[:taxons]
+    end
+
+    def content_base_paths
+      params[:content_base_paths]
+    end
+  end
+end

--- a/app/controllers/bulk_taggings_controller.rb
+++ b/app/controllers/bulk_taggings_controller.rb
@@ -1,0 +1,24 @@
+class BulkTaggingsController < ApplicationController
+  def new
+    render :new, locals: { results: [] }
+  end
+
+  def search
+    query = params[:collection_search][:query]
+    gds_response = Services.publishing_api.get_content_items(
+      document_type: "document_collection",
+      per_page: 20,
+      q: query
+    )
+
+    results = gds_response['results'].map { |result| ContentItem.new(result) }
+
+    render :new, locals: { results: results }
+  end
+
+  private
+
+  def search_params
+    params.require(:collection_search).permit(:query)
+  end
+end

--- a/app/controllers/tag_migrations_controller.rb
+++ b/app/controllers/tag_migrations_controller.rb
@@ -1,0 +1,56 @@
+class TagMigrationsController < ApplicationController
+  def show
+    render :show, locals: {
+      tag_migration: tag_migration,
+      tag_mappings: presented_tag_mappings,
+      confirmed: tag_mappings.completed.count,
+      progress_path: tag_migration_import_progress_path(tag_migration),
+    }
+  end
+
+  def publish_tags
+    TagImporter::PublishTags.new(tag_migration, user: current_user).run
+
+    # TODO update message
+    redirect_to tag_migration, success: I18n.t('tag_import.import_started')
+  end
+
+  def index
+    render :index, locals: { tag_migrations: presented_tag_migrations }
+  end
+
+  # TODO: update message
+  def destroy
+    tag_migration.mark_as_deleted
+    redirect_to tag_migrations_path, success: I18n.t('tag_import.import_removed')
+  end
+
+private
+
+  def tag_migrations
+    TagMigration.active.newest_first
+  end
+
+  def presented_tag_migrations
+    tag_migrations.map do |tag_migration|
+      TagMigrationPresenter.new(tag_migration)
+    end
+  end
+
+  def tag_migration
+    tag_migration = TagMigration.find(params[:id] || params.fetch(:tag_migration_id))
+  end
+
+  def tag_mappings
+    tag_migration.tag_mappings
+      .by_state
+      .by_content_base_path
+      .by_link_title
+  end
+
+  def presented_tag_mappings
+    tag_mappings.map do |tag_mapping|
+      TagMappingPresenter.new(tag_mapping)
+    end
+  end
+end

--- a/app/controllers/tag_migrations_controller.rb
+++ b/app/controllers/tag_migrations_controller.rb
@@ -11,18 +11,22 @@ class TagMigrationsController < ApplicationController
   def publish_tags
     TagImporter::PublishTags.new(tag_migration, user: current_user).run
 
-    # TODO update message
-    redirect_to tag_migration, success: I18n.t('tag_import.import_started')
+    redirect_to(
+      tag_migration,
+      success: I18n.t('controllers.tag_migrations.import_started')
+    )
   end
 
   def index
     render :index, locals: { tag_migrations: presented_tag_migrations }
   end
 
-  # TODO: update message
   def destroy
     tag_migration.mark_as_deleted
-    redirect_to tag_migrations_path, success: I18n.t('tag_import.import_removed')
+    redirect_to(
+      tag_migrations_path,
+      success: I18n.t('controllers.tag_migrations.import_removed')
+    )
   end
 
 private
@@ -38,7 +42,8 @@ private
   end
 
   def tag_migration
-    tag_migration = TagMigration.find(params[:id] || params.fetch(:tag_migration_id))
+    @tag_migration ||=
+      TagMigration.find(params[:id] || params.fetch(:tag_migration_id))
   end
 
   def tag_mappings

--- a/app/controllers/tagging_spreadsheets_controller.rb
+++ b/app/controllers/tagging_spreadsheets_controller.rb
@@ -26,6 +26,7 @@ class TaggingSpreadsheetsController < ApplicationController
       tagging_spreadsheet: tagging_spreadsheet,
       tag_mappings: presented_tag_mappings,
       confirmed: tag_mappings.completed.count,
+      progress_path: tagging_spreadsheet_import_progress_path(tagging_spreadsheet),
     }
   end
 

--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -58,9 +58,9 @@ private
 
   def destroy_flash_message(response_code)
     if response_code == 200
-      { success: I18n.t('messages.controller.taxons.success') }
+      { success: I18n.t('controllers.taxons.success') }
     else
-      { alert: I18n.t('messages.controller.taxons.alert') }
+      { alert: I18n.t('controllers.taxons.alert') }
     end
   end
 

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -7,7 +7,7 @@ class ContentItem
     @content_id = data.fetch('content_id')
     @title = data.fetch('title')
     @base_path = data.fetch('base_path')
-    @publishing_app = data.fetch('publishing_app')
+    @publishing_app = data.fetch('publishing_app', nil)
     @document_type = data.fetch('document_type')
   end
 

--- a/app/models/search_response.rb
+++ b/app/models/search_response.rb
@@ -11,10 +11,6 @@ class SearchResponse
     gds_api_response_hash['results'].map { |result| ContentItem.new(result) }
   end
 
-  def successful?
-    gds_api_response.code == 200
-  end
-
   def multiple_pages?
     gds_api_response_hash['pages'] > 1
   end

--- a/app/models/search_response.rb
+++ b/app/models/search_response.rb
@@ -1,0 +1,21 @@
+class SearchResponse
+  attr_reader :gds_api_response, :gds_api_response_hash, :document_type
+
+  def initialize(gds_api_response, document_type)
+    @gds_api_response = gds_api_response
+    @gds_api_response_hash = gds_api_response.to_hash
+    @document_type = document_type
+  end
+
+  def results
+    gds_api_response_hash['results'].map { |result| ContentItem.new(result) }
+  end
+
+  def successful?
+    gds_api_response.code == 200
+  end
+
+  def multiple_pages?
+    gds_api_response_hash['pages'] > 1
+  end
+end

--- a/app/models/tag_mapping.rb
+++ b/app/models/tag_mapping.rb
@@ -1,5 +1,6 @@
 class TagMapping < ActiveRecord::Base
-  belongs_to :tagging_spreadsheet
+  belongs_to :tagging_source, polymorphic: true
+
   scope :completed, -> { where(state: %w(tagged errored)) }
   scope :by_content_base_path, -> { order(content_base_path: :asc) }
   scope :by_link_title, -> { order(link_title: :asc) }

--- a/app/models/tag_migration.rb
+++ b/app/models/tag_migration.rb
@@ -1,4 +1,4 @@
 class TagMigration < ActiveRecord::Base
-  has_many :tag_mappings, dependent: :delete_all, as: :tagging_source
+  has_many :tag_mappings, dependent: :destroy, as: :tagging_source
   validates :original_link_content_id, presence: true
 end

--- a/app/models/tag_migration.rb
+++ b/app/models/tag_migration.rb
@@ -1,4 +1,17 @@
 class TagMigration < ActiveRecord::Base
   has_many :tag_mappings, dependent: :destroy, as: :tagging_source
   validates :original_link_content_id, presence: true
+
+  validates(
+    :state,
+    presence: true,
+    inclusion: { in: %w(ready_to_import imported) }
+  )
+
+  scope :newest_first, -> { order(created_at: :desc) }
+  scope :active, -> { where(deleted_at: nil) }
+
+  def mark_as_deleted
+    update!(deleted_at: DateTime.current)
+  end
 end

--- a/app/models/tag_migration.rb
+++ b/app/models/tag_migration.rb
@@ -1,0 +1,4 @@
+class TagMigration < ActiveRecord::Base
+  has_many :tag_mappings, dependent: :delete_all, as: :tagging_source
+  validates :original_link_content_id, presence: true
+end

--- a/app/models/tagging_spreadsheet.rb
+++ b/app/models/tagging_spreadsheet.rb
@@ -7,7 +7,7 @@ class TaggingSpreadsheet < ActiveRecord::Base
   )
   validates_with GoogleUrlValidator
 
-  has_many :tag_mappings, dependent: :delete_all
+  has_many :tag_mappings, dependent: :destroy, as: :tagging_source
   has_one :added_by, class_name: "User", primary_key: :user_uid, foreign_key: :uid
 
   scope :newest_first, -> { order(created_at: :desc) }

--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -4,7 +4,8 @@ class Taxon
                 :content_id,
                 :base_path,
                 :publication_state,
-                :internal_name
+                :internal_name,
+                :document_type
 
   include ActiveModel::Model
 

--- a/app/presenters/tag_migration_presenter.rb
+++ b/app/presenters/tag_migration_presenter.rb
@@ -1,0 +1,11 @@
+class TagMigrationPresenter < SimpleDelegator
+  def label_type
+    {
+      imported: 'label-success'
+    }.fetch(state.to_sym, 'label-warning')
+  end
+
+  def state_title
+    state.humanize
+  end
+end

--- a/app/services/bulk_tagging/build_tag_mapping.rb
+++ b/app/services/bulk_tagging/build_tag_mapping.rb
@@ -1,0 +1,24 @@
+module BulkTagging
+  class BuildTagMapping
+    attr_reader :taxon, :content_base_path
+
+    def initialize(taxon:, content_base_path:)
+      @taxon = taxon
+      @content_base_path = content_base_path
+    end
+
+    def self.perform(taxon:, content_base_path:)
+      new(taxon: taxon, content_base_path: content_base_path).perform
+    end
+
+    def perform
+      TagMapping.new(
+        content_base_path: content_base_path,
+        link_title:        taxon.title,
+        link_content_id:   taxon.content_id,
+        link_type:         taxon.link_type,
+        state:             'ready_to_tag'
+      )
+    end
+  end
+end

--- a/app/services/bulk_tagging/build_tag_migration.rb
+++ b/app/services/bulk_tagging/build_tag_migration.rb
@@ -1,0 +1,69 @@
+module BulkTagging
+  class BuildTagMigration
+    class InvalidArgumentError < ArgumentError; end
+
+    attr_reader :original_link_content_id, :taxon_content_ids, :content_base_paths
+
+    def initialize(original_link_content_id:, taxon_content_ids:, content_base_paths:)
+      @original_link_content_id = original_link_content_id
+      @taxon_content_ids = taxon_content_ids
+      @content_base_paths = content_base_paths
+    end
+
+    def self.perform(original_link_content_id:, taxon_content_ids:, content_base_paths:)
+      new(
+        original_link_content_id: original_link_content_id,
+        taxon_content_ids: taxon_content_ids,
+        content_base_paths: content_base_paths
+      ).perform
+    end
+
+    def perform
+      validate_taxons
+      validate_content_items
+
+      taxon_content_ids.each do |taxon_content_id|
+        expected_taxon = taxons.find { |taxon| taxon.content_id == taxon_content_id }
+        create_tag_mappings_for_taxon(expected_taxon)
+      end
+
+      tag_migration
+    end
+
+  private
+
+    def validate_taxons
+      return if taxon_content_ids.present?
+
+      raise InvalidArgumentError, I18n.t('bulk_tagging.update_tags.no_taxons')
+    end
+
+    def validate_content_items
+      return if content_base_paths.present?
+
+      raise InvalidArgumentError, I18n.t('bulk_tagging.update_tags.no_content_items')
+    end
+
+    def tag_migration
+      @tag_migration ||= TagMigration.new(
+        state: 'ready_to_import',
+        original_link_content_id: original_link_content_id
+      )
+    end
+
+    def create_tag_mappings_for_taxon(taxon)
+      content_base_paths.each do |content_base_path|
+        tag_mapping = BulkTagging::BuildTagMapping.perform(
+          taxon: taxon,
+          content_base_path: content_base_path
+        )
+
+        tag_migration.tag_mappings << tag_mapping
+      end
+    end
+
+    def taxons
+      @taxons ||= Taxonomy::TaxonFetcher.new.taxons
+    end
+  end
+end

--- a/app/services/bulk_tagging/search.rb
+++ b/app/services/bulk_tagging/search.rb
@@ -1,0 +1,28 @@
+module BulkTagging
+  class Search
+    attr_reader :query, :document_type
+
+    def initialize(query:, document_type:)
+      @query = query
+      @document_type = document_type
+    end
+
+    def self.perform(query:, document_type: "document_collection")
+      new(query: query, document_type: document_type).perform
+    end
+
+    def perform
+      SearchResponse.new(gds_response, document_type)
+    end
+
+  private
+
+    def gds_response
+      Services.publishing_api.get_content_items(
+        document_type: document_type,
+        per_page: 20,
+        q: query
+      )
+    end
+  end
+end

--- a/app/services/expanded_links_fetcher.rb
+++ b/app/services/expanded_links_fetcher.rb
@@ -1,0 +1,7 @@
+class ExpandedLinksFetcher
+  def self.expanded_links(content_id)
+    gds_response = Services.publishing_api.get_expanded_links(content_id)
+    documents = gds_response['expanded_links']['documents']
+    documents.map { |result| ContentItem.new(result) }
+  end
+end

--- a/app/services/tag_importer/publish_tags.rb
+++ b/app/services/tag_importer/publish_tags.rb
@@ -6,7 +6,7 @@ module TagImporter
 
     def initialize(tagging_spreadsheet, user:)
       @tagging_spreadsheet = tagging_spreadsheet
-      @tag_mappings = tagging_spreadsheet.tag_mappings
+      @tag_mappings = tagging_spreadsheet.tag_mappings.order(id: :asc)
       @user = user
     end
 

--- a/app/views/application/_import_preview.html.erb
+++ b/app/views/application/_import_preview.html.erb
@@ -4,7 +4,7 @@
   <div data-module="import-progress">
     <% if tag_mappings.any? %>
       <%= render partial: "import_progress_bar",
-        locals: { tag_mappings: tag_mappings, confirmed: confirmed } %>
+        locals: { tag_mappings: tag_mappings, confirmed: confirmed, progress_path: progress_path } %>
     <% end %>
   </div>
 

--- a/app/views/application/_import_progress_bar.html.erb
+++ b/app/views/application/_import_progress_bar.html.erb
@@ -1,8 +1,6 @@
 <% total = tag_mappings.count %>
 <% percentage_complete = Integer((confirmed / total.to_f) * 100) %>
-<div
-  class="js-import-progress"
-  data-progress-path="<%= tagging_spreadsheet_import_progress_path(tag_mappings.first.tagging_source) %>">
+<div class="js-import-progress" data-progress-path="<%= progress_path %>">
 
   <div class="progress">
     <div class="progress-bar <%= percentage_complete == 100 ? '' : 'progress-bar-striped active'%>"

--- a/app/views/bulk_tagging/collections/show.html.erb
+++ b/app/views/bulk_tagging/collections/show.html.erb
@@ -1,0 +1,42 @@
+<%= simple_form_for bulk_tagging,
+  url: bulk_tagging_collection_update_tags_path(content_id), method: :post do |f| %>
+  <% if flash[:error].present? %>
+    <div class="alert alert-danger" role="alert">
+      <%= flash[:error] %>
+    </div>
+  <% end %>
+  <div class='row'>
+    <div class='col-md-4'>
+      <div class="form-group">
+        <h3>Taxons</h3>
+        <%= select_tag :taxons,
+          options_from_collection_for_select(taxons, 'content_id', 'title'),
+          multiple: true,
+          class: :select2 %>
+      </div>
+      <%= f.submit "Bulk tag selected items", class: 'btn btn-md btn-success' %>
+    </div>
+    <div class='col-md-8'>
+      <h3>Content Items</h3>
+      <table class="table queries-list table-bordered" data-module="filterable-table">
+        <thead>
+          <tr class="table-header">
+            <th>Select</th>
+            <th>Title</th>
+            <th>Content ID</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% expanded_links.each do |expanded_link| %>
+            <tr>
+              <td><%= check_box_tag 'content_base_paths[]', expanded_link.base_path, true %></td>
+              <td><%= link_to expanded_link.title, website_url('/api/content' + expanded_link.base_path) %></td>
+              <td><%= link_to expanded_link.content_id,
+                "#{website_url('/api/content' + expanded_link.base_path)}" %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+<% end %>

--- a/app/views/bulk_taggings/new.html.erb
+++ b/app/views/bulk_taggings/new.html.erb
@@ -4,7 +4,9 @@
   <div class="col-md-4">
     <%= simple_form_for :collection_search, url: search_bulk_tagging_path , method: :get do |f| %>
       <div class="form-group">
-        <%= f.input :query, input_html: { type: :text, class: 'form-control' }, label: 'Query' %>
+        <%= f.input :query,
+          input_html: { type: :text, class: 'form-control', value: query },
+          label: 'Query'%>
         <%= f.submit "Search collection", class: "btn btn-md btn-success" %>
       </div>
     <% end %>

--- a/app/views/bulk_taggings/new.html.erb
+++ b/app/views/bulk_taggings/new.html.erb
@@ -1,0 +1,38 @@
+<%= display_header title: 'Bulk tagging', breadcrumbs: ["Search"] %>
+
+<div class="row">
+  <div class="col-md-4">
+    <%= simple_form_for :collection_search, url: search_bulk_tagging_path , method: :get do |f| %>
+      <div class="form-group">
+        <%= f.input :query, input_html: { type: :text, class: 'form-control' }, label: 'Query' %>
+        <%= f.submit "Search collection", class: "btn btn-md btn-success" %>
+      </div>
+    <% end %>
+  </div>
+  <div class="col-md-8">
+    <table class="table queries-list table-bordered" data-module="filterable-table">
+      <thead>
+        <tr class="table-header">
+          <th>Title</th>
+          <th>Content ID</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% if results.present? %>
+          <% results.each do |collection| %>
+            <tr>
+              <td><%= collection.title %></td>
+              <td><%= link_to collection.content_id,
+                    bulk_tagging_collection_path(collection.content_id) %></td>
+            </tr>
+          <% end %>
+        <% else %>
+            <tr>
+              <td><p>No results to display. Search to see results.</p></td>
+              <td></td>
+            </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,6 +14,12 @@
   <li class='<%= active_navigation_item == 'tagging_spreadsheets' ? 'active' : nil %>'>
     <%= link_to 'Tag Importer', tagging_spreadsheets_path %>
   </li>
+  <li class='<%= request.fullpath.starts_with?('/bulk_tagging') ? 'active' : nil %>'>
+    <%= link_to 'Bulk Tagging', new_bulk_tagging_path %>
+  </li>
+  <li class='<%= active_navigation_item == 'tag_migrations' ? 'active' : nil %>'>
+    <%= link_to 'Tag Migration', tag_migrations_path %>
+  </li>
 <% end %>
 
 <%= render template: 'layouts/govuk_admin_template' %>

--- a/app/views/tag_migrations/_migration_preview.html.erb
+++ b/app/views/tag_migrations/_migration_preview.html.erb
@@ -1,0 +1,47 @@
+<div class="import-preview">
+  <br/>
+
+  <div data-module="import-progress">
+    <% if tag_mappings.any? %>
+      <%= render partial: "import_progress_bar",
+        locals: { tag_mappings: tag_mappings, confirmed: confirmed, progress_path: progress_path } %>
+    <% end %>
+  </div>
+
+  <table class="table queries-list table-bordered table-striped" data-module="filterable-table">
+    <thead>
+      <tr>
+        <th>Page</th>
+        <th>Will be tagged to</th>
+        <th>Tag created?</th>
+      </tr>
+
+      <%= render partial: 'shared/table_filter' %>
+    </thead>
+
+    <tbody>
+      <% tag_mappings.each do |tag| %>
+        <tr>
+          <td><%= link_to tag.content_base_path, website_url(tag.content_base_path) %></td>
+          <td>
+            <%= link_to tag.link_title, tagging_path(tag.link_content_id) %> (<%= tag.link_type %>)
+
+            <% if tag.errored? %>
+              <hr />
+              <span class="error-message">
+                <ul>
+                  <% tag.error_messages.each do |error_message| %>
+                  <li><%= error_message %></li>
+                  <% end %>
+                </ul>
+              </span>
+            <% end %>
+          </td>
+          <td class="tag-mapping-status">
+            <%= state_label_for(label_type: tag.label_type, title: tag.state_title) %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/tag_migrations/index.html.erb
+++ b/app/views/tag_migrations/index.html.erb
@@ -1,0 +1,35 @@
+<%= display_header title: 'Tag Migrations', breadcrumbs: ['Bulk Tagging'] do %>
+  <%= link_to 'New tag migration', new_bulk_tagging_path, class: 'btn btn-default' %>
+<% end %>
+
+<table class="table queries-list table-bordered table-striped" data-module="filterable-table">
+  <thead>
+    <tr>
+      <th>State</th>
+      <th>Original content id</th>
+      <th>Date added</th>
+      <th></th>
+      <th></th>
+    </tr>
+    <%= render partial: 'shared/table_filter' %>
+  </thead>
+  <tbody>
+    <% tag_migrations.each do |tag_migration| %>
+      <tr>
+        <td><%= state_label_for(label_type: tag_migration.label_type,
+                                title: tag_migration.state_title) %></td>
+        <td><%= tag_migration.original_link_content_id %></td>
+        <td>
+          <%= time_tag_for(tag_migration.created_at) %>
+        </td>
+        <td>
+          <%= link_to "Preview", tag_migration_path(tag_migration) %>
+        </td>
+        <td>
+          <%= link_to "Delete", tag_migration_path(tag_migration),
+            method: :delete, class: "btn btn-danger btn-sm" %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/tag_migrations/show.html.erb
+++ b/app/views/tag_migrations/show.html.erb
@@ -1,0 +1,14 @@
+<%= display_header title: 'Preview import', breadcrumbs: [:tag_migrations, "Preview"] do %>
+  <%= link_to "Create tags", tag_migration_publish_tags_path(tag_migration), method: :post, class: "btn btn-md btn-default" %>
+<% end %>
+
+<% if tag_migration.state == "errored" %>
+  <p class="alert alert-danger">
+    An error occured when attempting to read the spreadsheet:
+
+    <%= "TODO: error messages" %>
+  </p>
+<% else %>
+  <%= render partial: "migration_preview",
+    locals: { confirmed: confirmed, tag_mappings: tag_mappings, progress_path: progress_path } %>
+<% end %>

--- a/app/views/tagging_spreadsheets/_import_progress_bar.html.erb
+++ b/app/views/tagging_spreadsheets/_import_progress_bar.html.erb
@@ -2,7 +2,7 @@
 <% percentage_complete = Integer((confirmed / total.to_f) * 100) %>
 <div
   class="js-import-progress"
-  data-progress-path="<%= tagging_spreadsheet_import_progress_path(tag_mappings.first.tagging_spreadsheet) %>">
+  data-progress-path="<%= tagging_spreadsheet_import_progress_path(tag_mappings.first.tagging_source) %>">
 
   <div class="progress">
     <div class="progress-bar <%= percentage_complete == 100 ? '' : 'progress-bar-striped active'%>"

--- a/app/views/tagging_spreadsheets/show.html.erb
+++ b/app/views/tagging_spreadsheets/show.html.erb
@@ -15,5 +15,5 @@
   </div>
 
   <%= render partial: "import_preview",
-    locals: { confirmed: confirmed, tag_mappings: tag_mappings } %>
+    locals: { confirmed: confirmed, tag_mappings: tag_mappings, progress_path: progress_path } %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,11 +30,16 @@ en:
       new_breadcrumb: New taxon
       new_button: Create taxon
       edit_button: Update taxon
-  messages:
-    controller:
-      taxons:
-        success: You have sucessfully deleted the taxon
-        alert: It was not possible to delete the taxon
+  controllers:
+    bulk_taggings:
+      too_many_results: Your search returned too many results. We are only displaying a subset, please try narrowing down your search.
+      failure: We could not perform search, please try again.
+    tag_migrations:
+      import_started: The tag migration import has started. It can take a few minutes for the tags to be published.
+      import_removed: Tag migration import has been removed.
+    taxons:
+      success: You have sucessfully deleted the taxon
+      alert: It was not possible to delete the taxon
     views:
       confirm: Are you sure?
   panels:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -15,6 +15,10 @@ en:
       invalid_content_id: We could not find this URL on GOV.UK.
       invalid_link_types: Invalid link types found - only taxons are allowed.
       invalid_taxons_found: Invalid taxons found - please make sure you only use existing taxons when tagging.
+  bulk_tagging:
+    update_tags:
+      no_taxons: No taxons selected.
+      no_content_items: No content items selected.
   views:
     callout_new: Creating
     callout_edit: Editing

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,21 @@ Rails.application.routes.draw do
     get  'import_progress'
   end
 
+  resources :tag_migrations, only: %i(index show create) do
+    post 'publish_tags'
+    get  'import_progress'
+  end
+
+  resource :bulk_tagging do
+    get 'search' => 'bulk_taggings#search'
+  end
+
+  namespace :bulk_tagging do
+    resources :collections, only: :show, param: :content_id do
+      resources :update_tags, only: :create
+    end
+  end
+
   get '/healthcheck', to: proc { [200, {}, ['OK']] }
 
   resources :taxonomies, only: %i(show), param: :content_id

--- a/db/migrate/20160902132101_make_tag_mapping_polymorphic.rb
+++ b/db/migrate/20160902132101_make_tag_mapping_polymorphic.rb
@@ -1,0 +1,12 @@
+class MakeTagMappingPolymorphic < ActiveRecord::Migration
+  def change
+    rename_column :tag_mappings, :tagging_spreadsheet_id, :tagging_source_id
+    add_column :tag_mappings, :tagging_source_type, :string
+
+    TagMapping.transaction do
+      TagMapping.all.each do |tag_mapping|
+        tag_mapping.update!(taggable_type: 'TaggingSpreadsheet')
+      end
+    end
+  end
+end

--- a/db/migrate/20160902140349_create_tag_migrations.rb
+++ b/db/migrate/20160902140349_create_tag_migrations.rb
@@ -1,0 +1,7 @@
+class CreateTagMigrations < ActiveRecord::Migration
+  def change
+    create_table :tag_migrations do |t|
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20160902153728_add_original_link_content_id_to_tag_migrations.rb
+++ b/db/migrate/20160902153728_add_original_link_content_id_to_tag_migrations.rb
@@ -1,0 +1,5 @@
+class AddOriginalLinkContentIdToTagMigrations < ActiveRecord::Migration
+  def change
+    add_column :tag_migrations, :original_link_content_id, :string
+  end
+end

--- a/db/migrate/20160905103610_delete_foreign_key_in_tag_mappings.rb
+++ b/db/migrate/20160905103610_delete_foreign_key_in_tag_mappings.rb
@@ -1,0 +1,5 @@
+class DeleteForeignKeyInTagMappings < ActiveRecord::Migration
+  def change
+    remove_foreign_key :tag_mappings, column: :tagging_source_id
+  end
+end

--- a/db/migrate/20160905114421_add_state_to_tag_migration.rb
+++ b/db/migrate/20160905114421_add_state_to_tag_migration.rb
@@ -1,0 +1,5 @@
+class AddStateToTagMigration < ActiveRecord::Migration
+  def change
+    add_column :tag_migrations, :state, :string
+  end
+end

--- a/db/migrate/20160905134833_add_last_published_timestamp_fields_to_tag_migration.rb
+++ b/db/migrate/20160905134833_add_last_published_timestamp_fields_to_tag_migration.rb
@@ -1,0 +1,6 @@
+class AddLastPublishedTimestampFieldsToTagMigration < ActiveRecord::Migration
+  def change
+    add_column :tag_migrations, :last_published_at, :datetime
+    add_column :tag_migrations, :last_published_by, :string
+  end
+end

--- a/db/migrate/20160905162106_add_deleted_at_to_tag_migrations.rb
+++ b/db/migrate/20160905162106_add_deleted_at_to_tag_migrations.rb
@@ -1,0 +1,5 @@
+class AddDeletedAtToTagMigrations < ActiveRecord::Migration
+  def change
+    add_column :tag_migrations, :deleted_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160815093345) do
+ActiveRecord::Schema.define(version: 20160902153728) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -32,6 +32,12 @@ ActiveRecord::Schema.define(version: 20160815093345) do
 
   add_index "tag_mappings", ["tagging_spreadsheet_id"], name: "index_tag_mappings_on_tagging_spreadsheet_id", using: :btree
 
+  create_table "tag_migrations", force: :cascade do |t|
+    t.datetime "created_at",               null: false
+    t.datetime "updated_at",               null: false
+    t.string   "original_link_content_id"
+  end
+
   create_table "tagging_spreadsheets", force: :cascade do |t|
     t.string   "url",               null: false
     t.datetime "created_at",        null: false
@@ -39,9 +45,13 @@ ActiveRecord::Schema.define(version: 20160815093345) do
     t.string   "user_uid",          null: false
     t.string   "last_published_by"
     t.datetime "last_published_at"
+    t.string   "description"
     t.string   "state",             null: false
     t.text     "error_message"
+<<<<<<< HEAD
     t.string   "description"
+=======
+>>>>>>> 66756b0... Create TagMigration model
     t.datetime "deleted_at"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160905103610) do
+ActiveRecord::Schema.define(version: 20160905162106) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -37,6 +37,10 @@ ActiveRecord::Schema.define(version: 20160905103610) do
     t.datetime "created_at",               null: false
     t.datetime "updated_at",               null: false
     t.string   "original_link_content_id"
+    t.string   "state"
+    t.datetime "last_published_at"
+    t.string   "last_published_by"
+    t.datetime "deleted_at"
   end
 
   create_table "tagging_spreadsheets", force: :cascade do |t|
@@ -49,15 +53,7 @@ ActiveRecord::Schema.define(version: 20160905103610) do
     t.string   "description"
     t.string   "state",             null: false
     t.text     "error_message"
-<<<<<<< HEAD
-<<<<<<< HEAD
-    t.string   "description"
-=======
->>>>>>> 66756b0... Create TagMigration model
-=======
->>>>>>> e0a3806... Convert TagMapping into a polymorphic relation
     t.datetime "deleted_at"
-    t.string   "description"
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,26 +11,27 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160902153728) do
+ActiveRecord::Schema.define(version: 20160905103610) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "tag_mappings", force: :cascade do |t|
-    t.integer  "tagging_spreadsheet_id", null: false
-    t.string   "content_base_path",      null: false
+    t.integer  "tagging_source_id",    null: false
+    t.string   "content_base_path",    null: false
     t.string   "link_title"
-    t.string   "link_content_id",        null: false
-    t.string   "link_type",              null: false
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
+    t.string   "link_content_id",      null: false
+    t.string   "link_type",            null: false
+    t.datetime "created_at",           null: false
+    t.datetime "updated_at",           null: false
     t.datetime "publish_requested_at"
     t.datetime "publish_completed_at"
-    t.string   "state",                  null: false
+    t.string   "state",                null: false
     t.string   "message"
+    t.string   "tagging_source_type"
   end
 
-  add_index "tag_mappings", ["tagging_spreadsheet_id"], name: "index_tag_mappings_on_tagging_spreadsheet_id", using: :btree
+  add_index "tag_mappings", ["tagging_source_id"], name: "index_tag_mappings_on_tagging_source_id", using: :btree
 
   create_table "tag_migrations", force: :cascade do |t|
     t.datetime "created_at",               null: false
@@ -49,10 +50,14 @@ ActiveRecord::Schema.define(version: 20160902153728) do
     t.string   "state",             null: false
     t.text     "error_message"
 <<<<<<< HEAD
+<<<<<<< HEAD
     t.string   "description"
 =======
 >>>>>>> 66756b0... Create TagMigration model
+=======
+>>>>>>> e0a3806... Convert TagMapping into a polymorphic relation
     t.datetime "deleted_at"
+    t.string   "description"
   end
 
   create_table "users", force: :cascade do |t|
@@ -68,5 +73,4 @@ ActiveRecord::Schema.define(version: 20160902153728) do
     t.datetime "updated_at",              null: false
   end
 
-  add_foreign_key "tag_mappings", "tagging_spreadsheets", on_delete: :cascade
 end

--- a/spec/factories/tag_mapping.rb
+++ b/spec/factories/tag_mapping.rb
@@ -3,7 +3,7 @@ FactoryGirl.define do
     content_base_path 'a/base/path'
     link_content_id 'a-content-id'
     link_type 'taxon'
-    tagging_spreadsheet
+    association :tagging_source, factory: :tagging_spreadsheet
     state 'ready_to_tag'
   end
 end

--- a/spec/factories/tag_migration.rb
+++ b/spec/factories/tag_migration.rb
@@ -1,5 +1,6 @@
 FactoryGirl.define do
-  factory :bulk_tagging do
-    taggable nil
+  factory :tag_migration do
+    original_link_content_id 'original-content-id'
+    state 'ready_to_import'
   end
 end

--- a/spec/factories/tag_migration.rb
+++ b/spec/factories/tag_migration.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :bulk_tagging do
+    taggable nil
+  end
+end

--- a/spec/factories/taxon.rb
+++ b/spec/factories/taxon.rb
@@ -1,0 +1,10 @@
+FactoryGirl.define do
+  factory :taxon do
+    title 'A taxon'
+    parent_taxons []
+    content_id 'taxon-content-id'
+    base_path '/taxon-base-path'
+    publication_state 'published'
+    internal_name 'An internal name'
+  end
+end

--- a/spec/features/bulk_tagging_spec.rb
+++ b/spec/features/bulk_tagging_spec.rb
@@ -1,0 +1,156 @@
+require "rails_helper"
+
+RSpec.feature "Bulk tagging", type: :feature do
+  require 'gds_api/test_helpers/publishing_api_v2'
+  include GdsApi::TestHelpers::PublishingApiV2
+  include ContentItemHelper
+
+  scenario "Migrating tags from a collection to taxons" do
+    given_a_collection_with_items
+    and_a_set_of_taxons
+    when_i_find_the_collection_via_the_bulk_tagger
+    then_i_can_see_the_content_items_in_this_collection
+    when_i_select_the_taxons_i_want_to_retag_them_to
+    then_i_can_preview_my_changes
+    when_i_create_tags
+    then_the_content_items_have_been_retagged
+  end
+
+  scenario "Not selecting anything to migrate" do
+    given_a_collection_with_items
+    and_a_set_of_taxons
+    when_i_find_the_collection_via_the_bulk_tagger
+    then_i_can_see_the_content_items_in_this_collection
+    when_i_submit_the_form
+    then_i_see_an_error_about_taxons
+    when_i_select_taxons
+    when_i_deselect_all_content_items
+    when_i_submit_the_form
+    then_i_see_an_error_about_content_items
+  end
+
+  def given_a_collection_with_items
+    publishing_api_has_content(
+      [{
+        content_id: "collection-id",
+        title: "Tax documents",
+        base_path: "/tax-documents",
+        document_type: "document_collection",
+      }],
+      document_type: "document_collection",
+      per_page: 20,
+      q: "Tax"
+    )
+
+    publishing_api_has_expanded_links(
+      content_id: "collection-id",
+      expanded_links: {
+        documents: [
+          basic_content_item("Tax doc 1"),
+          basic_content_item("Tax doc 2"),
+        ]
+      }
+    )
+  end
+
+  def and_a_set_of_taxons
+    linkables = [
+      basic_content_item("Taxon 1"),
+      basic_content_item("Taxon 2"),
+      basic_content_item("Taxon 3"),
+    ]
+    publishing_api_has_linkables(linkables, document_type: 'taxon')
+  end
+
+  def when_i_find_the_collection_via_the_bulk_tagger
+    visit new_bulk_tagging_path
+    fill_in "Query", with: "Tax"
+    click_button "Search collection"
+    expect(page).to have_text("Tax documents")
+    expect(page).to have_link("collection-id")
+  end
+
+  def then_i_can_see_the_content_items_in_this_collection
+    click_link("collection-id")
+    expect(page).to have_text "Tax doc 1"
+    expect(page).to have_text "Tax doc 2"
+    expect(page).to have_link "tax-doc-1"
+    expect(page).to have_link "tax-doc-2"
+    # All content items checked by default
+    expect(all("input[type='checkbox']").select(&:checked?).count).to eq 2
+  end
+
+  def when_i_select_the_taxons_i_want_to_retag_them_to
+    select "Taxon 1", from: "taxons"
+    select "Taxon 2", from: "taxons"
+  end
+
+  def then_i_can_preview_my_changes
+    click_button "Bulk tag selected items"
+
+    expect(all("table tbody tr").count).to eq 4
+    expect(page).to have_text("Taxon 1", count: 2)
+    expect(page).to have_text("Taxon 2", count: 2)
+    expect(page).to have_text("/path/tax-doc-1", count: 2)
+    expect(page).to have_text("/path/tax-doc-2", count: 2)
+
+    within("table") do
+      state_labels = all("span.label")
+      state_labels.each { |label| expect(label.text).to match(/Ready to tag/) }
+    end
+  end
+
+  def when_i_create_tags
+    publishing_api_has_lookups(
+      '/path/tax-doc-1' => 'tax-doc-1',
+      '/path/tax-doc-2' => 'tax-doc-2',
+    )
+    stub_publishing_api_patch_links(
+      "tax-doc-1",
+      links: {
+        taxons: ["taxon-1", "taxon-2"],
+      }
+    )
+    stub_publishing_api_patch_links(
+      "tax-doc-2",
+      links: {
+        taxons: ["taxon-1", "taxon-2"],
+      }
+    )
+
+    Sidekiq::Testing.inline!
+    click_link 'Create tags'
+  end
+
+  def then_the_content_items_have_been_retagged
+    # Refresh the page so we see the updates
+    visit current_path
+
+    within("table") do
+      state_labels = all("span.label")
+      state_labels.each { |label| expect(label.text).to match(/tagged/i) }
+    end
+  end
+
+  def when_i_deselect_all_content_items
+    all("input[type='checkbox']").each do |checkbox|
+      checkbox.set false
+    end
+  end
+
+  def then_i_see_an_error_about_taxons
+    expect(page).to have_text 'No taxons selected.'
+  end
+
+  def when_i_submit_the_form
+    click_button "Bulk tag selected items"
+  end
+
+  def then_i_see_an_error_about_content_items
+    expect(page).to have_text 'No content items selected.'
+  end
+
+  def when_i_select_taxons
+    select "Taxon 1", from: "taxons"
+  end
+end

--- a/spec/models/search_response_spec.rb
+++ b/spec/models/search_response_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe SearchResponse do
+  include ContentItemHelper
+
+  context 'with a successful response' do
+    let(:gds_api_response) do
+      double(
+        GdsApi::Response,
+        code: 200,
+        to_hash: {
+          'results' => [
+            basic_content_item('Content item 1'),
+            basic_content_item('Content item 2'),
+          ],
+          'pages' => 1
+        }
+      )
+    end
+
+    it 'is successful' do
+      expect(
+        described_class.new(gds_api_response, 'document_collection')
+      ).to be_successful
+    end
+
+    it 'includes content item search results' do
+      search_response =
+        described_class.new(gds_api_response, 'document_collection')
+
+      expect(search_response.results.length).to eq(2)
+      search_response.results.each do |result|
+        expect(result).to be_a(ContentItem)
+      end
+    end
+
+    it 'does not have multiple pages when pages are 1' do
+      expect(
+        described_class.new(gds_api_response, 'document_collection').multiple_pages?
+      ).to be_falsy
+    end
+  end
+end

--- a/spec/models/search_response_spec.rb
+++ b/spec/models/search_response_spec.rb
@@ -18,12 +18,6 @@ RSpec.describe SearchResponse do
       )
     end
 
-    it 'is successful' do
-      expect(
-        described_class.new(gds_api_response, 'document_collection')
-      ).to be_successful
-    end
-
     it 'includes content item search results' do
       search_response =
         described_class.new(gds_api_response, 'document_collection')

--- a/spec/models/tag_migration_spec.rb
+++ b/spec/models/tag_migration_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe TagMigration do
+  describe '#mark_as_deleted' do
+    it 'updates the deleted_at date' do
+      tag_migration = build(:tag_migration)
+      expect(tag_migration.deleted_at).to be_nil
+
+      tag_migration.mark_as_deleted
+      expect(tag_migration.deleted_at).to_not be_nil
+    end
+  end
+end

--- a/spec/presenters/tag_migration_presenter_spec.rb
+++ b/spec/presenters/tag_migration_presenter_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe TagMigrationPresenter do
+  let(:tag_migration) { TagMigration.new }
+  let(:presenter) { described_class.new(tag_migration) }
+
+  describe 'label_type' do
+    it 'returns a label css class indicting a success for the imported state' do
+      tag_migration.state = 'imported'
+
+      expect(presenter.label_type).to eq('label-success')
+    end
+
+    it 'returns a label css class indicting a warning for the ready_to_import state' do
+      tag_migration.state = 'ready_to_import'
+
+      expect(presenter.label_type).to eq('label-warning')
+    end
+  end
+
+  describe '#state_title' do
+    it 'humanizes the state' do
+      tag_migration.state = 'imported'
+
+      expect(presenter.state_title).to eq('Imported')
+    end
+  end
+end

--- a/spec/services/bulk_tagging/build_tag_mapping_spec.rb
+++ b/spec/services/bulk_tagging/build_tag_mapping_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe BulkTagging::BuildTagMapping do
+  let(:taxon) { build(:taxon) }
+  let(:build_tag_mapping) do
+    described_class.new(taxon: taxon, content_base_path: '/content-base-path')
+  end
+  let(:tag_mapping) { build_tag_mapping.perform }
+
+  it 'builds a TagMapping record' do
+    expect(tag_mapping).to be_a(TagMapping)
+  end
+
+  it 'assigns the content base path' do
+    expect(tag_mapping.content_base_path).to eq('/content-base-path')
+  end
+
+  it 'assigns the taxon title to link_title' do
+    expect(tag_mapping.link_title).to eq(taxon.title)
+  end
+
+  it 'assigns the taxon content id to link_content_id' do
+    expect(tag_mapping.link_content_id).to eq(taxon.content_id)
+  end
+
+  it 'assigns the taxon link type to link_type' do
+    expect(tag_mapping.link_type).to eq(taxon.link_type)
+  end
+
+  it 'gives it an initial state' do
+    expect(tag_mapping.state).to eq('ready_to_tag')
+  end
+end

--- a/spec/services/bulk_tagging/build_tag_migration_spec.rb
+++ b/spec/services/bulk_tagging/build_tag_migration_spec.rb
@@ -1,0 +1,81 @@
+require 'rails_helper'
+
+RSpec.describe BulkTagging::BuildTagMigration do
+  context 'without any taxons' do
+    let(:tag_migration) do
+      described_class.perform(
+        original_link_content_id: 'content-id',
+        taxon_content_ids: [],
+        content_base_paths: ['/content-1']
+      )
+    end
+
+    it 'raises an error' do
+      expect { tag_migration }.to raise_error(
+        BulkTagging::BuildTagMigration::InvalidArgumentError,
+        /no taxons selected/i
+      )
+    end
+  end
+
+  context 'without any content items' do
+    let(:tag_migration) do
+      described_class.perform(
+        original_link_content_id: 'content-id',
+        taxon_content_ids: ['taxon-1'],
+        content_base_paths: []
+      )
+    end
+
+    it 'raises an error' do
+      expect { tag_migration }.to raise_error(
+        BulkTagging::BuildTagMigration::InvalidArgumentError,
+        /no content items selected/i
+      )
+    end
+  end
+
+  context 'with 2 valid taxons and 2 content base paths' do
+    before do
+      linkables = [
+        { "title" => "Taxon 1", "base_path" => "/foo", "content_id" => 'taxon-1' },
+        { "title" => "Taxon 2", "base_path" => "/aha", "content_id" => 'taxon-2' },
+      ]
+
+      publishing_api_has_linkables(linkables, document_type: 'taxon')
+    end
+
+    let(:tag_migration) do
+      described_class.perform(
+        original_link_content_id: 'content-id',
+        taxon_content_ids: ['taxon-1', 'taxon-2'],
+        content_base_paths: ['/content-1', '/content-2']
+      )
+    end
+
+    it 'builds an instance of a TagMigration' do
+      expect(tag_migration).to be_a(TagMigration)
+    end
+
+    it 'assigns the original content id to the tag migration' do
+      expect(tag_migration.original_link_content_id).to eq('content-id')
+    end
+
+    it 'assigns an initial state to the tag migration' do
+      expect(tag_migration.state).to eq('ready_to_import')
+    end
+
+    it 'it builds 4 tag mappings' do
+      expect(tag_migration.tag_mappings.length).to eq(4)
+    end
+
+    it 'delegates the initialization of TagMapping records' do
+      expect(BulkTagging::BuildTagMapping).to receive(:perform)
+        .exactly(4)
+        .times
+        .and_return(TagMapping.new)
+
+      tag_migration
+    end
+  end
+end

--- a/spec/services/bulk_tagging/search_spec.rb
+++ b/spec/services/bulk_tagging/search_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe BulkTagging::Search do
+  include ContentItemHelper
+
+  before do
+    publishing_api_has_content(
+      [basic_content_item('A content item')],
+      q: 'tax',
+      per_page: 20,
+      document_type: 'taxon'
+    )
+  end
+
+  it 'returns an instance of SearchResponse' do
+    search = described_class.new(query: 'tax', document_type: 'taxon')
+
+    expect(search.perform).to be_a(SearchResponse)
+  end
+end

--- a/spec/services/tag_importer/publish_tags_spec.rb
+++ b/spec/services/tag_importer/publish_tags_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe TagImporter::PublishTags do
   before do
     create(
       :tag_mapping,
-      tagging_spreadsheet: tagging_spreadsheet,
+      tagging_source: tagging_spreadsheet,
       content_base_path: "/content-1",
       link_title: "GDS",
       link_content_id: "gds-ID",
@@ -16,7 +16,7 @@ RSpec.describe TagImporter::PublishTags do
 
     create(
       :tag_mapping,
-      tagging_spreadsheet: tagging_spreadsheet,
+      tagging_source: tagging_spreadsheet,
       content_base_path: "/content-1",
       link_title: "GDS",
       link_content_id: "gds-ID",
@@ -25,7 +25,7 @@ RSpec.describe TagImporter::PublishTags do
 
     create(
       :tag_mapping,
-      tagging_spreadsheet: tagging_spreadsheet,
+      tagging_source: tagging_spreadsheet,
       content_base_path: "/content-1",
       link_title: "Education",
       link_content_id: "education-ID",
@@ -34,7 +34,7 @@ RSpec.describe TagImporter::PublishTags do
 
     create(
       :tag_mapping,
-      tagging_spreadsheet: tagging_spreadsheet,
+      tagging_source: tagging_spreadsheet,
       content_base_path: "/content-2",
       link_title: "Education",
       link_content_id: "education-ID",

--- a/spec/support/content_item_helper.rb
+++ b/spec/support/content_item_helper.rb
@@ -1,0 +1,10 @@
+module ContentItemHelper
+  def basic_content_item(title, other_fields: {})
+    ActiveSupport::HashWithIndifferentAccess.new(
+      content_id: title.parameterize,
+      title: title,
+      base_path: title.parameterize.prepend('/path/'),
+      document_type: "guidance",
+    ).merge(other_fields)
+  end
+end


### PR DESCRIPTION
This PR allows us to:

- search for a collection;
- select which content items we want to tag;
- select which taxons we want to tag those content items with;
- preview a tag migration;
- bulk-tag all the content items.

**Note**: Until the publishing API removes the permissions from the `get_content_items` endpoint, we need to add `view_all` permissions to the `dummyapiuser` in development mode in order to see results from the search.

Trello: https://trello.com/c/9LajM53J/10-epic-bulk-tagging-from-existing-taxonomies-to-the-new-one

Work done by both myself and @mobaig (the rebase erased some of the commit details).

What's next:
- [ ] support for topics and browse pages
- [ ] tidy up navigation (perhaps merge some functionality into a single navigation item).

These will come in separate PRs.