### PR TITLE
Fix migration for polymorphic tag mappings

### DIFF
--- a/db/migrate/20160902132101_make_tag_mapping_polymorphic.rb
+++ b/db/migrate/20160902132101_make_tag_mapping_polymorphic.rb
@@ -3,10 +3,6 @@ class MakeTagMappingPolymorphic < ActiveRecord::Migration
     rename_column :tag_mappings, :tagging_spreadsheet_id, :tagging_source_id
     add_column :tag_mappings, :tagging_source_type, :string
 
-    TagMapping.transaction do
-      TagMapping.all.each do |tag_mapping|
-        tag_mapping.update!(taggable_type: 'TaggingSpreadsheet')
-      end
-    end
+    execute "UPDATE tag_mappings SET tagging_source_type = 'TaggingSpreadsheet'"
   end
 end


### PR DESCRIPTION
The `taggable_type` attribute got renamed from `taggable_type`.

Because locally there weren't any records in the tag_mappings table, this didn't surface. On staging there are records, so this migration fails because `taggable_type` doesn't exist.

Also makes it use a SQL query, which is faster and more robust.