### PR TITLE
Consolidate TagMappings by content_base_path

### DIFF
--- a/app/controllers/tag_migrations_controller.rb
+++ b/app/controllers/tag_migrations_controller.rb
@@ -38,7 +38,7 @@ class TagMigrationsController < ApplicationController
   def show
     render :show, locals: {
       tag_migration: tag_migration,
-      tag_mappings: presented_tag_mappings,
+      aggregated_tag_mappings: presented_aggregated_tag_mappings,
       confirmed: tag_mappings.completed.count,
       progress_path: tag_migration_progress_path(tag_migration),
     }
@@ -107,6 +107,16 @@ private
   def presented_tag_mappings
     tag_mappings.map do |tag_mapping|
       TagMappingPresenter.new(tag_mapping)
+    end
+  end
+
+  def aggregated_tag_mappings
+    tag_migration.aggregated_tag_mappings
+  end
+
+  def presented_aggregated_tag_mappings
+    aggregated_tag_mappings.map do |aggregated_tag_mapping|
+      AggregatedTagMappingPresenter.new(aggregated_tag_mapping)
     end
   end
 end

--- a/app/controllers/tagging_spreadsheets_controller.rb
+++ b/app/controllers/tagging_spreadsheets_controller.rb
@@ -24,7 +24,7 @@ class TaggingSpreadsheetsController < ApplicationController
   def show
     render :show, locals: {
       tagging_spreadsheet: tagging_spreadsheet,
-      tag_mappings: presented_tag_mappings,
+      aggregated_tag_mappings: presented_aggregated_tag_mappings,
       confirmed: tag_mappings.completed.count,
       progress_path: tagging_spreadsheet_progress_path(tagging_spreadsheet),
     }
@@ -70,9 +70,13 @@ private
       .by_link_title
   end
 
-  def presented_tag_mappings
-    tag_mappings.map do |tag_mapping|
-      TagMappingPresenter.new(tag_mapping)
+  def aggregated_tag_mappings
+    tagging_spreadsheet.aggregated_tag_mappings
+  end
+
+  def presented_aggregated_tag_mappings
+    aggregated_tag_mappings.map do |aggregated_tag_mapping|
+      AggregatedTagMappingPresenter.new(aggregated_tag_mapping)
     end
   end
 

--- a/app/models/aggregated_tag_mapping.rb
+++ b/app/models/aggregated_tag_mapping.rb
@@ -1,0 +1,21 @@
+class AggregatedTagMapping
+  include ActiveModel::Model
+
+  attr_accessor :content_base_path, :tag_mappings
+
+  def links
+    tag_mappings.map do |tag_mapping|
+      Link.new(
+        link_title: tag_mapping.link_title,
+        link_content_id: tag_mapping.link_content_id,
+        link_type: tag_mapping.link_type,
+      )
+    end
+  end
+
+  class Link 
+    include ActiveModel::Model
+
+    attr_accessor :link_title, :link_content_id, :link_type
+  end
+end

--- a/app/models/aggregated_tag_mapping.rb
+++ b/app/models/aggregated_tag_mapping.rb
@@ -13,7 +13,7 @@ class AggregatedTagMapping
     end
   end
 
-  class Link 
+  class Link
     include ActiveModel::Model
 
     attr_accessor :link_title, :link_content_id, :link_type

--- a/app/models/concerns/aggregatable_tag_mappings.rb
+++ b/app/models/concerns/aggregatable_tag_mappings.rb
@@ -1,0 +1,23 @@
+module AggregatableTagMappings
+  extend ActiveSupport::Concern
+
+  def aggregated_tag_mappings
+    tag_mappings_grouped_by_content_base_path.reduce([]) do |accumulator, aggregation|
+      accumulator << AggregatedTagMapping.new(content_base_path: aggregation.first, tag_mappings: aggregation.last)
+    end
+  end
+
+private
+
+  def tag_mappings_grouped_by_content_base_path
+    tag_mappings.by_state.by_content_base_path.by_link_title
+      .select(
+        :link_type,
+        :link_title,
+        :content_base_path,
+        :messages,
+        :link_content_id,
+        :state)
+      .group_by(&:content_base_path)
+  end
+end

--- a/app/models/tag_migration.rb
+++ b/app/models/tag_migration.rb
@@ -18,4 +18,25 @@ class TagMigration < ActiveRecord::Base
   def error_count
     tag_mappings.errored.count
   end
+
+  def aggregated_tag_mappings
+    tag_mappings_grouped_by_content_base_path.reduce([]) do |accumulator, aggregation|
+      accumulator << AggregatedTagMapping.new(content_base_path: aggregation.first, tag_mappings: aggregation.last)
+    end
+  end
+
+private
+
+  def tag_mappings_grouped_by_content_base_path
+    tag_mappings.by_state.by_content_base_path.by_link_title
+      .select(
+        :id,
+        :link_type,
+        :link_title,
+        :content_base_path,
+        :messages,
+        :link_content_id,
+        :state)
+      .group_by(&:content_base_path)
+  end
 end

--- a/app/models/tag_migration.rb
+++ b/app/models/tag_migration.rb
@@ -1,4 +1,6 @@
 class TagMigration < ActiveRecord::Base
+  include AggregatableTagMappings
+
   has_many :tag_mappings, dependent: :destroy, as: :tagging_source
   validates :source_content_id, presence: true
 
@@ -17,26 +19,5 @@ class TagMigration < ActiveRecord::Base
 
   def error_count
     tag_mappings.errored.count
-  end
-
-  def aggregated_tag_mappings
-    tag_mappings_grouped_by_content_base_path.reduce([]) do |accumulator, aggregation|
-      accumulator << AggregatedTagMapping.new(content_base_path: aggregation.first, tag_mappings: aggregation.last)
-    end
-  end
-
-private
-
-  def tag_mappings_grouped_by_content_base_path
-    tag_mappings.by_state.by_content_base_path.by_link_title
-      .select(
-        :id,
-        :link_type,
-        :link_title,
-        :content_base_path,
-        :messages,
-        :link_content_id,
-        :state)
-      .group_by(&:content_base_path)
   end
 end

--- a/app/models/tagging_spreadsheet.rb
+++ b/app/models/tagging_spreadsheet.rb
@@ -20,4 +20,28 @@ class TaggingSpreadsheet < ActiveRecord::Base
   def error_count
     tag_mappings.errored.count
   end
+
+  def aggregated_tag_mappings
+    aggregated_tag_mappings = []
+
+    tag_mappings_grouped_by_content_base_path.reduce([]) do |acc, aggregation|
+      aggregated_tag_mappings << AggregatedTagMapping.new(content_base_path: aggregation.first, tag_mappings: aggregation.last)
+    end
+
+    aggregated_tag_mappings
+  end
+
+private
+  def tag_mappings_grouped_by_content_base_path
+    tag_mappings.by_state.by_content_base_path.by_link_title.
+      select(
+        :id,
+        :link_type,
+        :link_title,
+        :content_base_path,
+        :message,
+        :link_content_id,
+        :state).
+      group_by(&:content_base_path)
+  end
 end

--- a/app/models/tagging_spreadsheet.rb
+++ b/app/models/tagging_spreadsheet.rb
@@ -22,26 +22,23 @@ class TaggingSpreadsheet < ActiveRecord::Base
   end
 
   def aggregated_tag_mappings
-    aggregated_tag_mappings = []
-
-    tag_mappings_grouped_by_content_base_path.reduce([]) do |acc, aggregation|
-      aggregated_tag_mappings << AggregatedTagMapping.new(content_base_path: aggregation.first, tag_mappings: aggregation.last)
+    tag_mappings_grouped_by_content_base_path.reduce([]) do |accumulator, aggregation|
+      accumulator << AggregatedTagMapping.new(content_base_path: aggregation.first, tag_mappings: aggregation.last)
     end
-
-    aggregated_tag_mappings
   end
 
 private
+
   def tag_mappings_grouped_by_content_base_path
-    tag_mappings.by_state.by_content_base_path.by_link_title.
-      select(
+    tag_mappings.by_state.by_content_base_path.by_link_title
+      .select(
         :id,
         :link_type,
         :link_title,
         :content_base_path,
-        :message,
+        :messages,
         :link_content_id,
-        :state).
-      group_by(&:content_base_path)
+        :state)
+      .group_by(&:content_base_path)
   end
 end

--- a/app/models/tagging_spreadsheet.rb
+++ b/app/models/tagging_spreadsheet.rb
@@ -1,4 +1,6 @@
 class TaggingSpreadsheet < ActiveRecord::Base
+  include AggregatableTagMappings
+
   validates :url, presence: true
   validates(
     :state,
@@ -19,26 +21,5 @@ class TaggingSpreadsheet < ActiveRecord::Base
 
   def error_count
     tag_mappings.errored.count
-  end
-
-  def aggregated_tag_mappings
-    tag_mappings_grouped_by_content_base_path.reduce([]) do |accumulator, aggregation|
-      accumulator << AggregatedTagMapping.new(content_base_path: aggregation.first, tag_mappings: aggregation.last)
-    end
-  end
-
-private
-
-  def tag_mappings_grouped_by_content_base_path
-    tag_mappings.by_state.by_content_base_path.by_link_title
-      .select(
-        :id,
-        :link_type,
-        :link_title,
-        :content_base_path,
-        :messages,
-        :link_content_id,
-        :state)
-      .group_by(&:content_base_path)
   end
 end

--- a/app/presenters/aggregated_tag_mapping_presenter.rb
+++ b/app/presenters/aggregated_tag_mapping_presenter.rb
@@ -1,17 +1,11 @@
 class AggregatedTagMappingPresenter < SimpleDelegator
   def errored?
-    presented_tag_mappings.any? do |tag_mapping|
-      tag_mapping.errored?
-    end
+    presented_tag_mappings.any?(&:errored?)
   end
 
   def error_messages
-    presented_tag_mappings.flat_map do |tag_mapping|
-      tag_mapping.messages
-    end
+    presented_tag_mappings.flat_map(&:messages)
   end
-
-private
 
   def presented_tag_mappings
     tag_mappings.map do |tag_mapping|

--- a/app/presenters/aggregated_tag_mapping_presenter.rb
+++ b/app/presenters/aggregated_tag_mapping_presenter.rb
@@ -1,0 +1,21 @@
+class AggregatedTagMappingPresenter < SimpleDelegator
+  def errored?
+    presented_tag_mappings.any? do |tag_mapping|
+      tag_mapping.errored?
+    end
+  end
+
+  def error_messages
+    presented_tag_mappings.flat_map do |tag_mapping|
+      tag_mapping.messages
+    end
+  end
+
+private
+
+  def presented_tag_mappings
+    tag_mappings.map do |tag_mapping|
+      TagMappingPresenter.new(tag_mapping)
+    end
+  end
+end

--- a/app/views/application/_aggregated_tag_mappings.html.erb
+++ b/app/views/application/_aggregated_tag_mappings.html.erb
@@ -1,0 +1,29 @@
+<% aggregated_tag_mappings.each do |aggregated_tagging| %>
+  <tr>
+    <td><%= link_to aggregated_tagging.content_base_path, website_url(aggregated_tagging.content_base_path) %></td>
+    <td>
+      <% aggregated_tagging.links.each do |tag_link| %>
+        <%= link_to tag_link.link_title, tagging_path(tag_link.link_content_id) %> (<%= tag_link.link_type %>)
+        <br />
+      <% end%>
+
+      <% if aggregated_tagging.errored? %>
+        <hr />
+        <span class="error-message">
+          <ul>
+            <% aggregated_tagging.error_messages.each do |error_message| %>
+            <li><%= error_message %></li>
+            <% end %>
+          </ul>
+        </span>
+      <% end %>
+    </td>
+
+    <td class="tag-mapping-status">
+      <% aggregated_tagging.presented_tag_mappings.each do |tag_mapping| %>
+        <%= state_label_for(label_type: tag_mapping.label_type, title: tag_mapping.state_title) %>
+        <br>
+      <% end %>
+    </td>
+  </tr>
+<% end %>

--- a/app/views/application/_tag_update_preview.html.erb
+++ b/app/views/application/_tag_update_preview.html.erb
@@ -2,9 +2,9 @@
   <br/>
 
   <div data-module="tag-update-progress">
-    <% if tag_mappings.any? %>
+    <% if aggregated_tag_mappings.any? %>
       <%= render partial: "tag_update_progress_bar",
-        locals: { tag_mappings: tag_mappings, confirmed: confirmed, progress_path: progress_path } %>
+        locals: { tag_mappings: aggregated_tag_mappings, confirmed: confirmed, progress_path: progress_path } %>
     <% end %>
   </div>
 
@@ -24,28 +24,8 @@
     </thead>
 
     <tbody>
-      <% tag_mappings.each do |tag| %>
-        <tr>
-          <td><%= link_to tag.content_base_path, website_url(tag.content_base_path) %></td>
-          <td>
-            <%= link_to tag.link_title, tagging_path(tag.link_content_id) %> (<%= tag.link_type %>)
-
-            <% if tag.errored? %>
-              <hr />
-              <span class="error-message">
-                <ul>
-                  <% tag.messages.each do |message| %>
-                  <li><%= message %></li>
-                  <% end %>
-                </ul>
-              </span>
-            <% end %>
-          </td>
-          <td class="tag-mapping-status">
-            <%= state_label_for(label_type: tag.label_type, title: tag.state_title) %>
-          </td>
-        </tr>
-      <% end %>
+      <%= render partial: 'aggregated_tag_mappings',
+        locals: { aggregated_tag_mappings: aggregated_tag_mappings } %>
     </tbody>
   </table>
 </div>

--- a/app/views/tag_migrations/show.html.erb
+++ b/app/views/tag_migrations/show.html.erb
@@ -15,7 +15,7 @@
       locals: {
         confirmed: confirmed,
         error_count: tag_migration.error_count,
-        tag_mappings: tag_mappings,
+        aggregated_tag_mappings: aggregated_tag_mappings,
         progress_path: progress_path,
       }
     )

--- a/app/views/tagging_spreadsheets/show.html.erb
+++ b/app/views/tagging_spreadsheets/show.html.erb
@@ -20,7 +20,7 @@
       locals: {
         confirmed: confirmed,
         error_count: tagging_spreadsheet.error_count,
-        tag_mappings: tag_mappings,
+        aggregated_tag_mappings: aggregated_tag_mappings,
         progress_path: progress_path,
       }
     )

--- a/spec/features/bulk_tagging_spec.rb
+++ b/spec/features/bulk_tagging_spec.rb
@@ -134,11 +134,11 @@ RSpec.feature "Bulk tagging", type: :feature do
   def then_i_can_preview_my_changes
     click_button "Bulk tag selected items"
 
-    expect(all("table tbody tr").count).to eq 4
+    expect(all("table tbody tr").count).to eq TagMigration.first.aggregated_tag_mappings.count
     expect(page).to have_text("Taxon 1", count: 2)
     expect(page).to have_text("Taxon 2", count: 2)
-    expect(page).to have_text("/path/tax-doc-1", count: 2)
-    expect(page).to have_text("/path/tax-doc-2", count: 2)
+    expect(page).to have_text("/path/tax-doc-1", count: 1)
+    expect(page).to have_text("/path/tax-doc-2", count: 1)
 
     within("table") do
       state_labels = all("span.label")

--- a/spec/features/tag_importer_spec.rb
+++ b/spec/features/tag_importer_spec.rb
@@ -128,7 +128,8 @@ RSpec.feature "Tag importer", type: :feature do
 
   def expect_tag_mapping_statuses_to_be(string)
     tag_mapping_statuses = page.all(".tag-mapping-status")
-    expect(tag_mapping_statuses.count).to eq TagMapping.count
+    expect(tag_mapping_statuses.count).to eq TaggingSpreadsheet.first.aggregated_tag_mappings.count
+
     tag_mapping_statuses.each do |status|
       expect(status.text).to include string
     end

--- a/spec/models/tagging_spreadsheet_spec.rb
+++ b/spec/models/tagging_spreadsheet_spec.rb
@@ -30,4 +30,29 @@ RSpec.describe TaggingSpreadsheet do
       expect(tagging_spreadsheet.deleted_at).to_not be_nil
     end
   end
+
+  describe '#aggregated_tag_mappings' do
+    before do
+      @tagging_spreadsheet = build(:tagging_spreadsheet)
+      @tagging_spreadsheet.tag_mappings << build(:tag_mapping, content_base_path: '/a/path', link_content_id: 'a-content-id-1', link_title: 'Education')
+      @tagging_spreadsheet.tag_mappings << build(:tag_mapping, content_base_path: '/a/path', link_content_id: 'a-content-id-2', link_title: 'Early Years')
+      @tagging_spreadsheet.tag_mappings << build(:tag_mapping, content_base_path: '/b/path', link_content_id: 'a-content-id-2', link_title: 'Early Years')
+      @tagging_spreadsheet.save!
+
+      @aggregated_tag_mappings = @tagging_spreadsheet.aggregated_tag_mappings
+    end
+
+    it 'returns an array of AggregatedTagMappings' do
+      expect(@aggregated_tag_mappings.class).to eql(Array)
+      expect(@aggregated_tag_mappings.first.class).to eql(AggregatedTagMapping)
+    end
+
+    it 'returns the expected aggregated tag mappings' do
+      expect(@aggregated_tag_mappings.first.content_base_path).to eql('/a/path')
+      expect(@aggregated_tag_mappings.first.tag_mappings.count).to eql(2)
+
+      expect(@aggregated_tag_mappings.last.content_base_path).to eql('/b/path')
+      expect(@aggregated_tag_mappings.last.tag_mappings.count).to eql(1)
+    end
+  end
 end

--- a/spec/presenters/aggregated_tag_mapping_presenter_spec.rb
+++ b/spec/presenters/aggregated_tag_mapping_presenter_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe AggregatedTagMappingPresenter do
+  let!(:tag_mappings) { [create(:tag_mapping), create(:tag_mapping)] }
+  let(:aggregated_tag_mapping) { TaggingSpreadsheet.first.aggregated_tag_mappings.first }
+  let(:presenter) { described_class.new(aggregated_tag_mapping) }
+
+  describe '#errored?' do
+    it 'should return true when any tag mapping state is "errored"' do
+      tag_mappings.first.update(state: 'errored')
+
+      expect(presenter.errored?).to be_truthy
+    end
+
+    it 'should return false when none of the tag mappings state is not "errored"' do
+      tag_mappings.first.update(state: 'tagged')
+
+      expect(presenter.errored?).to be_falsey
+    end
+  end
+end


### PR DESCRIPTION
This approach is to consolidate records in order to see them in one row per content item change.

I would like to receive some feedback on this approach and also make sure that it's not missing anything. I'm not sure if the local data I'm seeing is the whole picture as I seem to only have one `link_type` per content_base_path. 

Will leave the failing specs to be fixed after some discussion.

Trello: https://trello.com/c/lnE4VdSj

## Before

![screen shot 2016-09-14 at 16 12 59](https://cloud.githubusercontent.com/assets/136777/18519047/4f96c598-7a9a-11e6-9d43-7b76cc9d5494.png)

## After

![screen shot 2016-09-15 at 16 07 30](https://cloud.githubusercontent.com/assets/136777/18556692/11613342-7b64-11e6-8eda-0e7b92ac73f1.png)
![screen shot 2016-09-15 at 16 06 47](https://cloud.githubusercontent.com/assets/136777/18556693/1178230e-7b64-11e6-9134-4bc4c0879aac.png)

![screen shot 2016-09-15 at 16 56 15](https://cloud.githubusercontent.com/assets/136777/18557190/df48e4e8-7b65-11e6-8619-e302181ee769.png)

