### PR TITLE
Move "Bulk tag by upload" into "Bulk Tag"

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,11 +13,7 @@
     <%= link_to t('navigation.tag_search'), new_tag_search_path %>
   </li>
 
-  <li class='<%= active_navigation_item == 'tagging_spreadsheets' ? 'active' : nil %>'>
-    <%= link_to t('navigation.tag_importer'), tagging_spreadsheets_path %>
-  </li>
-
-  <li class='<%= active_navigation_item.in?(%w[taxons ]) ? 'active' : nil %>'>
+  <li class='<%= active_navigation_item.in?(%w[taxons]) ? 'active' : nil %>'>
     <%= link_to t('navigation.taxons'), taxons_path %>
   </li>
 <% end %>

--- a/app/views/tag_searches/new.html.erb
+++ b/app/views/tag_searches/new.html.erb
@@ -1,5 +1,6 @@
-<%= display_header title: t('bulk_tagging.title'), breadcrumbs: [t('navigation.tag_search')] do %>
-  <%= link_to t('navigation.tag_migration'), tag_migrations_path %>
+<%= display_header title: t('navigation.tag_search'), breadcrumbs: [t('navigation.tag_search')] do %>
+  <%= link_to t('navigation.tag_importer'), tagging_spreadsheets_path, class: 'btn btn-default' %>
+  <%= link_to t('navigation.tag_migration'), tag_migrations_path, class: 'btn btn-default' %>
 <% end %>
 
 <div class="lead">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,9 +2,9 @@ en:
   navigation:
     tagging_content: 'Tag a page'
     taxons: 'Edit taxonomy'
-    tag_importer: 'Bulk tag by upload'
     tag_search: 'Bulk tag'
     tag_migration: 'Bulk tag history'
+    tag_importer: 'Bulk tag by upload'
   errors:
     invalid_taxon: There was a problem with your request and we were notified about it. We will fix this issue as soon as possible
     invalid_hostname: Is not a Google Docs URL

--- a/spec/features/tag_importer_spec.rb
+++ b/spec/features/tag_importer_spec.rb
@@ -88,6 +88,8 @@ RSpec.feature "Tag importer", type: :feature do
 
   def when_i_provide_the_public_uri_of_this_spreadsheet
     visit root_path
+    click_link I18n.t('navigation.tag_search')
+
     click_link I18n.t("navigation.tag_importer")
     click_link I18n.t('tag_import.upload_sheet')
     expect(page).to have_text(/how to generate a google spreadsheet url/i)
@@ -235,7 +237,10 @@ RSpec.feature "Tag importer", type: :feature do
   def and_the_state_of_the_import_is_successful
     tagging_spreadsheet = TaggingSpreadsheet.first
     state = tagging_spreadsheet.state.humanize
+
     visit root_path
+    click_link I18n.t('navigation.tag_search')
+
     click_link I18n.t("navigation.tag_importer")
     row = first('table tbody tr')
 


### PR DESCRIPTION
Trello: https://trello.com/c/XZGZNtHb/213-content-tagger-updates-to-page-titles-and-labelling

We belive this functionality should move into the Bulk Tag tab.

Although having it directly within the page would make it confusing when
you search for content to be tagged and also see the list that comes
from the uploaded content. That's why I've created a "button" to point
to the "Bulk tag by upload"

Also the reason to make it a button is that it stands out in the eye of
the user instead of a link, which looks tiny and reads weird next to
"Bulk tag history".

![screen shot 2016-10-20 at 11 58 08](https://cloud.githubusercontent.com/assets/136777/19557726/f6ede5fc-96be-11e6-9432-80568a8f1c9e.png)
