### PR TITLE
Use taxon internal name

### DIFF
--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -31,6 +31,10 @@ class Taxon
     'taxons'
   end
 
+  def internal_name
+    @internal_name || @title
+  end
+
   def notes_for_editors
     @notes_for_editors || ""
   end

--- a/app/views/taxons/_taxonomy_tree.html.erb
+++ b/app/views/taxons/_taxonomy_tree.html.erb
@@ -12,7 +12,7 @@
         <div class="taxon-level-parent-links">
           <% parent_taxons.each do |parent_taxon| %>
             <p>
-              ↰ <%= link_to parent_taxon.title, taxon_path(parent_taxon.content_id) %>
+              ↰ <%= link_to parent_taxon.internal_name, taxon_path(parent_taxon.content_id) %>
             </p>
           <% end %>
         </div>

--- a/app/views/taxons/confirm_delete.html.erb
+++ b/app/views/taxons/confirm_delete.html.erb
@@ -1,4 +1,4 @@
-<h1>You are about to delete "<%= taxon.title %>"</h1>
+<h1>You are about to delete "<%= taxon.internal_name %>"</h1>
 
 <%= render partial: 'deletion_warning',
   locals: { taxon: taxon, children: children, tagged: tagged } %>

--- a/app/views/taxons/edit.html.erb
+++ b/app/views/taxons/edit.html.erb
@@ -1,5 +1,5 @@
-<%= display_header title: taxon.title,
-  breadcrumbs: [:taxons, link_to(taxon.title, taxon_path(taxon.content_id)), "Edit"] %>
+<%= display_header title: taxon.internal_name,
+  breadcrumbs: [:taxons, link_to(taxon.internal_name, taxon_path(taxon.content_id)), "Edit"] %>
 
 <%= simple_form_for taxon, url: taxon_path(taxon.content_id), method: :patch do |f| %>
   <%= f.hidden_field :content_id, value: taxon.content_id %>

--- a/app/views/taxons/index.html.erb
+++ b/app/views/taxons/index.html.erb
@@ -20,7 +20,7 @@
   <tbody>
     <% taxons.each do |taxon| %>
       <tr>
-        <td><%= taxon.title %></td>
+        <td><%= taxon.internal_name %></td>
         <td><%= link_to I18n.t('views.taxons.view'), taxon_path(taxon.content_id) %></td>
         <td><%= link_to I18n.t('views.taxons.edit'), edit_taxon_path(taxon.content_id) %></td>
       </tr>

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -1,4 +1,4 @@
-<%= display_header title: taxon.title, breadcrumbs: [:taxons, taxon] do %>
+<%= display_header title: taxon.internal_name, breadcrumbs: [:taxons, taxon] do %>
   <%= link_to I18n.t('views.taxons.edit'), edit_taxon_path(taxon.content_id), class: "btn btn-default"%>
 
   <%= link_to taxonomy_path(taxon.content_id, format: :csv), class: "btn btn-default" do %>

--- a/spec/models/taxon_spec.rb
+++ b/spec/models/taxon_spec.rb
@@ -16,6 +16,14 @@ RSpec.describe Taxon do
     expect(taxon_1.base_path).to_not eq(taxon_2.base_path)
   end
 
+  context 'when internal_name is not set' do
+    it 'uses the title value' do
+      taxon = described_class.new(title: 'I Title')
+
+      expect(taxon.internal_name).to eql(taxon.title)
+    end
+  end
+
   context 'without notes_for_editors set' do
     it 'returns an empty string to comply with the schema definition' do
       taxon = described_class.new


### PR DESCRIPTION
Trello: https://trello.com/c/jZtVkf4H/241-use-internal-name-everywhere-in-content-tagger

When the internal_name is not available it will fallback to use the title.
This shouldn't be a problem after running the rake task introduced in 2d56cf8d57d417247a396848971de8ea8f8807b0

Although it will fallback to use the title when `expanded links` is requested from Publishing API,
that happens on [ExpandedTaxonomy](https://github.com/alphagov/content-tagger/blob/master/app/models/expanded_taxonomy.rb#L28)

Paired with @klssmith 