### PR TITLE
Order taxons by updated at

### DIFF
--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -65,7 +65,7 @@ private
   end
 
   def taxons_for_select
-    taxon_fetcher.taxons_for_select
+    Linkables.new.taxons
   end
 
   def parent_taxons

--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -1,11 +1,13 @@
 class Taxon
-  attr_accessor :title,
-                :parent_taxons,
-                :content_id,
-                :base_path,
-                :publication_state,
-                :internal_name,
-                :document_type
+  ATTRIBUTES = %w(title
+                  parent_taxons
+                  content_id
+                  base_path
+                  publication_state
+                  internal_name
+                  document_type).freeze
+
+  attr_accessor(*ATTRIBUTES)
 
   include ActiveModel::Model
 

--- a/app/services/taxonomy/taxon_fetcher.rb
+++ b/app/services/taxonomy/taxon_fetcher.rb
@@ -13,10 +13,6 @@ module Taxonomy
       taxons.map(&:content_id)
     end
 
-    def taxons_for_select
-      taxons.map { |taxon| [taxon.title, taxon.content_id] }
-    end
-
     def parents_for_taxon(taxon_child)
       taxons.select do |taxon|
         taxon_child.parent_taxons.include?(taxon.content_id)

--- a/app/services/taxonomy/taxon_fetcher.rb
+++ b/app/services/taxonomy/taxon_fetcher.rb
@@ -1,11 +1,7 @@
 module Taxonomy
   class TaxonFetcher
-    # Return a list of taxons from the publishing API with links included.
     def taxons
-      @taxons ||=
-        Services.publishing_api.get_linkables(document_type: 'taxon')
-          .map { |taxon_hash| Taxon.new(taxon_hash) }
-          .sort_by(&:title)
+      @taxons ||= taxon_list.sort_by(&:title)
     end
 
     def taxon_content_ids
@@ -20,6 +16,20 @@ module Taxonomy
       taxons.select do |taxon|
         taxon_child.parent_taxons.include?(taxon.content_id)
       end
+    end
+
+  private
+
+    def taxon_list
+      taxon_content_items.map do |taxon_hash|
+        Taxon.new(taxon_hash.slice(*Taxon::ATTRIBUTES))
+      end
+    end
+
+    def taxon_content_items
+      Services
+        .publishing_api
+        .get_content_items(document_type: 'taxon')['results']
     end
   end
 end

--- a/app/services/taxonomy/taxon_fetcher.rb
+++ b/app/services/taxonomy/taxon_fetcher.rb
@@ -1,7 +1,12 @@
 module Taxonomy
   class TaxonFetcher
     def taxons
-      @taxons ||= taxon_list.sort_by(&:title)
+      @taxons ||=
+        begin
+          taxon_content_items.map do |taxon_hash|
+            Taxon.new(taxon_hash.slice(*Taxon::ATTRIBUTES))
+          end
+        end
     end
 
     def taxon_content_ids
@@ -20,16 +25,13 @@ module Taxonomy
 
   private
 
-    def taxon_list
-      taxon_content_items.map do |taxon_hash|
-        Taxon.new(taxon_hash.slice(*Taxon::ATTRIBUTES))
-      end
-    end
-
     def taxon_content_items
       Services
         .publishing_api
-        .get_content_items(document_type: 'taxon')['results']
+        .get_content_items(
+          document_type: 'taxon',
+          order: '-public_updated_at'
+        )['results']
     end
   end
 end

--- a/spec/controllers/taxons_controller_spec.rb
+++ b/spec/controllers/taxons_controller_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe TaxonsController, type: :controller do
+  include PublishingApiHelper
+
   describe "#index" do
     it "renders index" do
-      taxon_1 = { title: "foo", base_path: "/foo", content_id: SecureRandom.uuid }
-      taxon_2 = { title: "bar", base_path: "/bar", content_id: SecureRandom.uuid }
-      taxon_3 = { title: "aha", base_path: "/aha", content_id: SecureRandom.uuid }
+      taxon = { title: "foo", base_path: "/foo", content_id: SecureRandom.uuid }
 
-      publishing_api_has_content([taxon_1, taxon_2, taxon_3], document_type: "taxon")
+      publishing_api_has_taxons([taxon])
 
       get :index
 
@@ -17,15 +17,14 @@ RSpec.describe TaxonsController, type: :controller do
 
   describe "#destroy" do
     it "sends a request to Publishing API to mark the taxon as 'gone'" do
-      taxon_1 = { title: "foo", base_path: "/foo", content_id: SecureRandom.uuid }
-      taxon_2 = { title: "bar", base_path: "/bar", content_id: SecureRandom.uuid }
-      foo_content_id = taxon_1[:content_id]
+      taxon = { title: "foo", base_path: "/foo", content_id: SecureRandom.uuid }
+      foo_content_id = taxon[:content_id]
 
       stub_request(:post, "https://publishing-api.test.gov.uk/v2/content/#{foo_content_id}/unpublish")
         .with(body: "{\"type\":\"gone\"}")
         .to_return(status: 200, body: "", headers: {})
 
-      publishing_api_has_content([taxon_1, taxon_2], document_type: "taxon")
+      publishing_api_has_taxons([taxon])
 
       delete :destroy, id: foo_content_id
       expect(WebMock).to have_requested(:post, "https://publishing-api.test.gov.uk/v2/content/#{foo_content_id}/unpublish")

--- a/spec/controllers/taxons_controller_spec.rb
+++ b/spec/controllers/taxons_controller_spec.rb
@@ -3,16 +3,11 @@ require 'rails_helper'
 RSpec.describe TaxonsController, type: :controller do
   describe "#index" do
     it "renders index" do
-      linkables = [
-        { "title" => "foo", "base_path" => "/foo", "content_id" => SecureRandom.uuid },
-        { "title" => "bar", "base_path" => "/bar", "content_id" => SecureRandom.uuid },
-        { "title" => "aha", "base_path" => "/aha", "content_id" => SecureRandom.uuid },
-      ]
+      taxon_1 = { title: "foo", base_path: "/foo", content_id: SecureRandom.uuid }
+      taxon_2 = { title: "bar", base_path: "/bar", content_id: SecureRandom.uuid }
+      taxon_3 = { title: "aha", base_path: "/aha", content_id: SecureRandom.uuid }
 
-      publishing_api_has_linkables(
-        linkables,
-        document_type: "taxon",
-      )
+      publishing_api_has_content([taxon_1, taxon_2, taxon_3], document_type: "taxon")
 
       get :index
 
@@ -22,24 +17,18 @@ RSpec.describe TaxonsController, type: :controller do
 
   describe "#destroy" do
     it "sends a request to Publishing API to mark the taxon as 'gone'" do
-      linkables = [
-        { "title" => "foo", "base_path" => "/foo", "content_id" => SecureRandom.uuid },
-        { "title" => "bar", "base_path" => "/bar", "content_id" => SecureRandom.uuid },
-      ]
+      taxon_1 = { title: "foo", base_path: "/foo", content_id: SecureRandom.uuid }
+      taxon_2 = { title: "bar", base_path: "/bar", content_id: SecureRandom.uuid }
+      foo_content_id = taxon_1[:content_id]
 
-      foo_linkable_content_id = linkables.first["content_id"]
-
-      stub_request(:post, "https://publishing-api.test.gov.uk/v2/content/#{foo_linkable_content_id}/unpublish")
+      stub_request(:post, "https://publishing-api.test.gov.uk/v2/content/#{foo_content_id}/unpublish")
         .with(body: "{\"type\":\"gone\"}")
         .to_return(status: 200, body: "", headers: {})
 
-      publishing_api_has_linkables(
-        linkables,
-        document_type: "taxon",
-      )
+      publishing_api_has_content([taxon_1, taxon_2], document_type: "taxon")
 
-      delete :destroy, id: foo_linkable_content_id
-      expect(WebMock).to have_requested(:post, "https://publishing-api.test.gov.uk/v2/content/#{foo_linkable_content_id}/unpublish")
+      delete :destroy, id: foo_content_id
+      expect(WebMock).to have_requested(:post, "https://publishing-api.test.gov.uk/v2/content/#{foo_content_id}/unpublish")
     end
   end
 end

--- a/spec/features/bulk_tagging_spec.rb
+++ b/spec/features/bulk_tagging_spec.rb
@@ -56,12 +56,14 @@ RSpec.feature "Bulk tagging", type: :feature do
   end
 
   def and_a_set_of_taxons
-    linkables = [
-      basic_content_item("Taxon 1"),
-      basic_content_item("Taxon 2"),
-      basic_content_item("Taxon 3"),
-    ]
-    publishing_api_has_linkables(linkables, document_type: 'taxon')
+    publishing_api_has_content(
+      [
+        basic_content_item("Taxon 1"),
+        basic_content_item("Taxon 2"),
+        basic_content_item("Taxon 3"),
+      ],
+      document_type: "taxon"
+    )
   end
 
   def when_i_find_the_collection_via_the_bulk_tagger

--- a/spec/features/bulk_tagging_spec.rb
+++ b/spec/features/bulk_tagging_spec.rb
@@ -4,6 +4,7 @@ RSpec.feature "Bulk tagging", type: :feature do
   require 'gds_api/test_helpers/publishing_api_v2'
   include GdsApi::TestHelpers::PublishingApiV2
   include ContentItemHelper
+  include PublishingApiHelper
 
   scenario "Migrating tags from a collection to taxons" do
     given_a_collection_with_items
@@ -56,13 +57,12 @@ RSpec.feature "Bulk tagging", type: :feature do
   end
 
   def and_a_set_of_taxons
-    publishing_api_has_content(
+    publishing_api_has_taxons(
       [
         basic_content_item("Taxon 1"),
         basic_content_item("Taxon 2"),
         basic_content_item("Taxon 3"),
-      ],
-      document_type: "taxon"
+      ]
     )
   end
 

--- a/spec/features/tag_importer_spec.rb
+++ b/spec/features/tag_importer_spec.rb
@@ -125,13 +125,9 @@ RSpec.feature "Tag importer", type: :feature do
         taxons: ["early-years-content-id"],
       }
     )
-    publishing_api_has_linkables(
-      [
-        { 'title' => 'Early Years', content_id: 'early-years-content-id' },
-        { 'title' => 'Education', content_id: 'education-content-id' }
-      ],
-      document_type: 'taxon'
-    )
+    taxon_1 = { title: 'Early Years', content_id: 'early-years-content-id' }
+    taxon_2 = { title: 'Education', content_id: 'education-content-id' }
+    publishing_api_has_content([taxon_1, taxon_2], document_type: "taxon")
 
     click_link "Create tags"
     expect(link_update_1).to have_been_requested

--- a/spec/features/tag_importer_spec.rb
+++ b/spec/features/tag_importer_spec.rb
@@ -4,6 +4,7 @@ RSpec.feature "Tag importer", type: :feature do
   require 'gds_api/test_helpers/publishing_api_v2'
   include GdsApi::TestHelpers::PublishingApiV2
   include GoogleSheetHelper
+  include PublishingApiHelper
 
   before do
     Sidekiq::Testing.inline!
@@ -127,7 +128,7 @@ RSpec.feature "Tag importer", type: :feature do
     )
     taxon_1 = { title: 'Early Years', content_id: 'early-years-content-id' }
     taxon_2 = { title: 'Education', content_id: 'education-content-id' }
-    publishing_api_has_content([taxon_1, taxon_2], document_type: "taxon")
+    publishing_api_has_taxons([taxon_1, taxon_2])
 
     click_link "Create tags"
     expect(link_update_1).to have_been_requested

--- a/spec/features/tagging_content_spec.rb
+++ b/spec/features/tagging_content_spec.rb
@@ -151,26 +151,26 @@ RSpec.describe "Tagging content", type: :feature do
   end
 
   def given_we_can_populate_the_dropdowns_with_content_from_publishing_api
-    publishing_api_has_topics(
+    publishing_api_has_topic_linkables(
       [
         "/topic/id-of-already-tagged",
         "/topic/business-tax/pension-scheme-administration",
       ]
     )
 
-    publishing_api_has_taxons(
+    publishing_api_has_taxon_linkables(
       [
         "/alpha-taxonomy/vehicle-plating",
       ]
     )
 
-    publishing_api_has_organisations(
+    publishing_api_has_organisation_linkables(
       [
         "/government/organisations/student-loans-company",
       ]
     )
 
-    publishing_api_has_mainstream_browse_pages(
+    publishing_api_has_mainstream_browse_page_linkables(
       [
         "/browse/driving/car-tax-discs",
       ]

--- a/spec/features/tagging_during_migration_spec.rb
+++ b/spec/features/tagging_during_migration_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Tagging content during migration", type: :feature do
   end
 
   def given_we_can_populate_the_dropdowns_with_content_from_publishing_api
-    publishing_api_has_topics(
+    publishing_api_has_topic_linkables(
       [
         "/topic/id-of-already-tagged",
         "/topic/business-tax/pension-scheme-administration",

--- a/spec/features/taxonomy_manager_spec.rb
+++ b/spec/features/taxonomy_manager_spec.rb
@@ -60,8 +60,7 @@ RSpec.feature "Managing taxonomies" do
   end
 
   def given_there_are_taxons
-    stub_request(:get, "https://publishing-api.test.gov.uk/v2/linkables?document_type=taxon")
-      .to_return(body: [@taxon_1, @taxon_2].to_json)
+    publishing_api_has_content([@taxon_1, @taxon_2], document_type: "taxon")
 
     stub_request(:get, "https://publishing-api.test.gov.uk/v2/links/ID-1")
       .to_return(body: { links: { parent_taxons: [] } }.to_json)

--- a/spec/features/taxonomy_manager_spec.rb
+++ b/spec/features/taxonomy_manager_spec.rb
@@ -3,8 +3,20 @@ require "rails_helper"
 RSpec.feature "Managing taxonomies" do
   include PublishingApiHelper
   before do
-    @taxon_1 = { title: "I Am A Taxon", content_id: "ID-1", base_path: "/foo" }
-    @taxon_2 = { title: "I Am Another Taxon", content_id: "ID-2", base_path: "/bar" }
+    @taxon_1 = {
+      title: "I Am A Taxon",
+      content_id: "ID-1",
+      base_path: "/foo",
+      internal_name: "I Am A Taxon",
+      publication_state: 'active'
+    }
+    @taxon_2 = {
+      title: "I Am Another Taxon",
+      content_id: "ID-2",
+      base_path: "/bar",
+      internal_name: "I Am Another Taxon",
+      publication_state: 'active'
+    }
 
     @create_item = stub_request(:put, %r{https://publishing-api.test.gov.uk/v2/content*})
       .to_return(status: 200, body: {}.to_json)
@@ -61,6 +73,7 @@ RSpec.feature "Managing taxonomies" do
   end
 
   def given_there_are_taxons
+    publishing_api_has_linkables([@taxon_1, @taxon_2], document_type: 'taxon')
     publishing_api_has_taxons([@taxon_1, @taxon_2])
 
     stub_request(:get, "https://publishing-api.test.gov.uk/v2/links/ID-1")

--- a/spec/features/taxonomy_manager_spec.rb
+++ b/spec/features/taxonomy_manager_spec.rb
@@ -1,6 +1,7 @@
 require "rails_helper"
 
 RSpec.feature "Managing taxonomies" do
+  include PublishingApiHelper
   before do
     @taxon_1 = { title: "I Am A Taxon", content_id: "ID-1", base_path: "/foo" }
     @taxon_2 = { title: "I Am Another Taxon", content_id: "ID-2", base_path: "/bar" }
@@ -60,7 +61,7 @@ RSpec.feature "Managing taxonomies" do
   end
 
   def given_there_are_taxons
-    publishing_api_has_content([@taxon_1, @taxon_2], document_type: "taxon")
+    publishing_api_has_taxons([@taxon_1, @taxon_2])
 
     stub_request(:get, "https://publishing-api.test.gov.uk/v2/links/ID-1")
       .to_return(body: { links: { parent_taxons: [] } }.to_json)

--- a/spec/services/bulk_tagging/build_tag_migration_spec.rb
+++ b/spec/services/bulk_tagging/build_tag_migration_spec.rb
@@ -45,12 +45,10 @@ RSpec.describe BulkTagging::BuildTagMigration do
 
   context 'with 2 valid taxons and 2 content base paths' do
     before do
-      linkables = [
-        { "title" => "Taxon 1", "base_path" => "/foo", "content_id" => 'taxon-1' },
-        { "title" => "Taxon 2", "base_path" => "/aha", "content_id" => 'taxon-2' },
-      ]
+      taxon_1 = { title: "Taxon 1", base_path: "/foo", content_id: 'taxon-1' }
+      taxon_2 = { title: "Taxon 2", base_path: "/ha", content_id: 'taxon-2' }
 
-      publishing_api_has_linkables(linkables, document_type: 'taxon')
+      publishing_api_has_content([taxon_1, taxon_2], document_type: "taxon")
     end
 
     let(:tag_migration) do

--- a/spec/services/bulk_tagging/build_tag_migration_spec.rb
+++ b/spec/services/bulk_tagging/build_tag_migration_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe BulkTagging::BuildTagMigration do
+  include PublishingApiHelper
+
   let(:tag_migration_params) do
     {
       collection_content_id: 'content-id',
@@ -48,7 +50,7 @@ RSpec.describe BulkTagging::BuildTagMigration do
       taxon_1 = { title: "Taxon 1", base_path: "/foo", content_id: 'taxon-1' }
       taxon_2 = { title: "Taxon 2", base_path: "/ha", content_id: 'taxon-2' }
 
-      publishing_api_has_content([taxon_1, taxon_2], document_type: "taxon")
+      publishing_api_has_taxons([taxon_1, taxon_2])
     end
 
     let(:tag_migration) do

--- a/spec/services/taxonomy/taxon_fetcher_spec.rb
+++ b/spec/services/taxonomy/taxon_fetcher_spec.rb
@@ -6,13 +6,11 @@ RSpec.describe Taxonomy::TaxonFetcher do
 
   describe '#taxons' do
     it 'retrieves content items from publishing api and orders by title' do
-      linkables = [
-        { "title" => "foo", "base_path" => "/foo", "content_id" => SecureRandom.uuid },
-        { "title" => "bar", "base_path" => "/bar", "content_id" => SecureRandom.uuid },
-        { "title" => "aha", "base_path" => "/aha", "content_id" => SecureRandom.uuid },
-      ]
+      taxon_1 = { title: "foo", base_path: "/foo", content_id: SecureRandom.uuid }
+      taxon_2 = { title: "bar", base_path: "/bar", content_id: SecureRandom.uuid }
+      taxon_3 = { title: "aha", base_path: "/aha", content_id: SecureRandom.uuid }
 
-      publishing_api_has_linkables(linkables, document_type: 'taxon')
+      publishing_api_has_content([taxon_1, taxon_2, taxon_3], document_type: "taxon")
 
       result = described_class.new.taxons
 
@@ -25,11 +23,10 @@ RSpec.describe Taxonomy::TaxonFetcher do
     it 'returns the content ids of all taxons' do
       content_id_1 = SecureRandom.uuid
       content_id_2 = SecureRandom.uuid
-      linkables = [
-        { "title" => "foo", "base_path" => "/foo", "content_id" => content_id_1 },
-        { "title" => "bar", "base_path" => "/bar", "content_id" => content_id_2 },
-      ]
-      publishing_api_has_linkables(linkables, document_type: 'taxon')
+      taxon_1 = { title: "foo", base_path: "/foo", content_id: content_id_1 }
+      taxon_2 = { title: "bar", base_path: "/bar", content_id: content_id_2 }
+
+      publishing_api_has_content([taxon_1, taxon_2], document_type: "taxon")
 
       result = described_class.new.taxon_content_ids
 
@@ -44,24 +41,18 @@ RSpec.describe Taxonomy::TaxonFetcher do
     let(:taxon) do
       instance_double(Taxon, parent_taxons: [taxon_id_1, taxon_id_2])
     end
-    let(:link_1) do
-      { title: "foo", base_path: "/foo", content_id: taxon_id_1 }
-    end
-    let(:link_2) do
-      { title: "bar", base_path: "/bar", content_id: taxon_id_2 }
-    end
-    let(:link_3) do
-      { title: "aha", base_path: "/aha", content_id: SecureRandom.uuid }
-    end
-    let(:linkables) { [link_1, link_2, link_3] }
 
     it 'returns the parent taxons for a given taxon' do
-      publishing_api_has_linkables(linkables, document_type: 'taxon')
+      taxon_1 = { title: "foo", base_path: "/foo", content_id: taxon_id_1 }
+      taxon_2 = { title: "bar", base_path: "/bar", content_id: taxon_id_2 }
+      taxon_3 = { title: "bar", base_path: "/bar", content_id: SecureRandom.uuid }
+
+      publishing_api_has_content([taxon_1, taxon_2, taxon_3], document_type: "taxon")
       result = described_class.new.parents_for_taxon(taxon)
 
       expect(result.count).to eq(2)
-      expect(result).to include(taxon_with_attributes(link_1))
-      expect(result).to include(taxon_with_attributes(link_2))
+      expect(result).to include(taxon_with_attributes(taxon_1))
+      expect(result).to include(taxon_with_attributes(taxon_2))
     end
   end
 end

--- a/spec/services/taxonomy/taxon_fetcher_spec.rb
+++ b/spec/services/taxonomy/taxon_fetcher_spec.rb
@@ -2,20 +2,23 @@ require 'rails_helper'
 require 'gds_api/test_helpers/publishing_api_v2'
 
 RSpec.describe Taxonomy::TaxonFetcher do
+  include PublishingApiHelper
   include GdsApi::TestHelpers::PublishingApiV2
 
   describe '#taxons' do
-    it 'retrieves content items from publishing api and orders by title' do
-      taxon_1 = { title: "foo", base_path: "/foo", content_id: SecureRandom.uuid }
-      taxon_2 = { title: "bar", base_path: "/bar", content_id: SecureRandom.uuid }
-      taxon_3 = { title: "aha", base_path: "/aha", content_id: SecureRandom.uuid }
+    it 'retrieves taxons from publishing api in descending order by public updated at' do
+      taxon_1 = { title: "foo" }
+      taxon_2 = { title: "bar" }
+      taxon_3 = { title: "aha" }
 
-      publishing_api_has_content([taxon_1, taxon_2, taxon_3], document_type: "taxon")
+      publishing_api_has_taxons([taxon_1, taxon_2, taxon_3])
 
       result = described_class.new.taxons
 
-      expect(result.first.title).to eq("aha")
-      expect(result.last.title).to eq("foo")
+      expect(result.first).to be_a(Taxon)
+      expect(result.first.title).to eq("foo")
+      expect(result.last).to be_a(Taxon)
+      expect(result.last.title).to eq("aha")
     end
   end
 
@@ -26,7 +29,7 @@ RSpec.describe Taxonomy::TaxonFetcher do
       taxon_1 = { title: "foo", base_path: "/foo", content_id: content_id_1 }
       taxon_2 = { title: "bar", base_path: "/bar", content_id: content_id_2 }
 
-      publishing_api_has_content([taxon_1, taxon_2], document_type: "taxon")
+      publishing_api_has_taxons([taxon_1, taxon_2])
 
       result = described_class.new.taxon_content_ids
 
@@ -46,8 +49,8 @@ RSpec.describe Taxonomy::TaxonFetcher do
       taxon_1 = { title: "foo", base_path: "/foo", content_id: taxon_id_1 }
       taxon_2 = { title: "bar", base_path: "/bar", content_id: taxon_id_2 }
       taxon_3 = { title: "bar", base_path: "/bar", content_id: SecureRandom.uuid }
+      publishing_api_has_taxons([taxon_1, taxon_2, taxon_3])
 
-      publishing_api_has_content([taxon_1, taxon_2, taxon_3], document_type: "taxon")
       result = described_class.new.parents_for_taxon(taxon)
 
       expect(result.count).to eq(2)

--- a/spec/support/publishing_api_helper.rb
+++ b/spec/support/publishing_api_helper.rb
@@ -1,4 +1,12 @@
 module PublishingApiHelper
+  def publishing_api_has_taxons(taxons)
+    publishing_api_has_content(
+      taxons,
+      document_type: "taxon",
+      order: '-public_updated_at',
+    )
+  end
+
   def publishing_api_has_taxon_linkables(base_paths)
     publishing_api_has_linkables(
       select_by_base_path(stubbed_taxons, base_paths),

--- a/spec/support/publishing_api_helper.rb
+++ b/spec/support/publishing_api_helper.rb
@@ -1,26 +1,26 @@
 module PublishingApiHelper
-  def publishing_api_has_taxons(base_paths)
+  def publishing_api_has_taxon_linkables(base_paths)
     publishing_api_has_linkables(
       select_by_base_path(stubbed_taxons, base_paths),
       document_type: 'taxon'
     )
   end
 
-  def publishing_api_has_topics(base_paths)
+  def publishing_api_has_topic_linkables(base_paths)
     publishing_api_has_linkables(
       select_by_base_path(stubbed_topics, base_paths),
       document_type: 'topic'
     )
   end
 
-  def publishing_api_has_organisations(base_paths)
+  def publishing_api_has_organisation_linkables(base_paths)
     publishing_api_has_linkables(
       select_by_base_path(stubbed_organisations, base_paths),
       document_type: 'organisation'
     )
   end
 
-  def publishing_api_has_mainstream_browse_pages(base_paths)
+  def publishing_api_has_mainstream_browse_page_linkables(base_paths)
     publishing_api_has_linkables(
       select_by_base_path(stubbed_mainstream_browse_pages, base_paths),
       document_type: 'mainstream_browse_page'

--- a/spec/validators/taxons_validator_spec.rb
+++ b/spec/validators/taxons_validator_spec.rb
@@ -1,10 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe TaxonsValidator do
+  include PublishingApiHelper
+
   before do
     taxon = { title: "A taxon", content_id: 'taxon1-content-id' }
 
-    publishing_api_has_content([taxon], document_type: "taxon")
+    publishing_api_has_taxons([taxon])
   end
 
   it 'validates unknown taxons' do

--- a/spec/validators/taxons_validator_spec.rb
+++ b/spec/validators/taxons_validator_spec.rb
@@ -2,13 +2,9 @@ require 'rails_helper'
 
 RSpec.describe TaxonsValidator do
   before do
-    publishing_api_has_linkables(
-      [{
-        'title' => 'A taxon',
-        'content_id' => 'taxon1-content-id',
-      }],
-      document_type: 'taxon'
-    )
+    taxon = { title: "A taxon", content_id: 'taxon1-content-id' }
+
+    publishing_api_has_content([taxon], document_type: "taxon")
   end
 
   it 'validates unknown taxons' do


### PR DESCRIPTION
This PR does the following:

- changes the way we fetch Taxons from `get_linkables` to `get_content_items`;
- sorts taxons by their `public_updated_at` attribute rather than by `title`. This is now possible because we are using `get_content_items`, which returns a lot more attributes for each of the taxons.

Trello: https://trello.com/c/y9VdJshp/111-add-created-at-updated-at-ordering-to-taxons-list