### PR TITLE
Add pagination to taxons

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'plek', '~> 1.10'
 gem 'gds-sso', '~> 11.1'
 gem 'govuk_admin_template', '~> 4.4'
 gem 'simple_form', '~> 3.2', '>= 3.2.1'
-gem 'gds-api-adapters', '~> 35.0'
+gem 'gds-api-adapters', '~> 36.4'
 
 gem 'airbrake', '~> 4.3.1'
 
@@ -18,6 +18,9 @@ gem 'uglifier', '>= 1.3.0'
 gem 'select2-rails', '~> 3.5.9'
 
 gem 'govuk_sidekiq', '~> 0.0.4'
+
+gem 'kaminari', '~> 0.17'
+gem 'bootstrap-kaminari-views', '~> 0.0.5'
 
 group :development, :test do
   gem 'quiet_assets'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,6 +51,9 @@ GEM
       rack (>= 0.9.0)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
+    bootstrap-kaminari-views (0.0.5)
+      kaminari (>= 0.13)
+      rails (>= 3.1)
     bootstrap-sass (3.3.5.1)
       autoprefixer-rails (>= 5.0.0.1)
       sass (>= 3.3.0)
@@ -86,7 +89,7 @@ GEM
       railties (>= 3.0.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
-    gds-api-adapters (35.0.1)
+    gds-api-adapters (36.4.1)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -123,7 +126,7 @@ GEM
     hashdiff (0.3.0)
     hashie (3.4.4)
     headless (2.3.1)
-    http-cookie (1.0.2)
+    http-cookie (1.0.3)
       domain_name (~> 0.5)
     i18n (0.7.0)
     jquery-rails (4.1.1)
@@ -134,6 +137,9 @@ GEM
     json-schema (2.5.2)
       addressable (~> 2.3.8)
     jwt (1.5.4)
+    kaminari (0.17.0)
+      actionpack (>= 3.0.0)
+      activesupport (>= 3.0.0)
     kgio (2.10.0)
     link_header (0.0.8)
     logstash-event (1.1.5)
@@ -151,7 +157,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
     mini_portile2 (2.1.0)
-    minitest (5.9.0)
+    minitest (5.9.1)
     multi_json (1.12.1)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
@@ -225,7 +231,7 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rainbow (2.1.0)
     raindrops (0.16.0)
-    rake (11.2.2)
+    rake (11.3.0)
     redis (3.3.1)
     redis-namespace (1.5.2)
       redis (~> 3.0, >= 3.0.4)
@@ -300,7 +306,7 @@ GEM
     sprockets (3.7.0)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
-    sprockets-rails (3.1.1)
+    sprockets-rails (3.2.0)
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
@@ -342,17 +348,19 @@ PLATFORMS
 DEPENDENCIES
   airbrake (~> 4.3.1)
   better_errors
+  bootstrap-kaminari-views (~> 0.0.5)
   capybara
   capybara-webkit
   database_cleaner
   factory_girl_rails
-  gds-api-adapters (~> 35.0)
+  gds-api-adapters (~> 36.4)
   gds-sso (~> 11.1)
   govuk-content-schema-test-helpers (~> 1.4)
   govuk-lint
   govuk_admin_template (~> 4.4)
   govuk_sidekiq (~> 0.0.4)
   headless
+  kaminari (~> 0.17)
   logstasher (= 0.6.2)
   pg
   plek (~> 1.10)

--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -1,6 +1,14 @@
 class TaxonsController < ApplicationController
   def index
-    render :index, locals: { taxons: remote_taxons.all }
+    search_results = remote_taxons.search(
+      page: params[:page],
+      per_page: params[:per_page]
+    )
+
+    render :index, locals: {
+      taxons: search_results.taxons,
+      search_results: search_results,
+    }
   end
 
   def new

--- a/app/models/remote_taxons.rb
+++ b/app/models/remote_taxons.rb
@@ -1,19 +1,26 @@
 class RemoteTaxons
-  # Return a list of taxons from the publishing API with links included.
-  # Does not include the details hash of each taxon.
+  # TODO: deprecate this method in favour of search.
   def all
     @taxons ||=
       begin
-        taxon_content_items.map do |taxon_hash|
+        raw_taxons = taxon_content_items(page: nil, per_page: nil)
+        raw_taxons['results'].map do |taxon_hash|
           Taxon.new(taxon_hash.slice(*Taxon::ATTRIBUTES))
         end
       end
+  end
+
+  def search(page:, per_page:)
+    TaxonSearchResults.new(
+      taxon_content_items(page: page, per_page: per_page)
+    )
   end
 
   def content_ids
     all.map(&:content_id)
   end
 
+  # TODO: replace all with another method.
   def parents_for_taxon(taxon_child)
     all.select do |taxon|
       taxon_child.parent_taxons.include?(taxon.content_id)
@@ -22,12 +29,16 @@ class RemoteTaxons
 
 private
 
-  def taxon_content_items
+  # Return a list of taxons from the publishing API with links included.
+  # Does not include the details hash of each taxon.
+  def taxon_content_items(page:, per_page:)
     Services
       .publishing_api
       .get_content_items(
         document_type: 'taxon',
-        order: '-public_updated_at'
-      )['results']
+        order: '-public_updated_at',
+        page: page || 1,
+        per_page: per_page || 50
+      )
   end
 end

--- a/app/models/remote_taxons.rb
+++ b/app/models/remote_taxons.rb
@@ -16,10 +16,6 @@ class RemoteTaxons
     )
   end
 
-  def content_ids
-    all.map(&:content_id)
-  end
-
   # TODO: replace all with another method.
   def parents_for_taxon(taxon_child)
     all.select do |taxon|

--- a/app/models/taxon_search_results.rb
+++ b/app/models/taxon_search_results.rb
@@ -1,0 +1,28 @@
+class TaxonSearchResults
+  attr_reader :search_response
+
+  def initialize(search_response)
+    @search_response = search_response
+  end
+
+  def taxons
+    @taxons ||=
+      begin
+        search_response['results'].map do |taxon_hash|
+          Taxon.new(taxon_hash.slice(*Taxon::ATTRIBUTES))
+        end
+      end
+  end
+
+  def current_page
+    search_response['current_page']
+  end
+
+  def total_pages
+    search_response['pages']
+  end
+
+  def limit_value
+    5
+  end
+end

--- a/app/views/taxons/index.html.erb
+++ b/app/views/taxons/index.html.erb
@@ -36,3 +36,5 @@
     <% end %>
   </tbody>
 </table>
+
+<%= paginate search_results, theme: 'twitter-bootstrap-3' %>

--- a/spec/features/taxonomy_search_spec.rb
+++ b/spec/features/taxonomy_search_spec.rb
@@ -1,0 +1,94 @@
+require "rails_helper"
+
+RSpec.feature "Taxonomy Search" do
+  include PublishingApiHelper
+
+  scenario "User navigates using pagination links" do
+    given_there_are_multiple_pages_of_taxons
+    when_i_visit_the_taxonomy_page
+    then_i_can_see_the_first_page_of_taxons
+    and_i_can_see_pagination_links
+    when_i_visit_the_next_page
+    then_i_can_see_the_second_page_of_taxons
+  end
+
+  def given_there_are_multiple_pages_of_taxons
+    @taxon_1 = {
+      title: "I Am A Taxon 1",
+      content_id: "ID-1",
+      base_path: "/foo",
+      internal_name: "I Am A Taxon 1",
+      publication_state: 'active'
+    }
+    @taxon_2 = {
+      title: "I Am Another Taxon 2",
+      content_id: "ID-2",
+      base_path: "/bar",
+      internal_name: "I Am Another Taxon 2",
+      publication_state: 'active'
+    }
+    @taxon_3 = {
+      title: "I Am Yet Another Taxon 3",
+      content_id: "ID-3",
+      base_path: "/bar",
+      internal_name: "I Am Yet Another Taxon 3",
+      publication_state: 'active'
+    }
+
+    publishing_api_has_taxons(
+      [@taxon_1, @taxon_2, @taxon_3],
+      page: 1,
+      per_page: 2
+    )
+    publishing_api_has_taxons(
+      [@taxon_1, @taxon_2, @taxon_3],
+      page: 2,
+      per_page: 2
+    )
+  end
+
+  def when_i_visit_the_taxonomy_page
+    visit taxons_path(per_page: 2)
+  end
+
+  def then_i_can_see_the_first_page_of_taxons
+    expect(page).to have_text(@taxon_1[:title])
+    expect(page).to have_text(@taxon_2[:title])
+
+    expect(page).to_not have_text(@taxon_3[:title])
+  end
+
+  def and_i_can_see_pagination_links
+    pagination_list = find('.pagination')
+    page_links = pagination_list.all('li.page').map(&:text)
+
+    # We can see 2 pages
+    expect(page_links).to include('1')
+    expect(page_links).to include('2')
+
+    # There is no 3rd page
+    expect(page_links).to_not include('3')
+
+    # We start on the first page
+    expect(find('li.page.active').text).to eq('1')
+
+    # We also have Next and Last links
+    expect(pagination_list).to have_selector('li.next_page', text: /next/i)
+    expect(pagination_list).to have_selector('li.last', text: /last/i)
+  end
+
+  def when_i_visit_the_next_page
+    pagination_list = find('.pagination')
+
+    within pagination_list do
+      click_link 'Next'
+    end
+  end
+
+  def then_i_can_see_the_second_page_of_taxons
+    expect(page).to have_text(@taxon_3[:title])
+
+    expect(page).to_not have_text(@taxon_1[:title])
+    expect(page).to_not have_text(@taxon_2[:title])
+  end
+end

--- a/spec/models/remote_taxons_spec.rb
+++ b/spec/models/remote_taxons_spec.rb
@@ -41,22 +41,6 @@ RSpec.describe RemoteTaxons do
     end
   end
 
-  describe '#content_ids' do
-    it 'returns the content ids of all taxons' do
-      content_id_1 = SecureRandom.uuid
-      content_id_2 = SecureRandom.uuid
-      taxon_1 = { title: "foo", base_path: "/foo", content_id: content_id_1 }
-      taxon_2 = { title: "bar", base_path: "/bar", content_id: content_id_2 }
-
-      publishing_api_has_taxons([taxon_1, taxon_2])
-
-      result = described_class.new.content_ids
-
-      expect(result).to include(content_id_1)
-      expect(result).to include(content_id_2)
-    end
-  end
-
   describe '#parents_for_taxon' do
     let(:taxon_id_1) { SecureRandom.uuid }
     let(:taxon_id_2) { SecureRandom.uuid }

--- a/spec/models/remote_taxons_spec.rb
+++ b/spec/models/remote_taxons_spec.rb
@@ -5,12 +5,31 @@ RSpec.describe RemoteTaxons do
   include PublishingApiHelper
   include GdsApi::TestHelpers::PublishingApiV2
 
+  describe '#search' do
+    it 'fetches taxons from the publishing api with pagination' do
+      taxon_1 = { title: "foo" }
+      taxon_2 = { title: "bar" }
+      taxon_3 = { title: "aha" }
+      publishing_api_has_taxons(
+        [taxon_1, taxon_2, taxon_3],
+        page: 2,
+        per_page: 2
+      )
+
+      result = described_class.new.search(page: 2, per_page: 2)
+
+      expect(result).to be_a(TaxonSearchResults)
+      expect(result.taxons.length).to eq(1)
+      taxon = result.taxons.first
+      expect(taxon.title).to eq('aha')
+    end
+  end
+
   describe '#all' do
     it 'retrieves taxons from publishing api in descending order by public updated at' do
       taxon_1 = { title: "foo" }
       taxon_2 = { title: "bar" }
       taxon_3 = { title: "aha" }
-
       publishing_api_has_taxons([taxon_1, taxon_2, taxon_3])
 
       result = described_class.new.all

--- a/spec/models/taxon_search_results_spec.rb
+++ b/spec/models/taxon_search_results_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe TaxonSearchResults do
+  let(:search_response) do
+    {
+      'current_page' => 1,
+      'pages' => 2,
+      'results' => [{ content_id: 'id-1' }, { content_id: 'id-2' }]
+    }
+  end
+  let(:search_results) { described_class.new(search_response) }
+
+  it 'has access to taxons' do
+    expect(search_results.taxons.length).to eq(2)
+  end
+
+  it 'returns instances of Taxons' do
+    search_results.taxons.each do |taxon|
+      expect(taxon).to be_a(Taxon)
+    end
+  end
+
+  it 'knows about the current page' do
+    expect(search_results.current_page).to eq(1)
+  end
+
+  it 'knows about the total number of pages' do
+    expect(search_results.total_pages).to eq(2)
+  end
+
+  it 'knows about the limit value so it works with kaminari' do
+    expect(search_results.limit_value).to eq(5)
+  end
+end

--- a/spec/support/publishing_api_helper.rb
+++ b/spec/support/publishing_api_helper.rb
@@ -1,10 +1,13 @@
 module PublishingApiHelper
-  def publishing_api_has_taxons(taxons)
-    publishing_api_has_content(
-      taxons,
+  def publishing_api_has_taxons(taxons, options = {})
+    default_options = {
       document_type: "taxon",
       order: '-public_updated_at',
-    )
+      page: 1,
+      per_page: 50,
+    }
+
+    publishing_api_has_content(taxons, default_options.merge(options))
   end
 
   def publishing_api_has_taxon_linkables(base_paths)


### PR DESCRIPTION
This PR adds pagination to the taxons' index page.

Trello: https://trello.com/c/0fUIlIQ2/202-add-pagination-to-taxon-index-page

It looks like this:

<img width="992" alt="screen shot 2016-09-30 at 13 40 07" src="https://cloud.githubusercontent.com/assets/416701/18991944/785f8e30-8713-11e6-8098-c5279b97c265.png">

