### PR TITLE
Error handling improvements when importing spreadsheet data

### DIFF
--- a/app/services/tag_importer/fetch_remote_data.rb
+++ b/app/services/tag_importer/fetch_remote_data.rb
@@ -31,13 +31,14 @@ module TagImporter
     end
 
     def save_row(row)
-      tagging_spreadsheet.tag_mappings.build(
+      TagMapping.create!(
+        tagging_source:     tagging_spreadsheet,
         content_base_path:  String(row["content_base_path"]),
         link_title:         row["link_title"],
         link_content_id:    String(row["link_content_id"]),
         link_type:          String(row["link_type"]),
         state:              'ready_to_tag'
-      ).save
+      )
     end
 
     def parsed_data

--- a/app/services/tag_importer/fetch_remote_data.rb
+++ b/app/services/tag_importer/fetch_remote_data.rb
@@ -32,10 +32,10 @@ module TagImporter
 
     def save_row(row)
       tagging_spreadsheet.tag_mappings.build(
-        content_base_path:  row["content_base_path"],
+        content_base_path:  String(row["content_base_path"]),
         link_title:         row["link_title"],
-        link_content_id:    row["link_content_id"],
-        link_type:          row["link_type"],
+        link_content_id:    String(row["link_content_id"]),
+        link_type:          String(row["link_type"]),
         state:              'ready_to_tag'
       ).save
     end

--- a/app/workers/initial_tagging_import.rb
+++ b/app/workers/initial_tagging_import.rb
@@ -1,6 +1,8 @@
 class InitialTaggingImport
   include Sidekiq::Worker
 
+  sidekiq_options retry: false
+
   def perform(tagging_spreadsheet_id)
     tagging_spreadsheet = TaggingSpreadsheet.find(tagging_spreadsheet_id)
     errors = TagImporter::FetchRemoteData.new(tagging_spreadsheet).run


### PR DESCRIPTION
Fix a bug where blank values for certain fields in the import TSV file would result in the worker choking on a DB not null constraint.

Includes some small behavioural changes in how we handle the import. See commits for details.

https://trello.com/c/0JxMuAxU/166-content-tagger-fix-error-handling-behaviour-when-tag-mapping-base-path-is-blank