### PR TITLE
Clear parent links

### DIFF
--- a/app/models/taxon_parent_links_update.rb
+++ b/app/models/taxon_parent_links_update.rb
@@ -1,0 +1,11 @@
+class TaxonParentLinksUpdate
+  attr_reader :content_id
+
+  def initialize(content_id)
+    @content_id = content_id
+  end
+
+  def links_to_update
+    { 'parent' => [] }
+  end
+end

--- a/app/services/publish_links.rb
+++ b/app/services/publish_links.rb
@@ -21,7 +21,11 @@ private
 
   def updated_links
     links_update.links_to_update.merge(existing_links) do |_, new_links, old_links|
-      (old_links || []).concat(new_links).uniq
+      if new_links.empty?
+        []
+      else
+        (old_links || []).concat(new_links).uniq
+      end
     end
   end
 

--- a/app/services/publish_links.rb
+++ b/app/services/publish_links.rb
@@ -10,16 +10,11 @@ class PublishLinks
   end
 
   def publish
-    if links_update.valid?
-      Services.publishing_api.patch_links(
-        links_update.content_id,
-        links: updated_links,
-        previous_version: previous_version
-      )
-      links_update.mark_as_tagged
-    else
-      links_update.mark_as_errored
-    end
+    Services.publishing_api.patch_links(
+      links_update.content_id,
+      links: updated_links,
+      previous_version: previous_version
+    )
   end
 
 private

--- a/app/services/taxonomy/clear_parent_link.rb
+++ b/app/services/taxonomy/clear_parent_link.rb
@@ -1,0 +1,9 @@
+module Taxonomy
+  class ClearParentLink
+    def self.call(content_id)
+      taxon_parent_links_update = TaxonParentLinksUpdate.new(content_id)
+
+      PublishLinks.call(links_update: taxon_parent_links_update)
+    end
+  end
+end

--- a/app/workers/publish_links_worker.rb
+++ b/app/workers/publish_links_worker.rb
@@ -17,6 +17,11 @@ class PublishLinksWorker
     # time the job runs.
     return if links_update.tag_mappings.empty?
 
-    PublishLinks.call(links_update: links_update)
+    if links_update.valid?
+      PublishLinks.call(links_update: links_update)
+      links_update.mark_as_tagged
+    else
+      links_update.mark_as_errored
+    end
   end
 end

--- a/lib/tasks/taxons.rake
+++ b/lib/tasks/taxons.rake
@@ -1,0 +1,12 @@
+namespace :taxons do
+  desc 'Clear the parent link of existing Taxons'
+  task clear_parent: :environment do
+    taxons = Services.publishing_api.get_linkables(document_type: 'taxon')
+
+    taxons.each do |taxon|
+      Rails.logger.info "Clearing parent link for #{taxon['title']}"
+
+      Taxonomy::ClearParentLink.call(taxon['content_id'])
+    end
+  end
+end

--- a/spec/models/taxon_parent_links_update_spec.rb
+++ b/spec/models/taxon_parent_links_update_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe TaxonParentLinksUpdate do
+  describe '#content_id' do
+    it 'exposes the content id' do
+      links_update = described_class.new('a-content-id')
+
+      expect(links_update.content_id).to eq('a-content-id')
+    end
+  end
+
+  describe '#links_to_update' do
+    it 'includes an empty list of parents to update' do
+      links_update = described_class.new('a-content-id')
+
+      expect(links_update.links_to_update).to eq('parent' => [])
+    end
+  end
+end

--- a/spec/services/publish_links_spec.rb
+++ b/spec/services/publish_links_spec.rb
@@ -4,12 +4,11 @@ RSpec.describe PublishLinks do
   describe '.call' do
     let(:links_update) do
       instance_double(LinksUpdate,
-                      valid?: true,
                       content_id: 'a-content-id',
                       links_to_update: { 'taxons' => ['taxon1-content-id'] })
     end
 
-    context 'with valid link updates with pre-existing links' do
+    context 'with pre-existing links' do
       before do
         publishing_api_has_links(
           content_id: links_update.content_id,
@@ -24,13 +23,12 @@ RSpec.describe PublishLinks do
           links: { 'taxons' => ['existing-content-id', 'taxon1-content-id'] },
           previous_version: 10
         )
-        expect(links_update).to receive(:mark_as_tagged)
 
         described_class.new(links_update: links_update).publish
       end
     end
 
-    context 'with valid link updates with the same pre-existing links' do
+    context 'with the same pre-existing links' do
       before do
         publishing_api_has_links(
           content_id: links_update.content_id,
@@ -45,13 +43,12 @@ RSpec.describe PublishLinks do
           links: { 'taxons' => ['taxon1-content-id'] },
           previous_version: 10
         )
-        expect(links_update).to receive(:mark_as_tagged)
 
         described_class.new(links_update: links_update).publish
       end
     end
 
-    context 'with valid link updates without existing links' do
+    context 'without existing links' do
       before do
         publishing_api_has_links(
           content_id: links_update.content_id,
@@ -66,18 +63,6 @@ RSpec.describe PublishLinks do
           links: links_update.links_to_update,
           previous_version: 0
         )
-        expect(links_update).to receive(:mark_as_tagged)
-
-        described_class.new(links_update: links_update).publish
-      end
-    end
-
-    context 'with invalid link updates' do
-      let(:links_update) { instance_double(LinksUpdate, valid?: false) }
-
-      it 'does not call the publishing API and marks the taggings as errored' do
-        expect(Services.publishing_api).to_not receive(:patch_links)
-        expect(links_update).to receive(:mark_as_errored)
 
         described_class.new(links_update: links_update).publish
       end

--- a/spec/services/publish_links_spec.rb
+++ b/spec/services/publish_links_spec.rb
@@ -67,5 +67,31 @@ RSpec.describe PublishLinks do
         described_class.new(links_update: links_update).publish
       end
     end
+
+    context 'with an empty list of links for a given link type' do
+      let(:links_update) do
+        instance_double(LinksUpdate,
+                        content_id: 'a-content-id',
+                        links_to_update: { 'parent' => [] })
+      end
+
+      before do
+        publishing_api_has_links(
+          content_id: links_update.content_id,
+          links: { parent: ['parent-content-id'] },
+          version: 10
+        )
+      end
+
+      it 'deletes the existing links for that link type' do
+        expect(Services.publishing_api).to receive(:patch_links).with(
+          links_update.content_id,
+          links: links_update.links_to_update,
+          previous_version: 10
+        )
+
+        described_class.new(links_update: links_update).publish
+      end
+    end
   end
 end

--- a/spec/services/taxonomy/clear_parent_link_spec.rb
+++ b/spec/services/taxonomy/clear_parent_link_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe Taxonomy::ClearParentLink do
+  it 're-publishes the parent link with an empty list of links' do
+    expect(PublishLinks).to receive(:call).with(
+      links_update: instance_of(TaxonParentLinksUpdate)
+    )
+
+    described_class.call('a-content-id')
+  end
+end

--- a/spec/workers/publish_links_worker_spec.rb
+++ b/spec/workers/publish_links_worker_spec.rb
@@ -12,15 +12,38 @@ RSpec.describe PublishLinksWorker do
       )
     end
 
-    it 'it calls the links publisher service when there are tag mappings' do
-      tag_mapping = create(:tag_mapping)
-      expect(PublishLinks).to receive(:call)
+    context 'with valid links' do
+      before do
+        allow_any_instance_of(LinksUpdate).to receive(:valid?).and_return(true)
+      end
 
-      described_class.new.perform(
-        '/a/base/path',
-        'tag_mapping_ids' => [tag_mapping.id],
-        'taxons' => ['taxon1-content-id'],
-      )
+      it 'it calls the links publisher service when there are tag mappings' do
+        tag_mapping = create(:tag_mapping)
+        expect(PublishLinks).to receive(:call)
+
+        described_class.new.perform(
+          '/a/base/path',
+          'tag_mapping_ids' => [tag_mapping.id],
+          'taxons' => ['taxon1-content-id'],
+        )
+      end
+    end
+
+    context 'with invalid link updates' do
+      before do
+        allow_any_instance_of(LinksUpdate).to receive(:valid?).and_return(false)
+      end
+
+      it 'does not call the publishing API and marks the taggings as errored' do
+        tag_mapping = create(:tag_mapping)
+        expect(PublishLinks).to_not receive(:call)
+
+        described_class.new.perform(
+          '/a/base/path',
+          'tag_mapping_ids' => [tag_mapping.id],
+          'taxons' => ['taxon1-content-id'],
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
This PR allows us to clear the `parent` link of all our Taxons via the `PublishLinks` service class.

By specifically setting a link type to be an empty array, we are able to clear existing links for that link type. Otherwise, `PublishLinks` works as usual by appending links.

Furthermore, this PR adds a rake task that talks to the publishing API and allows us to clear all existing parent links for all taxons. We only have 100 taxons at the moment, which means that performing this via a rake task should be fine.

Trello task: https://trello.com/c/BAyP2r6c/187-fix-outdated-link-expansion-of-parent-taxons-clean-up-parent

```
irb(main):001:0> content_id = "e184c8d6-7142-4637-ae1e-3270247e0f4f"
=> "e184c8d6-7142-4637-ae1e-3270247e0f4f"
irb(main):002:0> Services.publishing_api.get_links(content_id)
=> #<GdsApi::Response:0x007fd9a7fbd668 @http_response=<RestClient::Response 200 "{\"content_i...">>
irb(main):003:0> Services.publishing_api.get_links(content_id)['links']
=> {"parent"=>["502eac33-76ad-499e-b15f-a1544be548c5"], "parent_taxons"=>["502eac33-76ad-499e-b15f-a1544be548c5"]}
irb(main):004:0> Taxonomy::ClearParentLink.call(content_id)
=> #<GdsApi::Response:0x007fd9a809a630 @http_response=<RestClient::Response 200 "{\"content_i...">>
irb(main):005:0> Services.publishing_api.get_links(content_id)['links']
=> {"parent_taxons"=>["502eac33-76ad-499e-b15f-a1544be548c5"]}
irb(main):006:0>
```