### PR TITLE
Labelling changes to step 1 of the "Bulk tag" tab

### DIFF
--- a/app/views/tag_searches/new.html.erb
+++ b/app/views/tag_searches/new.html.erb
@@ -1,4 +1,4 @@
-<%= display_header title: t('navigation.tag_search'), breadcrumbs: [t('navigation.tag_search')] do %>
+<%= display_header title: t('bulk_tagging.title'), breadcrumbs: [t('navigation.tag_search')] do %>
   <%= link_to t('navigation.tag_migration'), tag_migrations_path %>
 <% end %>
 
@@ -9,9 +9,9 @@
 
 <%= simple_form_for :tag_search, url: results_of_tag_search_path, method: :get do |f| %>
   <div class="form-group">
-    <%= f.input :query,
-      input_html: { class: 'form-control', value: query },
-      label: "Query" %>
+    <%= f.input :query, label: false,
+      input_html: { class: 'form-control', value: query }
+    %>
 
     <%= f.submit t('tag_search.search_button'), class: "btn btn-md btn-success" %>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,6 +34,7 @@ en:
       invalid_link_types: Invalid link types found - only taxons are allowed.
       tag_mappings_failed: We could not tag all items, please check the preview for more details.
   bulk_tagging:
+    title: "Find pages to tag"
     start_tagging: "Start tagging"
     preview: "Preview tagging"
     update_tags:

--- a/spec/features/bulk_tagging_spec.rb
+++ b/spec/features/bulk_tagging_spec.rb
@@ -108,15 +108,15 @@ RSpec.feature "Bulk tagging", type: :feature do
   def when_i_search_for_the_collection
     visit new_tag_search_path
 
-    fill_in "Query", with: "topic"
+    fill_in "tag_search_query", with: "topic"
     click_button I18n.t('tag_search.search_button')
     expect(page).to have_text("A Topic")
 
-    fill_in "Query", with: "browse"
+    fill_in "tag_search_query", with: "browse"
     click_button I18n.t('tag_search.search_button')
     expect(page).to have_text("A Mainstream Browse Page")
 
-    fill_in "Query", with: "Tax"
+    fill_in "tag_search_query", with: "Tax"
     click_button I18n.t('tag_search.search_button')
     expect(page).to have_text("Tax documents")
     expect(page).to have_text('Document collection')


### PR DESCRIPTION
Minor changes made as part of [this Trello card:](https://trello.com/c/XZGZNtHb/213-content-tagger-updates-to-page-titles-and-labelling)

- Removed label from the form
- Changed the title to "Find pages to tag"

Before:

![screen shot 2016-10-20 at 09 42 50](https://cloud.githubusercontent.com/assets/12881990/19554342/0d4eab06-96b0-11e6-9285-90687bc86c94.png)

After:

![screen shot 2016-10-20 at 15 39 40](https://cloud.githubusercontent.com/assets/12881990/19564564/dcd3cf16-96db-11e6-9bd4-59735b2b9125.png)
