### PR TITLE
Use linkables for tag migrations dropdown

### DIFF
--- a/app/controllers/tag_migrations_controller.rb
+++ b/app/controllers/tag_migrations_controller.rb
@@ -16,11 +16,9 @@ class TagMigrationsController < ApplicationController
       tag_document_type: source_content_item.document_type,
     )
 
-    taxons = RemoteTaxons.new.all
-
     render :new, locals: {
       tag_migration: TagMigration.new(source_content_id: source_content_item.content_id),
-      taxons: taxons,
+      taxons: Linkables.new.taxons,
       expanded_links: expanded_links,
     }
   end

--- a/app/views/tag_migrations/new.html.erb
+++ b/app/views/tag_migrations/new.html.erb
@@ -10,11 +10,8 @@
   <div class='row'>
     <div class='col-md-4'>
       <div class="form-group">
-        <h3>Taxons</h3>
-        <%= select_tag :taxons,
-          options_from_collection_for_select(taxons, 'content_id', 'title'),
-          multiple: true,
-          class: :select2 %>
+        <h4>Tag selected pages to taxon:</h4>
+        <%= select_tag :taxons, options_for_select(taxons), multiple: true, class: 'select2' %>
       </div>
       <%= f.submit "Bulk tag selected items", class: 'btn btn-md btn-success' %>
     </div>

--- a/spec/features/bulk_tagging_spec.rb
+++ b/spec/features/bulk_tagging_spec.rb
@@ -91,12 +91,23 @@ RSpec.feature "Bulk tagging", type: :feature do
   end
 
   def and_a_set_of_taxons
+    # Used in BuildTagMigration
     publishing_api_has_taxons(
       [
-        basic_content_item("Taxon 1"),
-        basic_content_item("Taxon 2"),
-        basic_content_item("Taxon 3"),
+        basic_content_item("Taxon 1", other_fields: { content_id: 'taxon-1' }),
+        basic_content_item("Taxon 2", other_fields: { content_id: 'taxon-2' }),
+        basic_content_item("Taxon 3", other_fields: { content_id: 'taxon-3' }),
       ]
+    )
+
+    # Used in the dropdown
+    publishing_api_has_linkables(
+      [
+        build_linkable(internal_name: "Taxon 1", content_id: 'taxon-1'),
+        build_linkable(internal_name: "Taxon 2", content_id: 'taxon-2'),
+        build_linkable(internal_name: "Taxon 3", content_id: 'taxon-3'),
+      ],
+      document_type: "taxon",
     )
   end
 

--- a/spec/support/content_item_helper.rb
+++ b/spec/support/content_item_helper.rb
@@ -7,4 +7,17 @@ module ContentItemHelper
       document_type: "guidance",
     ).merge(other_fields)
   end
+
+  def build_linkable(hash)
+    default = {
+      content_id: SecureRandom.uuid,
+      title: SecureRandom.hex,
+      internal_name: SecureRandom.hex,
+      base_path: "/#{SecureRandom.hex}",
+      document_type: SecureRandom.hex,
+      publication_state: %w(live draft).sample,
+    }
+
+    default.stringify_keys.merge(hash.stringify_keys)
+  end
 end


### PR DESCRIPTION
This changes the way we populate the select-a-taxon dropdown in the tag migration screen. Linkables is the appropriate class / API call for this, since it's already used for other dropdowns. This means that it uses the `internal_name` property (which disambiguates taxons with the same name) and shows the taxons alphabetically.