### PR TITLE
Skip updating internal name if it is blank

### DIFF
--- a/lib/tasks/copy_taxon_title.rake
+++ b/lib/tasks/copy_taxon_title.rake
@@ -4,7 +4,7 @@ task copy_taxons_title: :environment do
   taxons = RemoteTaxons.new.search(per_page: total).taxons
 
   taxons.each do |taxon|
-    unless taxon.internal_name == taxon.title
+    unless taxon.internal_name.blank?
       puts "Skipping #{taxon.title}..."
       next
     end


### PR DESCRIPTION
Previously, we were relying on building a Taxon object with the internal
name from the content item, and not from the internal name from the
details hash.

The internal name from the content item was either the internal name or
the title if no internal name was available.

This was problematic because we couldn't tell for sure if we should set
the internal name or not.

Since commit 39a2bd1e55404fa9b22083ed44bd146be301cec8 we now use the
internal name from the details hash, so we can accurately check if
that's blank or not.