### PR TITLE
Display context around a tag migration

### DIFF
--- a/app/controllers/bulk_tagging/collections_controller.rb
+++ b/app/controllers/bulk_tagging/collections_controller.rb
@@ -7,8 +7,10 @@ module BulkTagging
       render :show, locals: {
         bulk_tagging: TagMigration.new,
         content_id: params[:content_id],
+        base_path: params[:base_path],
         taxons: taxons,
-        expanded_links: expanded_links
+        expanded_links: expanded_links,
+        query: params[:query]
       }
     end
   end

--- a/app/controllers/bulk_tagging/update_tags_controller.rb
+++ b/app/controllers/bulk_tagging/update_tags_controller.rb
@@ -13,7 +13,7 @@ module BulkTagging
 
     def tag_migration
       @tag_migration ||= BulkTagging::BuildTagMigration.perform(
-        original_link_content_id: params[:collection_content_id],
+        tag_migration_params: tag_migration_params,
         taxon_content_ids: taxon_content_ids,
         content_base_paths: content_base_paths
       )
@@ -25,6 +25,10 @@ module BulkTagging
 
     def content_base_paths
       params[:content_base_paths]
+    end
+
+    def tag_migration_params
+      params.permit(:collection_base_path, :query, :collection_content_id)
     end
   end
 end

--- a/app/services/bulk_tagging/build_tag_migration.rb
+++ b/app/services/bulk_tagging/build_tag_migration.rb
@@ -2,17 +2,17 @@ module BulkTagging
   class BuildTagMigration
     class InvalidArgumentError < ArgumentError; end
 
-    attr_reader :original_link_content_id, :taxon_content_ids, :content_base_paths
+    attr_reader :tag_migration_params, :taxon_content_ids, :content_base_paths
 
-    def initialize(original_link_content_id:, taxon_content_ids:, content_base_paths:)
-      @original_link_content_id = original_link_content_id
+    def initialize(tag_migration_params:, taxon_content_ids:, content_base_paths:)
+      @tag_migration_params = tag_migration_params
       @taxon_content_ids = taxon_content_ids
       @content_base_paths = content_base_paths
     end
 
-    def self.perform(original_link_content_id:, taxon_content_ids:, content_base_paths:)
+    def self.perform(tag_migration_params:, taxon_content_ids:, content_base_paths:)
       new(
-        original_link_content_id: original_link_content_id,
+        tag_migration_params: tag_migration_params,
         taxon_content_ids: taxon_content_ids,
         content_base_paths: content_base_paths
       ).perform
@@ -47,7 +47,9 @@ module BulkTagging
     def tag_migration
       @tag_migration ||= TagMigration.new(
         state: 'ready_to_import',
-        original_link_content_id: original_link_content_id
+        original_link_content_id: tag_migration_params[:collection_content_id],
+        original_link_base_path: tag_migration_params[:collection_base_path],
+        query: tag_migration_params[:query]
       )
     end
 

--- a/app/views/bulk_tagging/collections/show.html.erb
+++ b/app/views/bulk_tagging/collections/show.html.erb
@@ -1,5 +1,9 @@
 <%= simple_form_for bulk_tagging,
-  url: bulk_tagging_collection_update_tags_path(content_id), method: :post do |f| %>
+  url: bulk_tagging_collection_update_tags_path(content_id,
+                                                query: query,
+                                                collection_base_path: base_path),
+  method: :post do |f| %>
+
   <% if flash[:error].present? %>
     <div class="alert alert-danger" role="alert">
       <%= flash[:error] %>

--- a/app/views/bulk_taggings/new.html.erb
+++ b/app/views/bulk_taggings/new.html.erb
@@ -24,8 +24,11 @@
           <% results.each do |collection| %>
             <tr>
               <td><%= collection.title %></td>
-              <td><%= link_to collection.content_id,
-                    bulk_tagging_collection_path(collection.content_id) %></td>
+              <td>
+                <%= link_to collection.content_id,
+                  bulk_tagging_collection_path(collection.content_id,
+                                               query: query,
+                                               base_path: collection.base_path) %></td>
             </tr>
           <% end %>
         <% else %>

--- a/app/views/tag_migrations/index.html.erb
+++ b/app/views/tag_migrations/index.html.erb
@@ -6,7 +6,8 @@
   <thead>
     <tr>
       <th>State</th>
-      <th>Original content id</th>
+      <th>Search term</th>
+      <th>Original source</th>
       <th>Date added</th>
       <th></th>
       <th></th>
@@ -18,7 +19,11 @@
       <tr>
         <td><%= state_label_for(label_type: tag_migration.label_type,
                                 title: tag_migration.state_title) %></td>
-        <td><%= tag_migration.original_link_content_id %></td>
+        <td><%= tag_migration.query %></td>
+        <td>
+          <%= link_to tag_migration.original_link_base_path,
+            website_url('/api/content' + tag_migration.original_link_base_path) %>
+        </td>
         <td>
           <%= time_tag_for(tag_migration.created_at) %>
         </td>

--- a/db/migrate/20160907125337_add_query_to_tag_migration.rb
+++ b/db/migrate/20160907125337_add_query_to_tag_migration.rb
@@ -1,0 +1,5 @@
+class AddQueryToTagMigration < ActiveRecord::Migration
+  def change
+    add_column :tag_migrations, :query, :string
+  end
+end

--- a/db/migrate/20160907131639_add_original_link_base_path_to_tag_migrations.rb
+++ b/db/migrate/20160907131639_add_original_link_base_path_to_tag_migrations.rb
@@ -1,0 +1,5 @@
+class AddOriginalLinkBasePathToTagMigrations < ActiveRecord::Migration
+  def change
+    add_column :tag_migrations, :original_link_base_path, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160905162106) do
+ActiveRecord::Schema.define(version: 20160907131639) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -41,6 +41,8 @@ ActiveRecord::Schema.define(version: 20160905162106) do
     t.datetime "last_published_at"
     t.string   "last_published_by"
     t.datetime "deleted_at"
+    t.string   "query"
+    t.string   "original_link_base_path"
   end
 
   create_table "tagging_spreadsheets", force: :cascade do |t|

--- a/spec/factories/tag_migration.rb
+++ b/spec/factories/tag_migration.rb
@@ -1,6 +1,8 @@
 FactoryGirl.define do
   factory :tag_migration do
     original_link_content_id 'original-content-id'
+    original_link_base_path '/original-base-path'
     state 'ready_to_import'
+    query 'a query'
   end
 end

--- a/spec/features/bulk_tagging_spec.rb
+++ b/spec/features/bulk_tagging_spec.rb
@@ -14,6 +14,8 @@ RSpec.feature "Bulk tagging", type: :feature do
     then_i_can_preview_my_changes
     when_i_create_tags
     then_the_content_items_have_been_retagged
+    when_i_go_to_all_migrations
+    then_i_can_see_it_has_been_imported
   end
 
   scenario "Not selecting anything to migrate" do
@@ -152,5 +154,19 @@ RSpec.feature "Bulk tagging", type: :feature do
 
   def when_i_select_taxons
     select "Taxon 1", from: "taxons"
+  end
+
+  def when_i_go_to_all_migrations
+    visit tag_migrations_path
+  end
+
+  def then_i_can_see_it_has_been_imported
+    expect(all('table tbody tr').count).to eq(1)
+
+    row = first('table tbody tr')
+
+    expect(row).to have_text(/imported/i)
+    expect(row).to have_text('Tax')
+    expect(row).to have_link('/tax-documents')
   end
 end

--- a/spec/services/bulk_tagging/build_tag_migration_spec.rb
+++ b/spec/services/bulk_tagging/build_tag_migration_spec.rb
@@ -1,10 +1,18 @@
 require 'rails_helper'
 
 RSpec.describe BulkTagging::BuildTagMigration do
+  let(:tag_migration_params) do
+    {
+      collection_content_id: 'content-id',
+      collection_base_path: '/content-base-path',
+      query: 'A query string'
+    }
+  end
+
   context 'without any taxons' do
     let(:tag_migration) do
       described_class.perform(
-        original_link_content_id: 'content-id',
+        tag_migration_params: tag_migration_params,
         taxon_content_ids: [],
         content_base_paths: ['/content-1']
       )
@@ -21,7 +29,7 @@ RSpec.describe BulkTagging::BuildTagMigration do
   context 'without any content items' do
     let(:tag_migration) do
       described_class.perform(
-        original_link_content_id: 'content-id',
+        tag_migration_params: tag_migration_params,
         taxon_content_ids: ['taxon-1'],
         content_base_paths: []
       )
@@ -47,7 +55,7 @@ RSpec.describe BulkTagging::BuildTagMigration do
 
     let(:tag_migration) do
       described_class.perform(
-        original_link_content_id: 'content-id',
+        tag_migration_params: tag_migration_params,
         taxon_content_ids: ['taxon-1', 'taxon-2'],
         content_base_paths: ['/content-1', '/content-2']
       )
@@ -57,12 +65,24 @@ RSpec.describe BulkTagging::BuildTagMigration do
       expect(tag_migration).to be_a(TagMigration)
     end
 
+    it 'builds a valid object' do
+      expect(tag_migration).to be_valid
+    end
+
     it 'assigns the original content id to the tag migration' do
       expect(tag_migration.original_link_content_id).to eq('content-id')
     end
 
     it 'assigns an initial state to the tag migration' do
       expect(tag_migration.state).to eq('ready_to_import')
+    end
+
+    it 'assigns the query to the tag migration' do
+      expect(tag_migration.query).to eq('A query string')
+    end
+
+    it 'assigns the content base path to the tag migration' do
+      expect(tag_migration.original_link_base_path).to eq('/content-base-path')
     end
 
     it 'it builds 4 tag mappings' do


### PR DESCRIPTION
This commits adds the following to a TagMigration:
- The original query string
- The original base path from the collection used

These 2 new fields will provide context when looking at the overview page of
TagMigrations.

Trello: https://trello.com/c/H403aTpk/152-bulk-tagging-add-a-description-to-tag-migration-in-order-to-provide-context

Before this change, it looked like this:

<img width="1433" alt="screen shot 2016-09-07 at 14 49 19" src="https://cloud.githubusercontent.com/assets/416701/18314271/4895ee3a-750a-11e6-8240-b021fc6170f0.png">


Now, it looks like this:

<img width="1433" alt="screen shot 2016-09-07 at 14 46 21" src="https://cloud.githubusercontent.com/assets/416701/18314212/f9d2bbe8-7509-11e6-8012-dd7ce4d9c83a.png">