### PR TITLE
Use internal_name from details hash

### DIFF
--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -1,15 +1,15 @@
 class Taxon
-  ATTRIBUTES = %w(title
-                  description
-                  parent_taxons
-                  content_id
-                  base_path
-                  publication_state
-                  internal_name
-                  notes_for_editors
-                  document_type).freeze
-
-  attr_accessor(*ATTRIBUTES)
+  attr_accessor(
+    :title,
+    :description,
+    :parent_taxons,
+    :content_id,
+    :base_path,
+    :publication_state,
+    :internal_name,
+    :notes_for_editors,
+    :document_type
+  )
 
   include ActiveModel::Model
 

--- a/app/models/taxon_search_results.rb
+++ b/app/models/taxon_search_results.rb
@@ -10,7 +10,18 @@ class TaxonSearchResults
       begin
         results = search_response['results'].map do |taxon_hash|
           next if taxon_hash['publication_state'] == 'unpublished'
-          Taxon.new(taxon_hash.slice(*Taxon::ATTRIBUTES))
+
+          details = taxon_hash['details'] || {}
+          Taxon.new(
+            document_type: taxon_hash['document_type'],
+            content_id: taxon_hash['content_id'],
+            title: taxon_hash["title"],
+            description: taxon_hash["description"],
+            base_path: taxon_hash["base_path"],
+            publication_state: taxon_hash['publication_state'],
+            internal_name: details['internal_name'],
+            notes_for_editors: details['notes_for_editors']
+          )
         end
 
         results.compact

--- a/spec/features/copy_taxons_spec.rb
+++ b/spec/features/copy_taxons_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe "Copying taxons for use in a spreadsheet" do
+  include ContentItemHelper
+
   scenario "Copy taxons" do
     given_there_are_taxons
     when_i_visit_the_bulk_tag_by_upload_page
@@ -9,20 +11,22 @@ RSpec.describe "Copying taxons for use in a spreadsheet" do
   end
 
   def given_there_are_taxons
-    @taxon_1 = {
-      title: "I Am A Taxon",
-      content_id: "ID-1",
-      base_path: "/foo",
-      internal_name: "I Am A Taxon",
-      publication_state: 'active'
-    }
-    @taxon_2 = {
-      title: "I Am Another Taxon",
-      content_id: "ID-2",
-      base_path: "/bar",
-      internal_name: "I Am Another Taxon",
-      publication_state: 'active'
-    }
+    @taxon_1 = basic_content_item(
+      "I Am A Taxon",
+      other_fields: {
+        content_id: "ID-1",
+        base_path: "/foo",
+        publication_state: 'active'
+      }
+    )
+    @taxon_2 = basic_content_item(
+      "I Am Another Taxon",
+      other_fields: {
+        content_id: "ID-2",
+        base_path: "/bar",
+        publication_state: 'active'
+      }
+    )
 
     publishing_api_has_linkables([@taxon_1, @taxon_2], document_type: 'taxon')
 

--- a/spec/features/taxon_search_spec.rb
+++ b/spec/features/taxon_search_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.feature "Taxon Search" do
   include PublishingApiHelper
+  include ContentItemHelper
 
   scenario "User navigates using pagination links" do
     given_there_are_multiple_pages_of_taxons
@@ -21,27 +22,30 @@ RSpec.feature "Taxon Search" do
   end
 
   def given_there_are_multiple_pages_of_taxons
-    @taxon_1 = {
-      title: "I Am A Taxon 1",
-      content_id: "ID-1",
-      base_path: "/foo",
-      internal_name: "I Am A Taxon 1",
-      publication_state: 'active'
-    }
-    @taxon_2 = {
-      title: "I Am Another Taxon 2",
-      content_id: "ID-2",
-      base_path: "/bar",
-      internal_name: "I Am Another Taxon 2",
-      publication_state: 'active'
-    }
-    @taxon_3 = {
-      title: "I Am Yet Another Taxon 3",
-      content_id: "ID-3",
-      base_path: "/bar",
-      internal_name: "I Am Yet Another Taxon 3",
-      publication_state: 'active'
-    }
+    @taxon_1 = content_item_with_details(
+      "I Am A Taxon 1",
+      other_fields: {
+        content_id: "ID-1",
+        base_path: "/foo",
+        publication_state: 'active'
+      }
+    )
+    @taxon_2 = content_item_with_details(
+      "I Am Another Taxon 2",
+      other_fields: {
+        content_id: "ID-2",
+        base_path: "/bar",
+        publication_state: 'active'
+      }
+    )
+    @taxon_3 = content_item_with_details(
+      "I Am Yet Another Taxon 3",
+      other_fields: {
+        content_id: "ID-3",
+        base_path: "/bar",
+        publication_state: 'active'
+      }
+    )
 
     publishing_api_has_taxons(
       [@taxon_1, @taxon_2, @taxon_3],
@@ -56,20 +60,22 @@ RSpec.feature "Taxon Search" do
   end
 
   def given_there_are_taxons_for_search
-    @taxon_1 = {
-      title: "Taxon 1",
-      content_id: "ID-1",
-      base_path: "/foo",
-      internal_name: "I Am A Taxon 1",
-      publication_state: 'active'
-    }
-    @taxon_2 = {
-      title: "Taxon 2",
-      content_id: "ID-2",
-      base_path: "/bar",
-      internal_name: "I Am Another Taxon 2",
-      publication_state: 'active'
-    }
+    @taxon_1 = content_item_with_details(
+      "Taxon 1",
+      other_fields: {
+        content_id: "ID-1",
+        base_path: "/foo",
+        publication_state: 'active'
+      }
+    )
+    @taxon_2 = content_item_with_details(
+      "Taxon 2",
+      other_fields: {
+        content_id: "ID-2",
+        base_path: "/bar",
+        publication_state: 'active'
+      }
+    )
 
     publishing_api_has_taxons(
       [@taxon_1, @taxon_2],

--- a/spec/features/taxonomy_editing_spec.rb
+++ b/spec/features/taxonomy_editing_spec.rb
@@ -2,22 +2,40 @@ require "rails_helper"
 
 RSpec.feature "Taxonomy editing" do
   include PublishingApiHelper
+  include ContentItemHelper
 
   before do
-    @taxon_1 = {
+    @taxon_1 = content_item_with_details(
+      "I Am A Taxon",
+      other_fields: {
+        content_id: "ID-1",
+        base_path: "/foo",
+        publication_state: 'active'
+      }
+    )
+    @taxon_2 = content_item_with_details(
+      "I Am Another Taxon",
+      other_fields: {
+        content_id: "ID-2",
+        base_path: "/bar",
+        publication_state: 'active'
+      }
+    )
+    @linkable_taxon_1 = {
       title: "I Am A Taxon",
       content_id: "ID-1",
       base_path: "/foo",
       internal_name: "I Am A Taxon",
       publication_state: 'active'
     }
-    @taxon_2 = {
+    @linkable_taxon_2 = {
       title: "I Am Another Taxon",
       content_id: "ID-2",
       base_path: "/bar",
       internal_name: "I Am Another Taxon",
       publication_state: 'active'
     }
+
     @dummy_editor_notes = "Some usage notes for this taxon."
 
     @create_item = stub_request(:put, %r{https://publishing-api.test.gov.uk/v2/content*})
@@ -59,19 +77,20 @@ RSpec.feature "Taxonomy editing" do
   end
 
   def given_there_are_taxons
-    publishing_api_has_linkables([@taxon_1, @taxon_2], document_type: 'taxon')
+    publishing_api_has_linkables(
+      [@linkable_taxon_1, @linkable_taxon_2],
+      document_type: 'taxon'
+    )
     publishing_api_has_taxons([@taxon_1, @taxon_2])
 
     stub_request(:get, "https://publishing-api.test.gov.uk/v2/links/ID-1")
       .to_return(body: { links: { parent_taxons: [] } }.to_json)
 
-    empty_details = { "details" => {} }
-
     stub_request(:get, "https://publishing-api.test.gov.uk/v2/content/ID-1")
-      .to_return(body: @taxon_1.merge(empty_details).to_json)
+      .to_return(body: @taxon_1.to_json)
 
     stub_request(:get, "https://publishing-api.test.gov.uk/v2/content/ID-2")
-      .to_return(body: @taxon_2.merge(empty_details).to_json)
+      .to_return(body: @taxon_2.to_json)
   end
 
   def when_i_visit_the_taxonomy_page


### PR DESCRIPTION
The publishing API used to return the internal_name field both in the details
hash and in the top level content item hash. The latter has been removed from
the publishing API and we should not use it.

This commit looks up internal names in the details hash and fixes the tests so
we always look in the details hash.