### PR TITLE
Add Select All checkbox to collections view

### DIFF
--- a/app/assets/javascripts/select-all.js
+++ b/app/assets/javascripts/select-all.js
@@ -1,0 +1,22 @@
+(function(Modules) {
+  "use strict";
+
+  Modules.SelectAll = function() {
+    var that = this;
+
+    that.start = function(element) {
+      addEventListener();
+
+      function addEventListener() {
+        var selectAll = element.find('#select_all');
+        if (selectAll != undefined) {
+          selectAll.on('change', function(e) {
+            var checked = selectAll.prop('checked');
+            var checkboxes = $('.select-content-item');
+            checkboxes.prop('checked', checked);
+          });
+        }
+      }
+    }
+  };
+})(window.GOVUKAdmin.Modules);

--- a/app/views/bulk_tagging/collections/show.html.erb
+++ b/app/views/bulk_tagging/collections/show.html.erb
@@ -21,7 +21,7 @@
       <table class="table queries-list table-bordered" data-module="filterable-table">
         <thead>
           <tr class="table-header">
-            <th>Select</th>
+            <th data-module="select-all"><%= check_box_tag 'select_all', nil, false %></th>
             <th>Title</th>
             <th>Content ID</th>
           </tr>
@@ -29,7 +29,10 @@
         <tbody>
           <% expanded_links.each do |expanded_link| %>
             <tr>
-              <td><%= check_box_tag 'content_base_paths[]', expanded_link.base_path, true %></td>
+              <td>
+                <%= check_box_tag 'content_base_paths[]',
+                  expanded_link.base_path, false, class: 'select-content-item' %>
+              </td>
               <td><%= link_to expanded_link.title, website_url('/api/content' + expanded_link.base_path) %></td>
               <td><%= link_to expanded_link.content_id,
                 "#{website_url('/api/content' + expanded_link.base_path)}" %></td>

--- a/spec/features/bulk_tagging_spec.rb
+++ b/spec/features/bulk_tagging_spec.rb
@@ -76,8 +76,10 @@ RSpec.feature "Bulk tagging", type: :feature do
     expect(page).to have_text "Tax doc 2"
     expect(page).to have_link "tax-doc-1"
     expect(page).to have_link "tax-doc-2"
-    # All content items checked by default
-    expect(all("input[type='checkbox']").select(&:checked?).count).to eq 2
+
+    expect(all(".select-content-item").select(&:checked?).count).to eq 0
+    when_i_select_all_content_items
+    expect(all(".select-content-item").select(&:checked?).count).to eq 2
   end
 
   def when_i_select_the_taxons_i_want_to_retag_them_to
@@ -133,8 +135,14 @@ RSpec.feature "Bulk tagging", type: :feature do
   end
 
   def when_i_deselect_all_content_items
-    all("input[type='checkbox']").each do |checkbox|
+    all(".select-content-item").each do |checkbox|
       checkbox.set false
+    end
+  end
+
+  def when_i_select_all_content_items
+    all(".select-content-item").each do |checkbox|
+      checkbox.set true
     end
   end
 


### PR DESCRIPTION
This checkbox toggles the content items' checkboxes so we can select/deselect
all easily.

Trello: https://trello.com/c/IJoqzkbq/155-bulk-tagging-add-select-all-checkbox-that-selects-deselects-all-checkboxes-in-collections-show

This feature isn't in the critical path of the system, so I decided to not test it directly by clicking on the checkbox. That behaviour doesn't work with `rack-test` and introducing something like `phantomjs` not only slows down the test suite but also forces us to change how we find some elements in the UI in other tests. 

It looks like this:

![sep-08-2016 10-40-28](https://cloud.githubusercontent.com/assets/416701/18344823/b8eb7906-75b0-11e6-9352-0df4ca296353.gif)
