### PR TITLE
Handle error messages from Publishing API

### DIFF
--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -47,7 +47,9 @@ class TaxonsController < ApplicationController
   def destroy
     response_code = Services.publishing_api.unpublish(params[:id], type: "gone").code
 
-    redirect_to taxons_path, flash: destroy_flash_message(response_code)
+    redirect_to taxon_path(params[:id]), flash: destroy_flash_message(response_code)
+  rescue GdsApi::HTTPUnprocessableEntity => e
+    redirect_to taxon_path(params[:id]), flash: { danger: e.error_details["error"]["message"] }
   end
 
   def confirm_delete


### PR DESCRIPTION
If Publishing API returns an error, then a message is now provided to the
user to show why it failed. Previously, the error caused Content-Tagger to
 crash.

[Trello card](https://trello.com/c/VBe1sCVb/238-handle-error-messages-from-publishing-api)

![screen shot 2016-10-12 at 14 55 57](https://cloud.githubusercontent.com/assets/12881990/19314963/ea14e5aa-9093-11e6-9637-69aa5a6c999d.png)
