### PR TITLE
Remove mixin usage from models

### DIFF
--- a/app/models/tag_migration.rb
+++ b/app/models/tag_migration.rb
@@ -1,6 +1,4 @@
 class TagMigration < ActiveRecord::Base
-  include AggregatableTagMappings
-
   has_many :tag_mappings, dependent: :destroy, as: :tagging_source
   validates :source_content_id, presence: true
 
@@ -12,6 +10,10 @@ class TagMigration < ActiveRecord::Base
 
   scope :newest_first, -> { order(created_at: :desc) }
   scope :active, -> { where(deleted_at: nil) }
+
+  def aggregated_tag_mappings
+    AggregatableTagMappings.new(tag_mappings).aggregated_tag_mappings
+  end
 
   def mark_as_deleted
     update!(deleted_at: DateTime.current)

--- a/app/models/tagging_spreadsheet.rb
+++ b/app/models/tagging_spreadsheet.rb
@@ -1,6 +1,4 @@
 class TaggingSpreadsheet < ActiveRecord::Base
-  include AggregatableTagMappings
-
   validates :url, presence: true
   validates(
     :state,
@@ -14,6 +12,10 @@ class TaggingSpreadsheet < ActiveRecord::Base
 
   scope :newest_first, -> { order(created_at: :desc) }
   scope :active, -> { where(deleted_at: nil) }
+
+  def aggregated_tag_mappings
+    AggregatableTagMappings.new(tag_mappings).aggregated_tag_mappings
+  end
 
   def mark_as_deleted
     update(deleted_at: DateTime.current)

--- a/app/services/aggregatable_tag_mappings.rb
+++ b/app/services/aggregatable_tag_mappings.rb
@@ -4,8 +4,8 @@ class AggregatableTagMappings
   end
 
   def aggregated_tag_mappings
-    tag_mappings_grouped_by_content_base_path.reduce([]) do |accumulator, aggregation|
-      accumulator << AggregatedTagMapping.new(content_base_path: aggregation.first, tag_mappings: aggregation.last)
+    tag_mappings_grouped_by_content_base_path.map do |content_base_path, tag_mappings|
+      AggregatedTagMapping.new(content_base_path: content_base_path, tag_mappings: tag_mappings)
     end
   end
 

--- a/app/services/aggregatable_tag_mappings.rb
+++ b/app/services/aggregatable_tag_mappings.rb
@@ -1,5 +1,7 @@
-module AggregatableTagMappings
-  extend ActiveSupport::Concern
+class AggregatableTagMappings
+  def initialize(tag_mappings)
+    @tag_mappings = tag_mappings
+  end
 
   def aggregated_tag_mappings
     tag_mappings_grouped_by_content_base_path.reduce([]) do |accumulator, aggregation|
@@ -8,6 +10,8 @@ module AggregatableTagMappings
   end
 
 private
+
+  attr_reader :tag_mappings
 
   def tag_mappings_grouped_by_content_base_path
     tag_mappings.by_state.by_content_base_path.by_link_title


### PR DESCRIPTION
In a recent PR we've introduced a mixin to share some code between two models. This commit removes the mixin in favour of a class.
