### PR TITLE
Differentiate between search and tagging

### DIFF
--- a/app/views/tag_searches/new.html.erb
+++ b/app/views/tag_searches/new.html.erb
@@ -14,6 +14,7 @@
     <tr class="table-header">
       <th>Title</th>
       <th>Content ID</th>
+      <th>Document type</th>
     </tr>
   </thead>
   <tbody>
@@ -31,6 +32,7 @@
                 }
               ) %>
           </td>
+          <td><%= collection.document_type.humanize %></td>
         </tr>
       <% end %>
     <% else %>

--- a/app/views/tag_searches/new.html.erb
+++ b/app/views/tag_searches/new.html.erb
@@ -1,48 +1,43 @@
 <%= display_header title: 'Tag Search', breadcrumbs: ["Tag Search"] %>
 
-<div class="row">
-  <div class="col-md-4">
-    <%= simple_form_for :collection_search, url: results_of_tag_search_path, method: :get do |f| %>
-      <div class="form-group">
-        <%= f.input :query,
-          input_html: { type: :text, class: 'form-control', value: query },
-          label: 'Query'%>
-        <%= f.submit "Search collection", class: "btn btn-md btn-success" %>
-      </div>
-    <% end %>
+<%= simple_form_for :collection_search, url: results_of_tag_search_path, method: :get do |f| %>
+  <div class="form-group">
+    <%= f.input :query,
+      input_html: { type: :text, class: 'form-control', value: query },
+      label: 'Query'%>
+    <%= f.submit "Search collection", class: "btn btn-md btn-success" %>
   </div>
-  <div class="col-md-8">
-    <table class="table queries-list table-bordered" data-module="filterable-table">
-      <thead>
-        <tr class="table-header">
-          <th>Title</th>
-          <th>Content ID</th>
+<% end %>
+
+<table class="table queries-list table-bordered" data-module="filterable-table">
+  <thead>
+    <tr class="table-header">
+      <th>Title</th>
+      <th>Content ID</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% if results.present? %>
+      <% results.each do |collection| %>
+        <tr>
+          <td><%= collection.title %></td>
+          <td>
+            <%= link_to collection.content_id,
+              new_tag_migration_path(
+                tag_migration: {
+                  source_content_id: collection.content_id,
+                  source_base_path: collection.base_path,
+                  query: query,
+                }
+              ) %>
+          </td>
         </tr>
-      </thead>
-      <tbody>
-        <% if results.present? %>
-          <% results.each do |collection| %>
-            <tr>
-              <td><%= collection.title %></td>
-              <td>
-                <%= link_to collection.content_id,
-                  new_tag_migration_path(
-                    tag_migration: {
-                      source_content_id: collection.content_id,
-                      source_base_path: collection.base_path,
-                      query: query,
-                    }
-                  ) %>
-              </td>
-            </tr>
-          <% end %>
-        <% else %>
-            <tr>
-              <td><p>No results to display. Search to see results.</p></td>
-              <td></td>
-            </tr>
-        <% end %>
-      </tbody>
-    </table>
-  </div>
-</div>
+      <% end %>
+    <% else %>
+        <tr>
+          <td><p>No results to display. Search to see results.</p></td>
+          <td></td>
+        </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/spec/features/bulk_tagging_spec.rb
+++ b/spec/features/bulk_tagging_spec.rb
@@ -72,6 +72,7 @@ RSpec.feature "Bulk tagging", type: :feature do
     click_button "Search collection"
     expect(page).to have_text("Tax documents")
     expect(page).to have_link("collection-id")
+    expect(page).to have_text('Document collection')
   end
 
   def then_i_can_see_the_content_items_in_this_collection


### PR DESCRIPTION
This commit changes how the `TagSearch#new` view is presented, so it is not confused with `TagMigrations#new` (i.e. the next step in the tagging process).

The layout is ported from `search-admin`, with the search form in full with and the search results underneath it.

I've also added the `document_type` to the search results to make it clear what document type we are selecting.

The new view looks like this:

<img width="1415" alt="screen shot 2016-09-12 at 11 07 27" src="https://cloud.githubusercontent.com/assets/416701/18432328/4d15211a-78d9-11e6-8f8f-2ba34af773ed.png">

And the next step stays as-is:

<img width="1416" alt="screen shot 2016-09-12 at 11 07 49" src="https://cloud.githubusercontent.com/assets/416701/18432332/546a82fc-78d9-11e6-9a56-6556b5a7e7e8.png">

Trello: https://trello.com/c/bw6RqXta/153-bulk-tagging-make-sure-the-bulk-taggings-new-and-collections-show-views-are-different-from-each-other-to-avoid-confusion

Thoughts?