### PR TITLE
Workaround for linkables with internal names of nil

### DIFF
--- a/lib/linkables.rb
+++ b/lib/linkables.rb
@@ -52,6 +52,9 @@ private
   end
 
   def get_tags_of_type(document_type)
-    Services.publishing_api.get_linkables(format: document_type)
+    items = Services.publishing_api.get_linkables(format: document_type)
+    # We only are interested in linkables that have an internal name and not
+    # redirects or similar
+    items.select { |item| item['internal_name'] }
   end
 end

--- a/spec/lib/linkables_spec.rb
+++ b/spec/lib/linkables_spec.rb
@@ -14,7 +14,15 @@ RSpec.describe Linkables do
             "publication_state" => "live",
             "base_path" => "/topic/business-tax/pension-scheme-administration",
             "internal_name" => "Business tax / Pension scheme administration"
-          }
+          },
+          {
+            "public_updated_at" => "2016-04-07 10:34:05",
+            "title" => nil,
+            "content_id" => "3535b8ad-7209-4c97-9dac-e25c25d9c27c",
+            "publication_state" => "live",
+            "base_path" => "/topic/redirect",
+            "internal_name" => nil
+          },
         ],
         document_type: "topic",
       )


### PR DESCRIPTION
Accessing linkables on the Publishing API can return nil for fields such as internal_name or title when the linkable item is a redirect. In this instance we have a problem when the internal_name is nil as we require it to be a string.

To address this we filter the linkables from the Publishing API to only include instances where the internal_name is not nil.

Whether redirects should be in the linkables is something we need to work out over at Publishing API land, but hopefully this can resolve the issues you're currently having.