### PR TITLE
Use `ContentItem.find` for fetching taxons in tag migration

### DIFF
--- a/app/services/bulk_tagging/build_tag_mapping.rb
+++ b/app/services/bulk_tagging/build_tag_mapping.rb
@@ -14,10 +14,10 @@ module BulkTagging
     def call
       TagMapping.new(
         content_base_path: content_base_path,
-        link_title:        taxon.title,
-        link_content_id:   taxon.content_id,
-        link_type:         taxon.link_type,
-        state:             'ready_to_tag'
+        link_title: taxon.title,
+        link_content_id: taxon.content_id,
+        link_type: 'taxons',
+        state: 'ready_to_tag'
       )
     end
   end

--- a/app/services/bulk_tagging/build_tag_migration.rb
+++ b/app/services/bulk_tagging/build_tag_migration.rb
@@ -23,7 +23,7 @@ module BulkTagging
       validate_content_items
 
       taxon_content_ids.each do |taxon_content_id|
-        expected_taxon = taxons.find { |taxon| taxon.content_id == taxon_content_id }
+        expected_taxon = ContentItem.find!(taxon_content_id)
         create_tag_mappings_for_taxon(expected_taxon)
       end
 
@@ -61,10 +61,6 @@ module BulkTagging
 
         tag_migration.tag_mappings << tag_mapping
       end
-    end
-
-    def taxons
-      @taxons ||= RemoteTaxons.new.all
     end
   end
 end

--- a/spec/features/bulk_tagging_spec.rb
+++ b/spec/features/bulk_tagging_spec.rb
@@ -91,14 +91,8 @@ RSpec.feature "Bulk tagging", type: :feature do
   end
 
   def and_a_set_of_taxons
-    # Used in BuildTagMigration
-    publishing_api_has_taxons(
-      [
-        basic_content_item("Taxon 1", other_fields: { content_id: 'taxon-1' }),
-        basic_content_item("Taxon 2", other_fields: { content_id: 'taxon-2' }),
-        basic_content_item("Taxon 3", other_fields: { content_id: 'taxon-3' }),
-      ]
-    )
+    publishing_api_has_item(basic_content_item("Taxon 1"))
+    publishing_api_has_item(basic_content_item("Taxon 2"))
 
     # Used in the dropdown
     publishing_api_has_linkables(

--- a/spec/services/bulk_tagging/build_tag_migration_spec.rb
+++ b/spec/services/bulk_tagging/build_tag_migration_spec.rb
@@ -40,10 +40,8 @@ RSpec.describe BulkTagging::BuildTagMigration do
 
   context 'with 2 valid taxons and 2 content base paths' do
     before do
-      taxon_1 = { title: "Taxon 1", base_path: "/foo", content_id: 'taxon-1' }
-      taxon_2 = { title: "Taxon 2", base_path: "/ha", content_id: 'taxon-2' }
-
-      publishing_api_has_taxons([taxon_1, taxon_2])
+      publishing_api_has_item(basic_content_item("Taxon 1", other_fields: { base_path: "/foo", content_id: 'taxon-1' }))
+      publishing_api_has_item(basic_content_item("Taxon 2", other_fields: { base_path: "/ha", content_id: 'taxon-2' }))
     end
 
     let(:tag_migration) do


### PR DESCRIPTION
`RemoteTaxons` currently has a bug, so using the existing `ContentItem` class is better.