### PR TITLE
Taxon#notes_for_editors needs to be a string

### DIFF
--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -30,4 +30,8 @@ class Taxon
   def link_type
     'taxons'
   end
+
+  def notes_for_editors
+    @notes_for_editors || ""
+  end
 end

--- a/spec/models/taxon_spec.rb
+++ b/spec/models/taxon_spec.rb
@@ -15,4 +15,12 @@ RSpec.describe Taxon do
 
     expect(taxon_1.base_path).to_not eq(taxon_2.base_path)
   end
+
+  context 'without notes_for_editors set' do
+    it 'returns an empty string to comply with the schema definition' do
+      taxon = described_class.new
+
+      expect(taxon.notes_for_editors).to eq('')
+    end
+  end
 end


### PR DESCRIPTION
When sending a taxon to publishing api, it needs to have the attribute `notes_for_editors` as a string.
At the moment it was sending a `null` value.

This commit aims to fix it to comply with the [schema definition](https://github.com/alphagov/govuk-content-schemas/blob/master/formats/taxon/publisher/details.json#L11).