### PR TITLE
Use get_linkables to populate the list of Taxons in CopyTaxonsController

### DIFF
--- a/app/controllers/copy_taxons_controller.rb
+++ b/app/controllers/copy_taxons_controller.rb
@@ -6,6 +6,6 @@ class CopyTaxonsController < ApplicationController
 private
 
   def taxons
-    @taxons ||= RemoteTaxons.new.all
+    Services.publishing_api.get_linkables(format: 'taxon')
   end
 end

--- a/app/views/copy_taxons/index.html.erb
+++ b/app/views/copy_taxons/index.html.erb
@@ -12,9 +12,9 @@
   <tbody>
     <% taxons.each do |taxon| %>
       <tr>
-        <td><%= taxon.title %></td>
-        <td><%= taxon.content_id %></td>
-        <td><%= taxon.link_type %></td>
+        <td><%= taxon['title'] %></td>
+        <td><%= taxon['content_id'] %></td>
+        <td>taxons</td>
       </tr>
     <% end %>
   </tbody>


### PR DESCRIPTION
This page is used to copy and paste taxon information to tagging spreadsheets.
We cannot use `RemoteTaxons#all` because that only returns the first page of
results by default.

By switching to `get_linkables` we are able to display all the necessary
information on that table for all available taxons.

Trello: https://trello.com/c/0fUIlIQ2/202-add-pagination-to-taxon-index-page