### PR TITLE
Add more fields to a taxon

### DIFF
--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -1,10 +1,12 @@
 class Taxon
   ATTRIBUTES = %w(title
+                  description
                   parent_taxons
                   content_id
                   base_path
                   publication_state
                   internal_name
+                  notes_for_editors
                   document_type).freeze
 
   attr_accessor(*ATTRIBUTES)

--- a/app/services/taxonomy/taxon_builder.rb
+++ b/app/services/taxonomy/taxon_builder.rb
@@ -14,10 +14,12 @@ module Taxonomy
       Taxon.new(
         content_id: content_id,
         title: content_item["title"],
+        description: content_item["description"],
         base_path: content_item["base_path"],
         publication_state: content_item['publication_state'],
-        internal_name: content_item['internal_name'],
-        parent_taxons: parent_taxons
+        internal_name: content_item['details']['internal_name'],
+        notes_for_editors: content_item['details']['notes_for_editors'],
+        parent_taxons: parent_taxons,
       )
     end
 

--- a/app/services/taxonomy/taxon_fetcher.rb
+++ b/app/services/taxonomy/taxon_fetcher.rb
@@ -1,5 +1,7 @@
 module Taxonomy
   class TaxonFetcher
+    # Return a list of taxons from the publishing API with links included.
+    # Does not include the details hash of each taxon.
     def taxons
       @taxons ||=
         begin

--- a/app/services/taxonomy/taxon_payload_builder.rb
+++ b/app/services/taxonomy/taxon_payload_builder.rb
@@ -14,11 +14,15 @@ module Taxonomy
         document_type: 'taxon',
         schema_name: 'taxon',
         title: title,
+        description: description,
         publishing_app: 'content-tagger',
         rendering_app: 'collections',
         public_updated_at: Time.now.iso8601,
         locale: 'en',
-        details: {},
+        details: {
+          internal_name: internal_name,
+          notes_for_editors: notes_for_editors,
+        },
         routes: [
           { path: base_path, type: "exact" },
         ]
@@ -28,6 +32,9 @@ module Taxonomy
   private
 
     attr_reader :taxon
-    delegate :base_path, :title, to: :taxon
+    delegate(
+      :base_path, :title, :description, :internal_name, :notes_for_editors,
+      to: :taxon
+    )
   end
 end

--- a/app/views/taxons/_form_fields.html.erb
+++ b/app/views/taxons/_form_fields.html.erb
@@ -1,0 +1,9 @@
+<%= f.input :title, input_html: { class: 'form-control' } %>
+<%= f.input :internal_name, input_html: { class: 'form-control' } %>
+<%= f.input :description,
+  as: :text,
+  label: "Description (displayed on frontend)",
+  input_html: { class: 'form-control' } %>
+<%= f.input :notes_for_editors, as: :text, input_html: { class: 'form-control' } %>
+<%= f.input :parent_taxons, collection: taxons_for_select,
+  input_html: { class: :select2, multiple: true, include_blank: true } %>

--- a/app/views/taxons/edit.html.erb
+++ b/app/views/taxons/edit.html.erb
@@ -4,10 +4,7 @@
   <%= f.hidden_field :content_id, value: taxon.content_id %>
   <%= f.hidden_field :base_path, value: taxon.base_path %>
 
-  <%= f.input :title, input_html: { class: 'form-control' } %>
-
-  <%= f.input :parent_taxons, collection: taxons_for_select,
-      input_html: { class: :select2, multiple: true, include_blank: true } %>
+  <%= render partial: 'form_fields', locals: { taxons_for_select: taxons_for_select, f: f} %>
 
   <%= f.submit I18n.t('views.taxons.edit_button'), class: "btn btn-lg btn-success" %>
 <% end %>

--- a/app/views/taxons/new.html.erb
+++ b/app/views/taxons/new.html.erb
@@ -8,9 +8,7 @@
     </div>
   <% end %>
 
-  <%= f.input :title, input_html: { class: 'form-control' } %>
-  <%= f.input :parent_taxons, collection: taxons_for_select,
-      input_html: { class: :select2, multiple: true, include_blank: true } %>
+  <%= render partial: 'form_fields', locals: { taxons_for_select: taxons_for_select, f: f} %>
 
   <%= f.submit I18n.t('views.taxons.new_button'), class: "btn btn-lg btn-success" %>
 <% end %>

--- a/spec/services/taxonomy/taxon_builder_spec.rb
+++ b/spec/services/taxonomy/taxon_builder_spec.rb
@@ -9,9 +9,13 @@ RSpec.describe Taxonomy::TaxonBuilder do
       {
         content_id: content_id,
         title: 'A title',
+        description: 'A description',
         base_path: 'A base path',
         publication_state: 'State',
-        internal_name: 'Internal name'
+        details: {
+          internal_name: 'Internal name',
+          notes_for_editors: 'Notes for editors',
+        }
       }
     end
     let(:taxon) { builder.build }
@@ -40,7 +44,11 @@ RSpec.describe Taxonomy::TaxonBuilder do
     end
 
     it 'assigns the title correctly' do
-      expect(taxon.title).to eq(content[:title])
+      expect(taxon.title).to eq('A title')
+    end
+
+    it 'assigns the description correctly' do
+      expect(taxon.description).to eq('A description')
     end
 
     it 'assigns the base_path correctly' do
@@ -52,7 +60,11 @@ RSpec.describe Taxonomy::TaxonBuilder do
     end
 
     it 'assigns the internal_name correctly' do
-      expect(taxon.internal_name).to eq(content[:internal_name])
+      expect(taxon.internal_name).to eq("Internal name")
+    end
+
+    it 'assigns the notes_for_editors correctly' do
+      expect(taxon.notes_for_editors).to eq("Notes for editors")
     end
 
     context 'without taxon parents' do

--- a/spec/services/taxonomy/taxon_payload_builder_spec.rb
+++ b/spec/services/taxonomy/taxon_payload_builder_spec.rb
@@ -2,7 +2,14 @@ require 'rails_helper'
 
 RSpec.describe Taxonomy::TaxonPayloadBuilder do
   let(:taxon) do
-    instance_double(Taxon, title: 'My Title', base_path: "/taxons/my-taxon")
+    instance_double(
+      Taxon,
+      title: 'My Title',
+      base_path: "/taxons/my-taxon",
+      description: "This is a taxon.",
+      internal_name: "Internal title",
+      notes_for_editors: "Use this taxon wisely."
+    )
   end
   let(:builder) { described_class.new(taxon) }
 


### PR DESCRIPTION
Needs https://github.com/alphagov/govuk-content-schemas/pull/382 merged first.

The following fields have been made editable to allow Finding Things IAs
to store additional information in the taxon content item.

- description
- internal_name
- notes_for_editors