### PR TITLE
Upgrade gds api adapters

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'plek', '~> 1.10'
 gem 'gds-sso', '~> 11.1'
 gem 'govuk_admin_template', '~> 4.4'
 gem 'simple_form', '~> 3.2', '>= 3.2.1'
-gem 'gds-api-adapters', '~> 36.4'
+gem 'gds-api-adapters', '~> 37.2'
 
 gem 'airbrake', '~> 4.3.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,7 +89,7 @@ GEM
       railties (>= 3.0.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
-    gds-api-adapters (36.4.1)
+    gds-api-adapters (37.2.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -353,7 +353,7 @@ DEPENDENCIES
   capybara-webkit
   database_cleaner
   factory_girl_rails
-  gds-api-adapters (~> 36.4)
+  gds-api-adapters (~> 37.2)
   gds-sso (~> 11.1)
   govuk-content-schema-test-helpers (~> 1.4)
   govuk-lint

--- a/config/initializers/gds_api_adapters.rb
+++ b/config/initializers/gds_api_adapters.rb
@@ -1,7 +1,0 @@
-GdsApi.configure do |config|
-  # Never return nil when a server responds with 404 or 410.
-  config.always_raise_for_not_found = true
-
-  # Return a hash, not an OpenStruct from a request.
-  config.hash_response_for_requests = true
-end

--- a/spec/features/delete_taxon_spec.rb
+++ b/spec/features/delete_taxon_spec.rb
@@ -57,7 +57,11 @@ RSpec.feature "Delete Taxon", type: :feature do
       }
     )
 
-    publishing_api_has_linked_content_items(@content_id, "taxons", [@taxon])
+    publishing_api_has_linked_items(
+      [@taxon],
+      content_id: @content_id,
+      link_type: "taxons"
+    )
 
     publishing_api_has_expanded_links(
       content_id: @content_id,
@@ -90,7 +94,11 @@ RSpec.feature "Delete Taxon", type: :feature do
       }
     )
 
-    publishing_api_has_linked_content_items(@content_id, "taxons", [@taxon, @child_taxon])
+    publishing_api_has_linked_items(
+      [@taxon, @child_taxon],
+      content_id: @content_id,
+      link_type: "taxons"
+    )
   end
 
   def given_a_taxon_with_children

--- a/spec/support/content_item_helper.rb
+++ b/spec/support/content_item_helper.rb
@@ -30,15 +30,4 @@ module ContentItemHelper
 
     default.stringify_keys.merge(hash.stringify_keys)
   end
-
-  def publishing_api_has_linked_content_items(content_id, link_type, response_body)
-    publishing_api_endpoint = "#{Plek.current.find('publishing-api')}/v2/linked/#{content_id}?"
-    request_parmeters = {
-      "fields" => %w(base_path content_id document_type title),
-      "link_type" => link_type,
-    }.to_query
-
-    stub_request(:get, "#{publishing_api_endpoint}#{request_parmeters}")
-      .and_return(body: response_body.to_json, status: 200)
-  end
 end


### PR DESCRIPTION
- Upgrade to version 37.2.0
- Remove test helper method in favour of the new one from gds-api-adapters