### PR TITLE
Serialize TagMigration#messages as an Array

### DIFF
--- a/app/models/tag_mapping.rb
+++ b/app/models/tag_mapping.rb
@@ -7,9 +7,7 @@ class TagMapping < ActiveRecord::Base
   scope :by_link_title, -> { order(link_title: :asc) }
   scope :by_state, -> { order(state: :asc) }
 
-  # TODO: when migration 20160915141004 runs in production, be more strict and
-  # change this serialization to `serialize :messages, Array`.
-  serialize :messages
+  serialize :messages, Array
 
   validates(
     :state,

--- a/spec/models/tag_mapping.rb
+++ b/spec/models/tag_mapping.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe TagMapping do
+  context '#messages' do
+    it 'serializes the messages as an array' do
+      expect { subject.messages = ['a message'] }.to_not raise_error
+    end
+
+    it "doesn't allow other types in the messages field" do
+      expect { subject.messages = 'a message' }.to raise_error(
+        ActiveRecord::SerializationTypeMismatch
+      )
+    end
+  end
+end


### PR DESCRIPTION
Now that we ran the migration 20160915141004 in production and converted all
pre-existing messages into an Array, we can now enforce the serialization type
to be an Array in order to prevent us from assigning it a different type in the
future.