### PR TITLE
Allow users to search for taxons in index page

### DIFF
--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -2,12 +2,14 @@ class TaxonsController < ApplicationController
   def index
     search_results = remote_taxons.search(
       page: params[:page],
-      per_page: params[:per_page]
+      per_page: params[:per_page],
+      query: query
     )
 
     render :index, locals: {
       taxons: search_results.taxons,
       search_results: search_results,
+      query: query,
     }
   end
 
@@ -94,5 +96,11 @@ private
       link_type: "taxons",
       fields: %w(title content_id base_path document_type)
     )
+  end
+
+  def query
+    return '' unless params[:taxon_search].present?
+
+    params[:taxon_search][:query]
   end
 end

--- a/app/models/remote_taxons.rb
+++ b/app/models/remote_taxons.rb
@@ -3,16 +3,16 @@ class RemoteTaxons
   def all
     @taxons ||=
       begin
-        raw_taxons = taxon_content_items(page: nil, per_page: nil)
+        raw_taxons = taxon_content_items(page: nil, per_page: nil, query: nil)
         raw_taxons['results'].map do |taxon_hash|
           Taxon.new(taxon_hash.slice(*Taxon::ATTRIBUTES))
         end
       end
   end
 
-  def search(page:, per_page:)
+  def search(page: 1, per_page: 50, query: '')
     TaxonSearchResults.new(
-      taxon_content_items(page: page, per_page: per_page)
+      taxon_content_items(page: page, per_page: per_page, query: query)
     )
   end
 
@@ -27,12 +27,13 @@ private
 
   # Return a list of taxons from the publishing API with links included.
   # Does not include the details hash of each taxon.
-  def taxon_content_items(page:, per_page:)
+  def taxon_content_items(page:, per_page:, query:)
     Services
       .publishing_api
       .get_content_items(
         document_type: 'taxon',
         order: '-public_updated_at',
+        q: query || '',
         page: page || 1,
         per_page: per_page || 50
       )

--- a/app/views/taxons/_search.html.erb
+++ b/app/views/taxons/_search.html.erb
@@ -1,0 +1,8 @@
+<%= simple_form_for :taxon_search, url: taxons_path, method: :get do |f| %>
+  <div class="form-group">
+    <%= f.input :query,
+      input_html: { type: :text, class: 'form-control', value: query },
+      label: 'Query'%>
+    <%= f.submit "Search taxons", class: "btn btn-md btn-success" %>
+  </div>
+<% end %>

--- a/app/views/taxons/index.html.erb
+++ b/app/views/taxons/index.html.erb
@@ -11,7 +11,9 @@
   <% end %>
 <% end %>
 
-<table class="table queries-list table-bordered table-striped" data-module="filterable-table">
+<%= render 'taxons/search', query: query %>
+
+<table class="table queries-list table-bordered table-striped">
   <thead>
     <tr class="table-header">
       <th>Title</th>
@@ -20,8 +22,6 @@
       <th></th>
       <th></th>
     </tr>
-
-    <%= render partial: 'shared/table_filter' %>
   </thead>
 
   <tbody>

--- a/spec/features/taxonomy_search_spec.rb
+++ b/spec/features/taxonomy_search_spec.rb
@@ -12,6 +12,14 @@ RSpec.feature "Taxonomy Search" do
     then_i_can_see_the_second_page_of_taxons
   end
 
+  scenario "User searches for taxons" do
+    given_there_are_taxons_for_search
+    when_i_visit_the_taxonomy_page
+    then_i_can_see_all_the_taxons
+    when_i_search_for_taxons
+    then_i_can_see_my_search_results
+  end
+
   def given_there_are_multiple_pages_of_taxons
     @taxon_1 = {
       title: "I Am A Taxon 1",
@@ -44,6 +52,38 @@ RSpec.feature "Taxonomy Search" do
       [@taxon_1, @taxon_2, @taxon_3],
       page: 2,
       per_page: 2
+    )
+  end
+
+  def given_there_are_taxons_for_search
+    @taxon_1 = {
+      title: "Taxon 1",
+      content_id: "ID-1",
+      base_path: "/foo",
+      internal_name: "I Am A Taxon 1",
+      publication_state: 'active'
+    }
+    @taxon_2 = {
+      title: "Taxon 2",
+      content_id: "ID-2",
+      base_path: "/bar",
+      internal_name: "I Am Another Taxon 2",
+      publication_state: 'active'
+    }
+
+    publishing_api_has_taxons(
+      [@taxon_1, @taxon_2],
+      document_type: 'taxon',
+      page: 1,
+      per_page: 2,
+    )
+
+    publishing_api_has_taxons(
+      [@taxon_2],
+      document_type: 'taxon',
+      page: 1,
+      per_page: 50,
+      q: 'Taxon 2'
     )
   end
 
@@ -90,5 +130,21 @@ RSpec.feature "Taxonomy Search" do
 
     expect(page).to_not have_text(@taxon_1[:title])
     expect(page).to_not have_text(@taxon_2[:title])
+  end
+
+  def then_i_can_see_all_the_taxons
+    expect(page).to have_text(@taxon_1[:title])
+    expect(page).to have_text(@taxon_2[:title])
+  end
+
+  def when_i_search_for_taxons
+    fill_in 'Query', with: 'Taxon 2'
+    click_button 'Search taxons'
+  end
+
+  def then_i_can_see_my_search_results
+    expect(page).to have_text(@taxon_2[:title])
+
+    expect(page).to_not have_text(@taxon_1[:title])
   end
 end

--- a/spec/models/remote_taxons_spec.rb
+++ b/spec/models/remote_taxons_spec.rb
@@ -23,6 +23,23 @@ RSpec.describe RemoteTaxons do
       taxon = result.taxons.first
       expect(taxon.title).to eq('aha')
     end
+
+    it 'is possible to search with a query string' do
+      taxon_1 = { title: "foo" }
+      publishing_api_has_taxons(
+        [taxon_1],
+        page: 1,
+        per_page: 1,
+        q: 'foo'
+      )
+      result = described_class.new.search(
+        page: 1,
+        per_page: 1,
+        query: 'foo'
+      )
+
+      expect(result.taxons.length).to eq(1)
+    end
   end
 
   describe '#all' do

--- a/spec/support/publishing_api_helper.rb
+++ b/spec/support/publishing_api_helper.rb
@@ -5,6 +5,7 @@ module PublishingApiHelper
       order: '-public_updated_at',
       page: 1,
       per_page: 50,
+      q: ''
     }
 
     publishing_api_has_content(taxons, default_options.merge(options))


### PR DESCRIPTION
This change allows users to perform text search on Taxons via the Publishing
API. The results are paginated and filtered by the query string. If no query
string is provided, the corresponding page is fetched and shown.

Trello: https://trello.com/c/0fUIlIQ2/202-add-pagination-to-taxon-index-page

An example:

<img width="1202" alt="screen shot 2016-09-30 at 15 17 35" src="https://cloud.githubusercontent.com/assets/416701/18995990/926c609c-8726-11e6-94ce-8403ab3e7c4e.png">

And example with fewer taxons per page and multiple pages (check the URL for details):

<img width="1439" alt="screen shot 2016-09-30 at 15 58 03" src="https://cloud.githubusercontent.com/assets/416701/18996046/c3e8c62e-8726-11e6-8350-180e4c983d58.png">
