### PR TITLE
Paginate bulk tag search

### DIFF
--- a/app/controllers/tag_searches_controller.rb
+++ b/app/controllers/tag_searches_controller.rb
@@ -1,24 +1,23 @@
 class TagSearchesController < ApplicationController
   def new
-    render :new, locals: { results: [], query: '' }
+    render :new, locals: {
+      search_results: EmptySearchResponse.new,
+      query: ''
+    }
   end
 
   def results
-    warning_about_multiple_pages
-
-    render :new, locals: { results: search_response.results, query: query }
+    render :new, locals: { search_results: search_response, query: query }
   end
 
 private
 
-  def warning_about_multiple_pages
-    if search_response.multiple_pages?
-      flash.now[:warning] = I18n.t('controllers.bulk_taggings.too_many_results')
-    end
+  def search_response
+    @search_response ||= BulkTagging::Search.call(query: query, page: page)
   end
 
-  def search_response
-    @search_response ||= BulkTagging::Search.call(query: query)
+  def page
+    params[:page] || 1
   end
 
   def query

--- a/app/models/empty_search_response.rb
+++ b/app/models/empty_search_response.rb
@@ -1,0 +1,17 @@
+class EmptySearchResponse
+  def results
+    []
+  end
+
+  def current_page
+    1
+  end
+
+  def total_pages
+    0
+  end
+
+  def limit_value
+    5
+  end
+end

--- a/app/models/search_response.rb
+++ b/app/models/search_response.rb
@@ -11,7 +11,15 @@ class SearchResponse
     gds_api_response_hash['results'].map { |result| ContentItem.new(result) }
   end
 
-  def multiple_pages?
-    gds_api_response_hash['pages'] > 1
+  def current_page
+    gds_api_response_hash['current_page']
+  end
+
+  def total_pages
+    gds_api_response_hash['pages']
+  end
+
+  def limit_value
+    5
   end
 end

--- a/app/services/bulk_tagging/search.rb
+++ b/app/services/bulk_tagging/search.rb
@@ -1,18 +1,19 @@
 module BulkTagging
   class Search
-    attr_reader :query, :document_type
+    attr_reader :query, :page, :document_type
 
     def self.default_document_types
       BulkTaggingSource.new.source_names
     end
 
-    def initialize(query:, document_type:)
+    def initialize(query:, page:, document_type:)
       @query = query
+      @page = page
       @document_type = document_type
     end
 
-    def self.call(query:, document_type: default_document_types)
-      new(query: query, document_type: document_type).call
+    def self.call(query:, page:, document_type: default_document_types)
+      new(query: query, document_type: document_type, page: page).call
     end
 
     def call
@@ -24,7 +25,7 @@ module BulkTagging
     def gds_response
       Services.publishing_api.get_content_items(
         document_type: document_type,
-        per_page: 20,
+        page: page,
         q: query
       )
     end

--- a/app/views/tag_searches/new.html.erb
+++ b/app/views/tag_searches/new.html.erb
@@ -17,8 +17,10 @@
   </div>
 <% end %>
 
-<% if results.any? %>
-  <%= render 'search_results', results: results %>
+<% if search_results.results.any? %>
+  <%= render 'search_results', results: search_results.results %>
 <% elsif query.present? %>
   <p class="no-content no-content-bordered">No search results for '<%= query %>'</p>
 <% end %>
+
+<%= paginate search_results, theme: 'twitter-bootstrap-3' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -66,7 +66,6 @@ en:
       displayed_on_govuk: 'Displayed on GOV.UK'
   controllers:
     bulk_taggings:
-      too_many_results: Your search returned too many results. We are only displaying a subset, please try narrowing down your search.
       failure: We could not perform search, please try again.
     tag_migrations:
       import_started: The tag migration import has started. It can take a few minutes for the tags to be published.

--- a/spec/features/bulk_tagging_spec.rb
+++ b/spec/features/bulk_tagging_spec.rb
@@ -49,7 +49,7 @@ RSpec.feature "Bulk tagging", type: :feature do
     publishing_api_has_content(
       [document_collection],
       document_type: BulkTagging::Search.default_document_types,
-      per_page: 20,
+      page: 1,
       q: "Tax"
     )
 
@@ -63,7 +63,7 @@ RSpec.feature "Bulk tagging", type: :feature do
         document_type: "topic",
       }],
       document_type: BulkTagging::Search.default_document_types,
-      per_page: 20,
+      page: 1,
       q: "topic"
     )
 
@@ -75,7 +75,7 @@ RSpec.feature "Bulk tagging", type: :feature do
         document_type: "mainstream_browse_page",
       }],
       document_type: BulkTagging::Search.default_document_types,
-      per_page: 20,
+      page: 1,
       q: "browse"
     )
 

--- a/spec/models/search_response_spec.rb
+++ b/spec/models/search_response_spec.rb
@@ -13,25 +13,33 @@ RSpec.describe SearchResponse do
             basic_content_item('Content item 1'),
             basic_content_item('Content item 2'),
           ],
-          'pages' => 1
+          'pages' => 2,
+          'current_page' => 1
         }
       )
     end
 
-    it 'includes content item search results' do
-      search_response =
-        described_class.new(gds_api_response, 'document_collection')
+    let(:search_response) do
+      described_class.new(gds_api_response, 'document_collection')
+    end
 
+    it 'includes content item search results' do
       expect(search_response.results.length).to eq(2)
       search_response.results.each do |result|
         expect(result).to be_a(ContentItem)
       end
     end
 
-    it 'does not have multiple pages when pages are 1' do
-      expect(
-        described_class.new(gds_api_response, 'document_collection').multiple_pages?
-      ).to be_falsy
+    it 'knows the total number of pages' do
+      expect(search_response.total_pages).to eq(2)
+    end
+
+    it 'knows in which page the results are on' do
+      expect(search_response.current_page).to eq(1)
+    end
+
+    it 'sets a limit number of pagination links to display' do
+      expect(search_response.limit_value).to eq(5)
     end
   end
 end

--- a/spec/services/bulk_tagging/search_spec.rb
+++ b/spec/services/bulk_tagging/search_spec.rb
@@ -7,13 +7,13 @@ RSpec.describe BulkTagging::Search do
     publishing_api_has_content(
       [basic_content_item('A content item')],
       q: 'tax',
-      per_page: 20,
+      page: 1,
       document_type: 'taxon'
     )
   end
 
   it 'returns an instance of SearchResponse' do
-    search = described_class.new(query: 'tax', document_type: 'taxon')
+    search = described_class.new(query: 'tax', page: 1, document_type: 'taxon')
 
     expect(search.call).to be_a(SearchResponse)
   end


### PR DESCRIPTION
When searching for tags in the bulk tagging feature, the results will
now be paginated instead of showing a warning messages about multiple
results.

Trello:
https://trello.com/c/HkbPffzv/242-content-tagger-add-pagination-to-bulk-tag-search