### PR TITLE
Fix tag search

### DIFF
--- a/app/services/bulk_tagging/fetch_tagged_content.rb
+++ b/app/services/bulk_tagging/fetch_tagged_content.rb
@@ -12,18 +12,34 @@ module BulkTagging
     end
 
     def call
-      request_tagged_content_items
+      if taxon_document_type?
+        request_tagged_content_to_taxon
+      else
+        request_tagged_content_items
+      end
     end
 
   private
 
-    def request_tagged_content_items
+    def taxon_document_type?
+      document_type == "taxon"
+    end
+
+    def request_tagged_content_to_taxon
       results = Services.publishing_api.get_linked_items(
         content_id,
-        link_type: document_type,
+        link_type: "taxons",
         fields: %w(title content_id base_path document_type)
       )
 
+      results.map { |result| ContentItem.new(result) }
+    end
+
+    def request_tagged_content_items
+      api_response = Services.publishing_api.get_expanded_links(content_id)
+      results = api_response['expanded_links'].fetch(
+        BulkTaggingSource.new.content_key_for(document_type), []
+      )
       results.map { |result| ContentItem.new(result) }
     end
   end

--- a/spec/features/bulk_tagging_spec.rb
+++ b/spec/features/bulk_tagging_spec.rb
@@ -75,24 +75,15 @@ RSpec.feature "Bulk tagging", type: :feature do
       q: "browse"
     )
 
-    publishing_api_has_linked_content_items(
-      "collection-id",
-      [
-        basic_content_item('Tax doc 1'),
-        basic_content_item('Tax doc 2'),
-      ]
+    publishing_api_has_expanded_links(
+      content_id: "collection-id",
+      expanded_links: {
+        documents: [
+          basic_content_item("Tax doc 1"),
+          basic_content_item("Tax doc 2"),
+        ]
+      }
     )
-  end
-
-  def publishing_api_has_linked_content_items(content_id, response_body)
-    publishing_api_endpoint = "#{Plek.current.find('publishing-api')}/v2/linked/#{content_id}?"
-    request_parmeters = {
-      "fields" => %w(base_path content_id document_type title),
-      "link_type" => "document_collection"
-    }.to_query
-
-    stub_request(:get, "#{publishing_api_endpoint}#{request_parmeters}")
-      .and_return(body: response_body.to_json, status: 200)
   end
 
   def and_a_set_of_taxons


### PR DESCRIPTION
This reverts commit 8c87e8057926ed5c0485d5519729a47b4c9b0709. Turns out to use `get_expanded_links` we need the link type, which we don't have easy access to here. Let's revisit when we fix the app workflow.

cc @Davidslv 