### PR TITLE
Clean up string data from remote TSV files

### DIFF
--- a/app/services/tag_importer/fetch_remote_data.rb
+++ b/app/services/tag_importer/fetch_remote_data.rb
@@ -33,12 +33,16 @@ module TagImporter
     def save_row(row)
       TagMapping.create!(
         tagging_source:     tagging_spreadsheet,
-        content_base_path:  String(row["content_base_path"]),
-        link_title:         row["link_title"],
-        link_content_id:    String(row["link_content_id"]),
-        link_type:          String(row["link_type"]),
-        state:              'ready_to_tag'
+        content_base_path:  cast_and_strip(row["content_base_path"]),
+        link_title:         cast_and_strip(row["link_title"]),
+        link_content_id:    cast_and_strip(row["link_content_id"]),
+        link_type:          cast_and_strip(row["link_type"]),
+        state:              'ready_to_tag',
       )
+    end
+
+    def cast_and_strip(string)
+      String(string).strip
     end
 
     def parsed_data

--- a/spec/support/google_sheet_helper.rb
+++ b/spec/support/google_sheet_helper.rb
@@ -12,6 +12,12 @@ module GoogleSheetHelper
     ].concat(extra_rows).join("\n")
   end
 
+  def empty_google_sheet(with_rows: [])
+    [
+      google_sheet_row(content_base_path: "content_base_path", link_title: "link_title", link_content_id: "link_content_id", link_type: "link_type"),
+    ].concat(with_rows).join("\n")
+  end
+
   def google_sheet_row(content_base_path:, link_title:, link_content_id:, link_type:)
     [content_base_path, link_title, link_content_id, link_type].join("\t")
   end


### PR DESCRIPTION
Extra whitespace on the values used to create a tag mapping can lead to
errors when bulk updating tags. This was first noticed on an import
where some items contained an extra space on the base path, causing the
content ID lookup to fail.

https://trello.com/c/i8l1URk0/174-clean-up-whitespace-before-creating-tag-mappings-content-tagger-import