### PR TITLE
Revert "Workaround for linkables with internal names of nil"

### DIFF
--- a/lib/linkables.rb
+++ b/lib/linkables.rb
@@ -52,9 +52,6 @@ private
   end
 
   def get_tags_of_type(document_type)
-    items = Services.publishing_api.get_linkables(format: document_type)
-    # We only are interested in linkables that have an internal name and not
-    # redirects or similar
-    items.select { |item| item['internal_name'] }
+    Services.publishing_api.get_linkables(format: document_type)
   end
 end

--- a/spec/lib/linkables_spec.rb
+++ b/spec/lib/linkables_spec.rb
@@ -14,15 +14,7 @@ RSpec.describe Linkables do
             "publication_state" => "live",
             "base_path" => "/topic/business-tax/pension-scheme-administration",
             "internal_name" => "Business tax / Pension scheme administration"
-          },
-          {
-            "public_updated_at" => "2016-04-07 10:34:05",
-            "title" => nil,
-            "content_id" => "3535b8ad-7209-4c97-9dac-e25c25d9c27c",
-            "publication_state" => "live",
-            "base_path" => "/topic/redirect",
-            "internal_name" => nil
-          },
+          }
         ],
         document_type: "topic",
       )


### PR DESCRIPTION
This reverts alphagov/content-tagger#163.

This workaround is no longer necessary since the publishing-api has been fixed.