### PR TITLE
Add feature spec to test the progress bar

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,4 +38,7 @@ end
 group :test do
   gem 'webmock', '~> 1.22'
   gem 'capybara'
+  gem 'capybara-webkit'
+  gem 'headless'
+  gem 'database_cleaner'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,11 +63,15 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    capybara-webkit (1.11.1)
+      capybara (>= 2.3.0, < 2.8.0)
+      json
     coderay (1.1.1)
     concurrent-ruby (1.0.2)
     connection_pool (2.2.0)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
+    database_cleaner (1.5.3)
     debug_inspector (0.0.2)
     diff-lcs (1.2.5)
     docile (1.1.5)
@@ -118,6 +122,7 @@ GEM
       sidekiq-statsd (~> 0.1)
     hashdiff (0.3.0)
     hashie (3.4.4)
+    headless (2.3.1)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
     i18n (0.7.0)
@@ -338,6 +343,8 @@ DEPENDENCIES
   airbrake (~> 4.3.1)
   better_errors
   capybara
+  capybara-webkit
+  database_cleaner
   factory_girl_rails
   gds-api-adapters (~> 35.0)
   gds-sso (~> 11.1)
@@ -345,6 +352,7 @@ DEPENDENCIES
   govuk-lint
   govuk_admin_template (~> 4.4)
   govuk_sidekiq (~> 0.0.4)
+  headless
   logstasher (= 0.6.2)
   pg
   plek (~> 1.10)

--- a/spec/features/bulk_tagging_spec.rb
+++ b/spec/features/bulk_tagging_spec.rb
@@ -32,6 +32,13 @@ RSpec.feature "Bulk tagging", type: :feature do
     then_i_see_an_error_about_content_items
   end
 
+  scenario "Creating tags shows progress", js: true do
+    given_a_tag_migration_exists
+    when_i_go_to_the_tag_migration_page
+    when_i_create_tags
+    then_i_can_see_a_progress_bar
+  end
+
   def given_a_collection_with_items_and_some_other_content_groupings
     publishing_api_has_content(
       [{
@@ -214,5 +221,27 @@ RSpec.feature "Bulk tagging", type: :feature do
     expect(row).to have_text(/imported/i)
     expect(row).to have_text('Tax')
     expect(row).to have_link('/tax-documents')
+  end
+
+  def given_a_tag_migration_exists
+    tag_migration = build(:tag_migration)
+    tag_migration.tag_mappings << build(:tag_mapping)
+    tag_migration.save!
+  end
+
+  def when_i_go_to_the_tag_migration_page
+    tag_migration = TagMigration.last
+
+    visit tag_migration_path(tag_migration.id)
+  end
+
+  def then_i_can_see_a_progress_bar
+    expect(page).to have_selector('.progress-bar')
+
+    bar = find('.progress-bar')
+    max_value = bar['aria-valuemax']
+    current_value = bar['aria-valuenow']
+
+    expect(current_value).to eq(max_value)
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,7 @@
 require 'webmock/rspec'
 
+WebMock.disable_net_connect!(allow_localhost: true)
+
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
@@ -22,12 +24,4 @@ RSpec.configure do |config|
   config.order = :random
 
   Kernel.srand config.seed
-
-  config.before :suite do
-    User.create!
-  end
-
-  config.before(:each) do
-    WebMock.reset!
-  end
 end


### PR DESCRIPTION
This test makes sure we can see the progress bar and that it completes.

The side effects of adding this feature test (and other JS tests in the future)
is that:
- we cannot use `:rack_test`, therefore we need to rely on a slower `webkit`
  driver to run those particular javascript tests;
- we cannot enable RSpec fixtures, and have to use `database_cleaner` instead (see [this](https://github.com/jnicklas/capybara/blob/master/README.md#transactions-and-database-setup));
- we have to use a `truncation` strategy, which means we then need to create our
  User record before each example (or re-create it after the js test)

On the plus side, we can select the Capybara javascript driver depending on the
type of tests, which means most of the tests still use `:rack_test`.

Trello: https://trello.com/c/qoimvKOL/167-add-a-basic-poltergeist-test-for-the-progress-bar-in-content-tagger