### PR TITLE
Simplify data flow for tagging migration creation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,7 +16,7 @@ LineLength:
 # Complexity metrics are disabled in govuk-lint
 
 Metrics/AbcSize:
-  Enabled: true
+  Enabled: false
   Max: 20
   Exclude:
     - spec/features/**/*

--- a/app/services/bulk_tagging/build_tag_migration.rb
+++ b/app/services/bulk_tagging/build_tag_migration.rb
@@ -2,17 +2,17 @@ module BulkTagging
   class BuildTagMigration
     class InvalidArgumentError < ArgumentError; end
 
-    attr_reader :tag_migration_params, :taxon_content_ids, :content_base_paths
+    attr_reader :source_content_item, :taxon_content_ids, :content_base_paths
 
-    def initialize(tag_migration_params:, taxon_content_ids:, content_base_paths:)
-      @tag_migration_params = tag_migration_params
+    def initialize(source_content_item:, taxon_content_ids:, content_base_paths:)
+      @source_content_item = source_content_item
       @taxon_content_ids = taxon_content_ids
       @content_base_paths = content_base_paths
     end
 
-    def self.call(tag_migration_params:, taxon_content_ids:, content_base_paths:)
+    def self.call(source_content_item:, taxon_content_ids:, content_base_paths:)
       new(
-        tag_migration_params: tag_migration_params,
+        source_content_item: source_content_item,
         taxon_content_ids: taxon_content_ids,
         content_base_paths: content_base_paths
       ).call
@@ -47,9 +47,8 @@ module BulkTagging
     def tag_migration
       @tag_migration ||= TagMigration.new(
         state: 'ready_to_import',
-        source_content_id: tag_migration_params[:source_content_id],
-        source_base_path: tag_migration_params[:source_base_path],
-        query: tag_migration_params[:query]
+        source_content_id: source_content_item.content_id,
+        source_description: "#{source_content_item.title} (#{source_content_item.document_type.humanize})",
       )
     end
 

--- a/app/views/tag_migrations/index.html.erb
+++ b/app/views/tag_migrations/index.html.erb
@@ -6,8 +6,7 @@
   <thead>
     <tr>
       <th>State</th>
-      <th>Search term</th>
-      <th>Source tag</th>
+      <th>Description</th>
       <th>Date added</th>
       <th></th>
       <th></th>
@@ -19,10 +18,8 @@
       <tr>
         <td><%= state_label_for(label_type: tag_migration.label_type,
                                 title: tag_migration.state_title) %></td>
-        <td><%= tag_migration.query %></td>
         <td>
-          <%= link_to tag_migration.source_base_path,
-            website_url('/api/content' + tag_migration.source_base_path) %>
+          <%= tag_migration.source_description %>
         </td>
         <td>
           <%= time_tag_for(tag_migration.created_at) %>

--- a/app/views/tag_migrations/new.html.erb
+++ b/app/views/tag_migrations/new.html.erb
@@ -1,8 +1,5 @@
 <%= simple_form_for tag_migration, url: tag_migrations_path, method: :post do |f| %>
   <%= f.hidden_field :source_content_id %>
-  <%= f.hidden_field :source_base_path %>
-  <%= f.hidden_field :document_type %>
-  <%= f.hidden_field :query %>
 
   <% if flash[:error].present? %>
     <div class="alert alert-danger" role="alert">

--- a/app/views/tag_migrations/show.html.erb
+++ b/app/views/tag_migrations/show.html.erb
@@ -1,4 +1,4 @@
-<%= display_header title: 'Preview import', breadcrumbs: [:tag_migrations, "Preview"] do %>
+<%= display_header title: tag_migration.source_description, breadcrumbs: [:tag_migrations, tag_migration.source_description] do %>
   <%= link_to "Create tags", tag_migration_publish_tags_path(tag_migration), method: :post, class: "btn btn-md btn-default" %>
 <% end %>
 

--- a/app/views/tag_searches/new.html.erb
+++ b/app/views/tag_searches/new.html.erb
@@ -23,14 +23,7 @@
               <td><%= tag.title %></td>
               <td>
                 <%= link_to tag.content_id,
-                  new_tag_migration_path(
-                    tag_migration: {
-                      source_content_id: tag.content_id,
-                      source_base_path: tag.base_path,
-                      document_type: tag.document_type,
-                      query: query,
-                    }
-                  ) %>
+                  new_tag_migration_path(source_content_id: tag.content_id) %>
               </td>
               <td> <%= tag.document_type.humanize %> </td>
             </tr>

--- a/db/migrate/20160926164808_use_source_description_for_tag_migrations.rb
+++ b/db/migrate/20160926164808_use_source_description_for_tag_migrations.rb
@@ -1,0 +1,8 @@
+class UseSourceDescriptionForTagMigrations < ActiveRecord::Migration
+  def change
+    remove_column :tag_migrations, :document_type, :string
+    remove_column :tag_migrations, :source_base_path, :string
+    remove_column :tag_migrations, :query, :string
+    add_column :tag_migrations, :source_description, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160915152936) do
+ActiveRecord::Schema.define(version: 20160926164808) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,17 +34,15 @@ ActiveRecord::Schema.define(version: 20160915152936) do
   add_index "tag_mappings", ["tagging_source_id"], name: "index_tag_mappings_on_tagging_source_id", using: :btree
 
   create_table "tag_migrations", force: :cascade do |t|
-    t.datetime "created_at",        null: false
-    t.datetime "updated_at",        null: false
+    t.datetime "created_at",         null: false
+    t.datetime "updated_at",         null: false
     t.string   "source_content_id"
     t.string   "state"
     t.datetime "last_published_at"
     t.string   "last_published_by"
     t.datetime "deleted_at"
-    t.string   "query"
-    t.string   "source_base_path"
-    t.string   "document_type"
     t.string   "error_message"
+    t.text     "source_description"
   end
 
   create_table "tagging_spreadsheets", force: :cascade do |t|

--- a/spec/factories/tag_migration.rb
+++ b/spec/factories/tag_migration.rb
@@ -1,8 +1,6 @@
 FactoryGirl.define do
   factory :tag_migration do
     source_content_id 'original-content-id'
-    source_base_path '/original-base-path'
     state 'ready_to_import'
-    query 'a query'
   end
 end

--- a/spec/features/bulk_tagging_spec.rb
+++ b/spec/features/bulk_tagging_spec.rb
@@ -39,17 +39,21 @@ RSpec.feature "Bulk tagging", type: :feature do
   end
 
   def given_a_collection_with_items_and_some_other_content_groupings
+    document_collection = {
+      content_id: "collection-id",
+      title: "Tax documents",
+      base_path: "/tax-documents",
+      document_type: "document_collection",
+    }
+
     publishing_api_has_content(
-      [{
-        content_id: "collection-id",
-        title: "Tax documents",
-        base_path: "/tax-documents",
-        document_type: "document_collection",
-      }],
+      [document_collection],
       document_type: BulkTagging::Search.default_document_types,
       per_page: 20,
       q: "Tax"
     )
+
+    publishing_api_has_item(document_collection)
 
     publishing_api_has_content(
       [{
@@ -218,8 +222,7 @@ RSpec.feature "Bulk tagging", type: :feature do
     row = first('table tbody tr')
 
     expect(row).to have_text(/imported/i)
-    expect(row).to have_text('Tax')
-    expect(row).to have_link('/tax-documents')
+    expect(row).to have_text('Tax documents (Document collection)')
   end
 
   def given_a_tag_migration_exists

--- a/spec/services/bulk_tagging/build_tag_migration_spec.rb
+++ b/spec/services/bulk_tagging/build_tag_migration_spec.rb
@@ -2,19 +2,12 @@ require 'rails_helper'
 
 RSpec.describe BulkTagging::BuildTagMigration do
   include PublishingApiHelper
-
-  let(:tag_migration_params) do
-    {
-      source_content_id: 'content-id',
-      source_base_path: '/content-base-path',
-      query: 'A query string'
-    }
-  end
+  include ContentItemHelper
 
   context 'without any taxons' do
     let(:tag_migration) do
       described_class.call(
-        tag_migration_params: tag_migration_params,
+        source_content_item: stub_content_item,
         taxon_content_ids: [],
         content_base_paths: ['/content-1']
       )
@@ -31,7 +24,7 @@ RSpec.describe BulkTagging::BuildTagMigration do
   context 'without any content items' do
     let(:tag_migration) do
       described_class.call(
-        tag_migration_params: tag_migration_params,
+        source_content_item: stub_content_item,
         taxon_content_ids: ['taxon-1'],
         content_base_paths: []
       )
@@ -55,7 +48,7 @@ RSpec.describe BulkTagging::BuildTagMigration do
 
     let(:tag_migration) do
       described_class.call(
-        tag_migration_params: tag_migration_params,
+        source_content_item: stub_content_item,
         taxon_content_ids: ['taxon-1', 'taxon-2'],
         content_base_paths: ['/content-1', '/content-2']
       )
@@ -77,14 +70,6 @@ RSpec.describe BulkTagging::BuildTagMigration do
       expect(tag_migration.state).to eq('ready_to_import')
     end
 
-    it 'assigns the query to the tag migration' do
-      expect(tag_migration.query).to eq('A query string')
-    end
-
-    it 'assigns the content base path to the tag migration' do
-      expect(tag_migration.source_base_path).to eq('/content-base-path')
-    end
-
     it 'it builds 4 tag mappings' do
       expect(tag_migration.tag_mappings.length).to eq(4)
     end
@@ -97,5 +82,9 @@ RSpec.describe BulkTagging::BuildTagMigration do
 
       tag_migration
     end
+  end
+
+  def stub_content_item
+    ContentItem.new(basic_content_item("Some random title", other_fields: { content_id: 'content-id' }))
   end
 end


### PR DESCRIPTION
This is an attempt to simplify the controller data flow when creating a `TagMigration`.

Instead of passing on the base path and document type of the thing we're retagging, we just pass on the content_id (`source_content_id`) and query the publishing-api whenever we need something from the content item.

This means there's less data passed down through the URL and tag migration form, making it easier to follow. We can also link more easily to the retagging page (`http://content-tagger.dev.gov.uk/tag_migrations/new?source_content_id=CONTENT_ID`). It didn't seem useful to keep the `query`.

The `source_description` is not strictly necessary, because on the index & show pages we could query the publishing-api and generate it with that. But this would cause a publishing-api request per `TagMigration` so pre-calculating and persisting it locally is a lot faster.

## Before

1. In the view for `tag_searches#new`, we pass in `document_type`, `query` and `source_base_path` and `source_content_id` to the path helper, which goes to `tag_migrations#new`
2. `tag_migrations#new` passes them into the form and sends them on submit to `tag_migrations#create`
3. `tag_migrations#create` takes the params and pass them into `BuildTagMigration`, which saves them to the database.

![screen shot 2016-09-26 at 18 55 47](https://cloud.githubusercontent.com/assets/233676/18845756/e171e482-841a-11e6-8e27-e60751031fbc.png)
![screen shot 2016-09-26 at 18 55 50](https://cloud.githubusercontent.com/assets/233676/18845758/e1773004-841a-11e6-8c3a-a26cf37f8386.png)
![screen shot 2016-09-26 at 18 55 54](https://cloud.githubusercontent.com/assets/233676/18845757/e176ab3e-841a-11e6-8db8-dad43c59598d.png)

## After

1. In `tag_searches#new`, we only pass through `source_content_id`
2. `tag_migrations#new` uses the `source_content_id` to infer `document_type`, so that it can load tagged content
3. `tag_migrations#create` uses `source_content_id` to create a human-readable `source_description`.



![screen shot 2016-09-26 at 18 53 02](https://cloud.githubusercontent.com/assets/233676/18845682/8d70c8bc-841a-11e6-98e8-323e44b02d99.png)
(note the url)
![screen shot 2016-09-26 at 18 53 05](https://cloud.githubusercontent.com/assets/233676/18845680/8d67da68-841a-11e6-8488-91cd09b8f696.png)
![screen shot 2016-09-26 at 18 53 13](https://cloud.githubusercontent.com/assets/233676/18845681/8d6af43c-841a-11e6-9d24-662b863a90ac.png)
