### PR TITLE
Use publishing-api state filter when retrieving taxons

### DIFF
--- a/app/models/remote_taxons.rb
+++ b/app/models/remote_taxons.rb
@@ -23,7 +23,8 @@ private
         order: '-public_updated_at',
         q: query || '',
         page: page || 1,
-        per_page: per_page || 50
+        per_page: per_page || 50,
+        states: ["published"],
       )
   end
 end

--- a/app/models/taxon_search_results.rb
+++ b/app/models/taxon_search_results.rb
@@ -9,8 +9,6 @@ class TaxonSearchResults
     @taxons ||=
       begin
         results = search_response['results'].map do |taxon_hash|
-          next if taxon_hash['publication_state'] == 'unpublished'
-
           details = taxon_hash['details'] || {}
           Taxon.new(
             document_type: taxon_hash['document_type'],

--- a/app/views/taxons/confirm_delete.html.erb
+++ b/app/views/taxons/confirm_delete.html.erb
@@ -3,12 +3,12 @@
 <%= render partial: 'deletion_warning',
   locals: { taxon: taxon, children: children, tagged: tagged } %>
 
-<h2>Children</h2>
 <% if children.any? %>
+  <h2>Children</h2>
   <%= render partial: 'children', locals: { children: children } %>
 <% end %>
 
-<h2>Tagged content</h2>
 <% if tagged.any? %>
+  <h2>Tagged content</h2>
   <%= render partial: 'tagged_content', locals: { tagged: tagged } %>
 <% end %>

--- a/spec/models/taxon_search_results_spec.rb
+++ b/spec/models/taxon_search_results_spec.rb
@@ -31,19 +31,4 @@ RSpec.describe TaxonSearchResults do
   it 'knows about the limit value so it works with kaminari' do
     expect(search_results.limit_value).to eq(5)
   end
-
-  context 'when unpublished items are in the results' do
-    let(:search_response) do
-      {
-        'results' => [
-          { 'content_id' => 'id-1', 'publication_state' => 'published' },
-          { 'content_id' => 'id-2', 'publication_state' => 'unpublished' },
-        ]
-      }
-    end
-
-    it 'filters them out' do
-      expect(search_results.taxons.count).to eq 1
-    end
-  end
 end

--- a/spec/support/publishing_api_helper.rb
+++ b/spec/support/publishing_api_helper.rb
@@ -5,7 +5,8 @@ module PublishingApiHelper
       order: '-public_updated_at',
       page: 1,
       per_page: 50,
-      q: ''
+      q: '',
+      states: ["published"],
     }
 
     publishing_api_has_content(taxons, default_options.merge(options))


### PR DESCRIPTION
We're not interested in unpublished (deleted) taxons appearing in the
taxon search. Instead of filtering the result set in Ruby, we can now
pass in a state filter when calling get_content_items.