### PR TITLE
Improve error handling

### DIFF
--- a/app/models/links_update.rb
+++ b/app/models/links_update.rb
@@ -35,6 +35,6 @@ class LinksUpdate
   def mark_as_errored
     return if errors.messages.blank?
     message = errors.messages.values.join(' ')
-    tag_mappings.update_all(state: :errored, message: message)
+    tag_mappings.update_all(state: :errored, messages: message)
   end
 end

--- a/app/models/links_update.rb
+++ b/app/models/links_update.rb
@@ -35,9 +35,17 @@ class LinksUpdate
   def mark_as_errored
     return if errors.messages.blank?
 
-    tag_mappings.update_all(
-      state: :errored,
-      messages: errors.messages.values.flatten
-    )
+    ActiveRecord::Base.transaction do
+      tag_mappings.update_all(
+        state: :errored,
+        messages: errors.messages.values.flatten
+      )
+
+      tag_mapping = tag_mappings.first
+      tag_mapping.tagging_source.update(
+        state: :errored,
+        error_message: I18n.t('tag_import.errors.tag_mappings_failed')
+      )
+    end
   end
 end

--- a/app/models/links_update.rb
+++ b/app/models/links_update.rb
@@ -34,7 +34,10 @@ class LinksUpdate
 
   def mark_as_errored
     return if errors.messages.blank?
-    message = errors.messages.values.join(' ')
-    tag_mappings.update_all(state: :errored, messages: message)
+
+    tag_mappings.update_all(
+      state: :errored,
+      messages: errors.messages.values.flatten
+    )
   end
 end

--- a/app/models/tag_mapping.rb
+++ b/app/models/tag_mapping.rb
@@ -7,6 +7,10 @@ class TagMapping < ActiveRecord::Base
   scope :by_link_title, -> { order(link_title: :asc) }
   scope :by_state, -> { order(state: :asc) }
 
+  # TODO: when migration 20160915141004 runs in production, be more strict and
+  # change this serialization to `serialize :messages, Array`.
+  serialize :messages
+
   validates(
     :state,
     presence: true,

--- a/app/models/tag_migration.rb
+++ b/app/models/tag_migration.rb
@@ -5,7 +5,7 @@ class TagMigration < ActiveRecord::Base
   validates(
     :state,
     presence: true,
-    inclusion: { in: %w(ready_to_import imported) }
+    inclusion: { in: %w(ready_to_import imported errored) }
   )
 
   scope :newest_first, -> { order(created_at: :desc) }

--- a/app/presenters/tag_mapping_presenter.rb
+++ b/app/presenters/tag_mapping_presenter.rb
@@ -15,6 +15,6 @@ class TagMappingPresenter < SimpleDelegator
   end
 
   def error_messages
-    message.split('.')
+    messages.split('.')
   end
 end

--- a/app/presenters/tag_mapping_presenter.rb
+++ b/app/presenters/tag_mapping_presenter.rb
@@ -13,8 +13,4 @@ class TagMappingPresenter < SimpleDelegator
   def errored?
     state == 'errored'
   end
-
-  def error_messages
-    messages.split('.')
-  end
 end

--- a/app/views/application/_tag_update_preview.html.erb
+++ b/app/views/application/_tag_update_preview.html.erb
@@ -34,8 +34,8 @@
               <hr />
               <span class="error-message">
                 <ul>
-                  <% tag.error_messages.each do |error_message| %>
-                  <li><%= error_message %></li>
+                  <% tag.messages.each do |message| %>
+                  <li><%= message %></li>
                   <% end %>
                 </ul>
               </span>

--- a/app/views/tagging_spreadsheets/index.html.erb
+++ b/app/views/tagging_spreadsheets/index.html.erb
@@ -20,9 +20,8 @@
       <tr>
         <td><%= state_label_for(label_type: spreadsheet.label_type,
                                 title: spreadsheet.state_title) %></td>
-        <td><%= link_to spreadsheet.url, spreadsheet.url %></td>
         <td>
-          <%= spreadsheet.description %>
+          <%= link_to spreadsheet.url, spreadsheet.url %>
 
           <% if spreadsheet.errored? %>
             <hr />
@@ -32,6 +31,9 @@
               </ul>
             </span>
           <% end %>
+        </td>
+        <td>
+          <%= spreadsheet.description %>
         </td>
         <td>
           <%= time_tag_for(spreadsheet.created_at) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -15,6 +15,7 @@ en:
       invalid_content_id: We could not find this URL on GOV.UK.
       invalid_link_types: Invalid link types found - only taxons are allowed.
       invalid_taxons_found: Invalid taxons found - please make sure you only use existing taxons when tagging.
+      tag_mappings_failed: We could not tag all items, please check the preview for more details.
   bulk_tagging:
     update_tags:
       no_taxons: No taxons selected.

--- a/db/migrate/20160915140148_rename_message_to_messages_on_tag_mappings.rb
+++ b/db/migrate/20160915140148_rename_message_to_messages_on_tag_mappings.rb
@@ -1,0 +1,5 @@
+class RenameMessageToMessagesOnTagMappings < ActiveRecord::Migration
+  def change
+    rename_column :tag_mappings, :message, :messages
+  end
+end

--- a/db/migrate/20160915141004_change_existing_messages_to_an_array_on_tag_mappings.rb
+++ b/db/migrate/20160915141004_change_existing_messages_to_an_array_on_tag_mappings.rb
@@ -1,0 +1,15 @@
+class ChangeExistingMessagesToAnArrayOnTagMappings < ActiveRecord::Migration
+  def change
+    TagMapping.transaction do
+      TagMapping.all.each do |tag_mapping|
+        current_messages = tag_mapping.messages
+        # We have stored messages in the database as strings separated by ".". The
+        # reason we are not splitting existing messages by "." here is because we
+        # have strings like "GOV.UK", which would incorrectly be split. This will
+        # allow us to serialize all the existing messages as an array.
+        tag_mapping.messages = [current_messages]
+        tag_mapping.save!
+      end
+    end
+  end
+end

--- a/db/migrate/20160915152936_add_error_message_to_tag_migrations.rb
+++ b/db/migrate/20160915152936_add_error_message_to_tag_migrations.rb
@@ -1,0 +1,5 @@
+class AddErrorMessageToTagMigrations < ActiveRecord::Migration
+  def change
+    add_column :tag_migrations, :error_message, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160915141004) do
+ActiveRecord::Schema.define(version: 20160915152936) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,6 +44,7 @@ ActiveRecord::Schema.define(version: 20160915141004) do
     t.string   "query"
     t.string   "source_base_path"
     t.string   "document_type"
+    t.string   "error_message"
   end
 
   create_table "tagging_spreadsheets", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160915140148) do
+ActiveRecord::Schema.define(version: 20160915141004) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160912102243) do
+ActiveRecord::Schema.define(version: 20160915140148) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -27,7 +27,7 @@ ActiveRecord::Schema.define(version: 20160912102243) do
     t.datetime "publish_requested_at"
     t.datetime "publish_completed_at"
     t.string   "state",                null: false
-    t.string   "message"
+    t.string   "messages"
     t.string   "tagging_source_type"
   end
 

--- a/spec/factories/tag_mapping.rb
+++ b/spec/factories/tag_mapping.rb
@@ -1,8 +1,9 @@
 FactoryGirl.define do
   factory :tag_mapping do
+    link_title 'A taxon title'
     content_base_path 'a/base/path'
     link_content_id 'a-content-id'
-    link_type 'taxon'
+    link_type 'taxons'
     association :tagging_source, factory: :tagging_spreadsheet
     state 'ready_to_tag'
   end

--- a/spec/features/tag_importer_spec.rb
+++ b/spec/features/tag_importer_spec.rb
@@ -215,7 +215,7 @@ RSpec.feature "Tag importer", type: :feature do
   def when_the_last_tag_mapping_has_errored
     tag_mapping = TagMapping.last
     tag_mapping.state = 'errored'
-    tag_mapping.message = 'An error message'
+    tag_mapping.messages = 'An error message'
     tag_mapping.save!
   end
 

--- a/spec/features/tag_importer_spec.rb
+++ b/spec/features/tag_importer_spec.rb
@@ -215,7 +215,7 @@ RSpec.feature "Tag importer", type: :feature do
   def when_the_last_tag_mapping_has_errored
     tag_mapping = TagMapping.last
     tag_mapping.state = 'errored'
-    tag_mapping.messages = 'An error message'
+    tag_mapping.messages = ['An error message']
     tag_mapping.save!
   end
 

--- a/spec/models/links_update_spec.rb
+++ b/spec/models/links_update_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe LinksUpdate do
       end
 
       it "concatenates the error messages and sets them on the tag mapping" do
-        expect(tag_mapping.message).to eql("Broken. Rubbish.")
+        expect(tag_mapping.messages).to eql("Broken. Rubbish.")
       end
     end
 
@@ -94,8 +94,8 @@ RSpec.describe LinksUpdate do
         expect { expectation.call }.to_not change { tag_mapping.state }
       end
 
-      it "doesn't change the tag mapping message" do
-        expect { expectation.call }.to_not change { tag_mapping.message }
+      it "doesn't change the tag mapping messages" do
+        expect { expectation.call }.to_not change { tag_mapping.messages }
       end
     end
   end

--- a/spec/models/links_update_spec.rb
+++ b/spec/models/links_update_spec.rb
@@ -77,8 +77,8 @@ RSpec.describe LinksUpdate do
         expect(tag_mapping.state).to eql("errored")
       end
 
-      it "concatenates the error messages and sets them on the tag mapping" do
-        expect(tag_mapping.messages).to eql("Broken. Rubbish.")
+      it "assigns the error messages to the record" do
+        expect(tag_mapping.messages).to eql(["Broken.", "Rubbish."])
       end
     end
 

--- a/spec/models/links_update_spec.rb
+++ b/spec/models/links_update_spec.rb
@@ -80,6 +80,15 @@ RSpec.describe LinksUpdate do
       it "assigns the error messages to the record" do
         expect(tag_mapping.messages).to eql(["Broken.", "Rubbish."])
       end
+
+      it 'changes the state of the tagging source to errored' do
+        expect(tag_mapping.tagging_source.state).to eq('errored')
+      end
+
+      it 'changes the error message of the tagging source' do
+        tagging_source = tag_mapping.tagging_source
+        expect(tagging_source.error_message).to match(/we could not tag all items/i)
+      end
     end
 
     context "when the links update is valid" do
@@ -96,6 +105,10 @@ RSpec.describe LinksUpdate do
 
       it "doesn't change the tag mapping messages" do
         expect { expectation.call }.to_not change { tag_mapping.messages }
+      end
+
+      it "doesn't change the state of the tagging source" do
+        expect { expectation.call }.to_not change { tag_mapping.tagging_source }
       end
     end
   end

--- a/spec/models/tag_migration_spec.rb
+++ b/spec/models/tag_migration_spec.rb
@@ -1,6 +1,22 @@
 require 'rails_helper'
 
 RSpec.describe TagMigration do
+  describe '#state' do
+    context 'valid states' do
+      it 'can be in an imported state' do
+        expect(build(:tag_migration, state: :imported)).to be_valid
+      end
+
+      it 'can be in a ready to import state' do
+        expect(build(:tag_migration, state: :ready_to_import)).to be_valid
+      end
+
+      it 'can be in an error state' do
+        expect(build(:tag_migration, state: :errored)).to be_valid
+      end
+    end
+  end
+
   describe '#mark_as_deleted' do
     it 'updates the deleted_at date' do
       tag_migration = build(:tag_migration)

--- a/spec/models/tagging_spreadsheet_spec.rb
+++ b/spec/models/tagging_spreadsheet_spec.rb
@@ -1,6 +1,26 @@
 require 'rails_helper'
 
 RSpec.describe TaggingSpreadsheet do
+  describe '#state' do
+    context 'valid states' do
+      it 'can be in an imported state' do
+        expect(build(:tagging_spreadsheet, state: :imported)).to be_valid
+      end
+
+      it 'can be in a ready to import state' do
+        expect(build(:tagging_spreadsheet, state: :ready_to_import)).to be_valid
+      end
+
+      it 'can be in an error state' do
+        expect(build(:tagging_spreadsheet, state: :errored)).to be_valid
+      end
+
+      it 'can be in an uploaded state' do
+        expect(build(:tagging_spreadsheet, state: :uploaded)).to be_valid
+      end
+    end
+  end
+
   describe '#mark_as_deleted' do
     it 'updates the deleted_at date' do
       tagging_spreadsheet = build(:tagging_spreadsheet)


### PR DESCRIPTION
This PR fixes:

1) how we display errors in the Tagging Spreadsheet's page

Before:

<img width="1152" alt="screen shot 2016-09-15 at 13 54 58" src="https://cloud.githubusercontent.com/assets/416701/18556205/97fb95ac-7b62-11e6-8d4d-50ce30b11eb4.png">

After:

<img width="1156" alt="screen shot 2016-09-15 at 13 55 18" src="https://cloud.githubusercontent.com/assets/416701/18556207/9b4ea3c0-7b62-11e6-9309-629e57e7e784.png">

2) Makes sure we can store multiple messages as a serialized Array into TagMapping records. With this change, we can store multiple messages in an Array and display it as-is in the view without needing to manipulate a string (by splitting in `.`, which isn't ideal).

3) Updates the `state` and `error_message` of a Tagging Source if at least one TagMapping fails.

4) Adds `error_message` and the `errored` state to TagMigrations, as those can be a Tagging Source. Without this, the point 3) would fail in this case.

Trello: https://trello.com/c/ETZ95krI/176-bug-content-tagger-spreadsheet-errors