### PR TITLE
Remove RemoteTaxons#all

### DIFF
--- a/app/models/remote_taxons.rb
+++ b/app/models/remote_taxons.rb
@@ -1,25 +1,13 @@
 class RemoteTaxons
-  # TODO: deprecate this method in favour of search.
-  def all
-    @taxons ||=
-      begin
-        raw_taxons = taxon_content_items(page: nil, per_page: nil, query: nil)
-        raw_taxons['results'].map do |taxon_hash|
-          Taxon.new(taxon_hash.slice(*Taxon::ATTRIBUTES))
-        end
-      end
-  end
-
   def search(page: 1, per_page: 50, query: '')
     TaxonSearchResults.new(
       taxon_content_items(page: page, per_page: per_page, query: query)
     )
   end
 
-  # TODO: replace all with another method.
   def parents_for_taxon(taxon_child)
-    all.select do |taxon|
-      taxon_child.parent_taxons.include?(taxon.content_id)
+    taxon_child.parent_taxons.map do |parent_taxon_content_id|
+      Taxonomy::BuildTaxon.call(content_id: parent_taxon_content_id)
     end
   end
 

--- a/spec/models/remote_taxons_spec.rb
+++ b/spec/models/remote_taxons_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 require 'gds_api/test_helpers/publishing_api_v2'
 
 RSpec.describe RemoteTaxons do
+  include ContentItemHelper
   include PublishingApiHelper
   include GdsApi::TestHelpers::PublishingApiV2
 
@@ -42,34 +43,42 @@ RSpec.describe RemoteTaxons do
     end
   end
 
-  describe '#all' do
-    it 'retrieves taxons from publishing api in descending order by public updated at' do
-      taxon_1 = { title: "foo" }
-      taxon_2 = { title: "bar" }
-      taxon_3 = { title: "aha" }
-      publishing_api_has_taxons([taxon_1, taxon_2, taxon_3])
-
-      result = described_class.new.all
-
-      expect(result.first).to be_a(Taxon)
-      expect(result.first.title).to eq("foo")
-      expect(result.last).to be_a(Taxon)
-      expect(result.last.title).to eq("aha")
-    end
-  end
-
   describe '#parents_for_taxon' do
     let(:taxon_id_1) { SecureRandom.uuid }
     let(:taxon_id_2) { SecureRandom.uuid }
+    let(:taxon_id_3) { SecureRandom.uuid }
     let(:taxon) do
       instance_double(Taxon, parent_taxons: [taxon_id_1, taxon_id_2])
     end
 
     it 'returns the parent taxons for a given taxon' do
-      taxon_1 = { title: "foo", base_path: "/foo", content_id: taxon_id_1 }
-      taxon_2 = { title: "bar", base_path: "/bar", content_id: taxon_id_2 }
-      taxon_3 = { title: "bar", base_path: "/bar", content_id: SecureRandom.uuid }
-      publishing_api_has_taxons([taxon_1, taxon_2, taxon_3])
+      taxon_1 = content_item_with_details(
+        "foo",
+        other_fields: {
+          base_path: "/foo",
+          content_id: taxon_id_1
+        }
+      )
+      taxon_2 = content_item_with_details(
+        "bar",
+        other_fields: {
+          base_path: "/bar",
+          content_id: taxon_id_2
+        }
+      )
+      taxon_3 = content_item_with_details(
+        "bar",
+        other_fields: {
+          base_path: "/bar",
+          content_id: taxon_id_3
+        }
+      )
+      publishing_api_has_item(taxon_1)
+      publishing_api_has_links(content_id: taxon_id_1, links: {})
+      publishing_api_has_item(taxon_2)
+      publishing_api_has_links(content_id: taxon_id_2, links: {})
+      publishing_api_has_item(taxon_3)
+      publishing_api_has_links(content_id: taxon_id_3, links: {})
 
       result = described_class.new.parents_for_taxon(taxon)
 

--- a/spec/support/content_item_helper.rb
+++ b/spec/support/content_item_helper.rb
@@ -1,4 +1,14 @@
 module ContentItemHelper
+  def content_item_with_details(title, other_fields: {})
+    other_fields_with_details = other_fields.merge(
+      details: {
+        internal_name: "internal name for #{title}",
+        notes_for_editors: "Editor notes for #{title}"
+      }
+    )
+    basic_content_item(title, other_fields: other_fields_with_details)
+  end
+
   def basic_content_item(title, other_fields: {})
     ActiveSupport::HashWithIndifferentAccess.new(
       content_id: title.parameterize,


### PR DESCRIPTION
This method was not returning all taxons and therefore was misleading. This
commit removes it from the codebase and replaces its calls with other
alternatives.

Trello: https://trello.com/c/0fUIlIQ2/202-add-pagination-to-taxon-index-page