### PR TITLE
Solves bug related with taxon deletion workflow

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -44,3 +44,7 @@ $red: #b10e1e;
     display: none;
   }
 }
+
+.left-space {
+  margin-left: 5px;
+}

--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -65,6 +65,16 @@ class TaxonsController < ApplicationController
     redirect_to taxons_path, flash: destroy_flash_message(response_code)
   end
 
+  def confirm_delete
+    tree = ExpandedTaxonomy.new(taxon.content_id).build
+
+    render :confirm_delete, locals: {
+      taxon: tree.taxon,
+      tagged: tagged,
+      children: tree.children,
+    }
+  end
+
 private
 
   def destroy_flash_message(response_code)
@@ -84,7 +94,8 @@ private
   end
 
   def taxon
-    Taxonomy::BuildTaxon.call(content_id: params[:id])
+    content_id = params[:id] || params[:taxon_id]
+    Taxonomy::BuildTaxon.call(content_id: content_id)
   end
 
   def tagged

--- a/app/models/tree_node.rb
+++ b/app/models/tree_node.rb
@@ -1,7 +1,7 @@
 class TreeNode
-  attr_reader :taxon
+  attr_reader :taxon, :children
   attr_accessor :parent
-  delegate :title, :content_id, :parent_taxons, :parent_taxons=, to: :taxon
+  delegate :title, :base_path, :content_id, :parent_taxons, :parent_taxons=, to: :taxon
   delegate :map, :each, to: :tree
 
   def initialize(title:, content_id:)

--- a/app/views/taxons/_children.html.erb
+++ b/app/views/taxons/_children.html.erb
@@ -1,0 +1,19 @@
+<h1>Children</h1>
+
+<table class="table queries-list table-bordered table-striped" data-module="filterable-table">
+ <thead>
+   <tr class="table-header">
+     <th>Taxon</th>
+   </tr>
+
+   <%= render partial: 'shared/table_filter' %>
+ </thead>
+
+ <tbody>
+   <% children.each do |child| %>
+     <tr>
+       <td><%= link_to child.title, taxon_path(child.content_id) %></td>
+     </tr>
+   <% end %>
+ </tbody>
+</table>

--- a/app/views/taxons/_deletion_warning.html.erb
+++ b/app/views/taxons/_deletion_warning.html.erb
@@ -1,0 +1,39 @@
+<% if tagged.any? || children.any? %>
+<div class="alert alert-warning clearfix" role="warning">
+  <p>
+    <%= I18n.t('views.taxons.delete_warning_1') %>
+    <ul>
+      <li><%= I18n.t('views.taxons.delete_warning_2') %></li>
+      <li><%= I18n.t('views.taxons.delete_warning_3') %></li>
+    </ul>
+  </p>
+
+  <%= link_to taxon_path(taxon.content_id), method: :delete,
+    class: 'btn btn-md btn-danger pull-right left-space' do %>
+    <span class="glyphicon glyphicon-trash"></span>
+    <span>
+      <%= I18n.t('views.taxons.confirm_deletion') %>
+    </span>
+  <% end %>
+
+  <%= link_to taxon_path(taxon.content_id), class: 'btn btn-md btn-default pull-right' do %>
+    <span>
+      <%= I18n.t('views.taxons.cancel_button') %>
+    </span>
+  <% end %>
+</div>
+<% else %>
+  <%= link_to taxon_path(taxon.content_id), class: 'btn btn-md btn-default' do %>
+    <span>
+      <%= I18n.t('views.taxons.cancel_button') %>
+    </span>
+  <% end %>
+
+  <%= link_to taxon_path(taxon.content_id), method: :delete,
+    class: 'btn btn-md btn-danger left-space' do %>
+    <span class="glyphicon glyphicon-trash"></span>
+    <span>
+      <%= I18n.t('views.taxons.confirm_deletion') %>
+    </span>
+  <% end %>
+<% end %>

--- a/app/views/taxons/_tagged_content.html.erb
+++ b/app/views/taxons/_tagged_content.html.erb
@@ -1,9 +1,11 @@
+<h1>Tagged Content</h1>
+
 <table class="table queries-list table-bordered table-striped" data-module="filterable-table">
   <thead>
     <tr class="table-header">
       <th>Title</th>
-      <th></th>
-      <th></th>
+      <th>Format</th>
+      <th>Actions</th>
     </tr>
 
     <%= render partial: 'shared/table_filter' %>
@@ -12,9 +14,9 @@
   <tbody>
     <% tagged.each do |content_item| %>
       <tr>
-        <td><%= content_item["title"] %> (<%= content_item["document_type"].humanize %>)<br/></td>
-        <td><%= link_to "View on site", website_url(content_item["base_path"]) %></td>
-        <td><%= link_to I18n.t('views.taxons.update_tags'), tagging_url(content_item["content_id"]) %></td>
+        <td><%= link_to content_item["title"], website_url(content_item["base_path"]) %></td>
+        <td><%= content_item["document_type"].humanize %></td>
+        <td><%= link_to 'Update tags', tagging_url(content_item["content_id"]) %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/taxons/confirm_delete.html.erb
+++ b/app/views/taxons/confirm_delete.html.erb
@@ -1,0 +1,12 @@
+<h1>You are about to delete "<%= taxon.title %>"</h1>
+
+<%= render partial: 'deletion_warning',
+  locals: { taxon: taxon, children: children, tagged: tagged } %>
+
+<% if children.any? %>
+  <%= render partial: 'children', locals: { children: children } %>
+<% end %>
+
+<% if tagged.any? %>
+  <%= render partial: 'tagged_content', locals: { tagged: tagged } %>
+<% end %>

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -7,9 +7,7 @@
     </i>
   <% end %>
 
-  <%= link_to taxon_path(taxon.content_id), method: :delete,
-    class: 'btn btn-md btn-default',
-    data: { confirm: I18n.t('messages.views.confirm') } do %>
+  <%= link_to taxon_confirm_delete_path(taxon.content_id), class: 'btn btn-md btn-default' do %>
     <i class="glyphicon glyphicon-trash"></i>
       <%= I18n.t('views.taxons.delete_taxon') %>
     </i>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -52,6 +52,11 @@ en:
       new_button: Create taxon
       edit_button: Update taxon
       download_csv: Download taxonomy as CSV
+      confirm_deletion: I understand and I want to delete it!
+      cancel_button: Cancel
+      delete_warning_1: "Before you delete this taxon, make sure you've:"
+      delete_warning_2: given its child taxons a new parent
+      delete_warning_3: added new tags for all content tagged to this taxon
   controllers:
     bulk_taggings:
       too_many_results: Your search returned too many results. We are only displaying a subset, please try narrowing down your search.
@@ -62,6 +67,7 @@ en:
     taxons:
       success: You have sucessfully deleted the taxon
       alert: It was not possible to delete the taxon
+  messages:
     views:
       confirm: Are you sure?
   panels:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,9 @@
 Rails.application.routes.draw do
   root to: 'taggings#lookup'
 
-  resources :taxons
+  resources :taxons do
+    get :confirm_delete
+  end
   resources :copy_taxons, only: [:index], path: 'copy-taxons'
 
   resources :taggings, only: %i(show update), param: :content_id do

--- a/spec/features/delete_taxon_spec.rb
+++ b/spec/features/delete_taxon_spec.rb
@@ -1,0 +1,142 @@
+require "rails_helper"
+
+RSpec.feature "Delete Taxon", type: :feature do
+  include ContentItemHelper
+  include PublishingApiHelper
+
+  scenario "a taxon with no children" do
+    given_a_taxon_with_no_children
+    when_i_visit_the_taxon_page
+    and_i_click_to_delete_the_taxon
+    then_i_expect_to_be_informed_that_im_about_to_delete_the_taxon
+    and_i_should_see_the_action_buttons
+    and_i_click_delete
+    then_i_expect_the_request_to_have_been_made
+  end
+
+  scenario "a parent taxon with children" do
+    given_a_taxon_with_children
+    when_i_visit_the_taxon_page
+    then_i_expect_to_see_the_child_taxon
+    and_i_click_to_delete_the_taxon
+    then_i_should_see_a_warning_message
+    and_i_should_see_the_action_buttons
+    and_i_click_delete
+    then_i_expect_the_request_to_have_been_made
+  end
+
+  def given_a_taxon_with_no_children
+    @content_id = SecureRandom.uuid
+
+    @taxon = {
+      content_id: @content_id,
+      title: 'Taxon 1',
+      description: 'A description',
+      base_path: 'A base path',
+      publication_state: 'State',
+      document_type: 'taxon',
+      details: {
+        internal_name: 'Internal name',
+        notes_for_editors: 'Notes for editors',
+      }
+    }
+
+    publishing_api_has_taxons(
+      [@taxon],
+      page: 1,
+      per_page: 2,
+    )
+
+    publishing_api_has_item(@taxon)
+
+    publishing_api_has_links(
+      content_id: @content_id,
+      links: {
+        topics: [],
+        parent_taxons: []
+      }
+    )
+
+    publishing_api_has_linked_content_items(@content_id, "taxons", [@taxon])
+
+    publishing_api_has_expanded_links(
+      content_id: @content_id,
+      expanded_links: {
+        documents: []
+      }
+    )
+  end
+
+  def a_child_taxon
+    @child_taxon_content_id = SecureRandom.uuid
+    @child_taxon = {
+      content_id: @child_taxon_content_id,
+      title: 'A child taxon',
+      description: 'a child taxon description',
+      base_path: '/a/child/taxon/base/path',
+      document_type: 'taxon',
+      publication_state: 'State',
+      details: {
+        internal_name: 'Child Taxon',
+        notes_for_editors: 'Notes for editors',
+      }
+    }
+
+    publishing_api_has_links(
+      content_id: @child_taxon_content_id,
+      links: {
+        topics: [],
+        parent_taxons: [@content_id]
+      }
+    )
+
+    publishing_api_has_linked_content_items(@content_id, "taxons", [@taxon, @child_taxon])
+  end
+
+  def given_a_taxon_with_children
+    given_a_taxon_with_no_children
+    a_child_taxon
+  end
+
+  def when_i_visit_the_taxon_page
+    visit taxon_path(@content_id)
+    expect(page).to have_text("Taxon")
+  end
+
+  def and_i_click_to_delete_the_taxon
+    expect(page).to have_link("Delete taxon")
+    click_on "Delete taxon"
+  end
+
+  def then_i_expect_to_be_informed_that_im_about_to_delete_the_taxon
+    expect(page).to have_text('You are about to delete "Taxon 1"')
+  end
+
+  def and_i_should_see_the_action_buttons
+    expect(page).to have_link('Cancel')
+    expect(page).to have_link('I understand and I want to delete it')
+  end
+
+  def and_i_click_delete
+    @unpublish_request = stub_request(:post, "https://publishing-api.test.gov.uk/v2/content/#{@content_id}/unpublish")
+      .with(body: "{\"type\":\"gone\"}").to_return(status: 200)
+
+    # Because we'll end up on the taxons page
+    stub_request(:get, "https://publishing-api.test.gov.uk/v2/content?document_type=taxon&order=-public_updated_at&page=1&per_page=50&q=")
+      .to_return(body: "{\"total\": 0,\"pages\": 0,\"current_page\": 1,\"results\":[]}", status: 200)
+
+    click_on "I understand and I want to delete it!"
+  end
+
+  def then_i_expect_the_request_to_have_been_made
+    expect(@unpublish_request).to have_been_made
+  end
+
+  def then_i_expect_to_see_the_child_taxon
+    expect(page).to have_text('A child taxon')
+  end
+
+  def then_i_should_see_a_warning_message
+    expect(page).to have_text("Before you delete this taxon, make sure you've")
+  end
+end

--- a/spec/support/content_item_helper.rb
+++ b/spec/support/content_item_helper.rb
@@ -30,4 +30,15 @@ module ContentItemHelper
 
     default.stringify_keys.merge(hash.stringify_keys)
   end
+
+  def publishing_api_has_linked_content_items(content_id, link_type, response_body)
+    publishing_api_endpoint = "#{Plek.current.find('publishing-api')}/v2/linked/#{content_id}?"
+    request_parmeters = {
+      "fields" => %w(base_path content_id document_type title),
+      "link_type" => link_type,
+    }.to_query
+
+    stub_request(:get, "#{publishing_api_endpoint}#{request_parmeters}")
+      .and_return(body: response_body.to_json, status: 200)
+  end
 end


### PR DESCRIPTION
This was reverted here: https://github.com/alphagov/content-tagger/pull/190

The problem was that the wrong method was being called
(taxon.child_taxons instead of children here: https://github.com/alphagov/content-tagger/compare/solve-taxons-deletion-workflow?expand=1#diff-8258490cf5fbd5fae1b039d4d51ded74R1)