### PR TITLE
Make sure we update existing taxons' internal name

### DIFF
--- a/lib/tasks/copy_taxon_title.rake
+++ b/lib/tasks/copy_taxon_title.rake
@@ -4,8 +4,12 @@ task copy_taxons_title: :environment do
   taxons = RemoteTaxons.new.search(per_page: total).taxons
 
   taxons.each do |taxon|
-    next unless taxon.internal_name.empty?
+    unless taxon.internal_name == taxon.title
+      puts "Skipping #{taxon.title}..."
+      next
+    end
 
+    puts "Updating #{taxon.title}'s internal name..."
     taxon.internal_name = taxon.title
     Taxonomy::PublishTaxon.call(taxon: taxon)
   end


### PR DESCRIPTION
The Publishing API returns both a details hash containing the internal
name, and an internal name field in the content item.

We use the latter throughout the code base.

The behaviour on the publishing API is as follows: if there is an
internal name in the details hash, return it; otherwise, return the
title instead. More information [here](https://github.com/alphagov/publishing-api/blob/master/app/presenters/queries/content_item_presenter.rb#L131-L133).

The previous condition would not let us update the taxons, because
internal name was never empty (it is the title when it's actually empty).

This commit makes sure we only update taxons' internal names when the
internal name is the same as the title (i.e., there is no internal name
in the details hash yet).