### PR TITLE
Remove success message when building tags

### DIFF
--- a/app/controllers/tag_migrations_controller.rb
+++ b/app/controllers/tag_migrations_controller.rb
@@ -71,10 +71,7 @@ class TagMigrationsController < ApplicationController
   def publish_tags
     QueueLinksForPublishing.call(tag_migration, user: current_user)
 
-    redirect_to(
-      tag_migration,
-      success: I18n.t('controllers.tag_migrations.import_started')
-    )
+    redirect_to tag_migration
   end
 
 private

--- a/app/controllers/tagging_spreadsheets_controller.rb
+++ b/app/controllers/tagging_spreadsheets_controller.rb
@@ -51,7 +51,7 @@ class TaggingSpreadsheetsController < ApplicationController
   def publish_tags
     QueueLinksForPublishing.call(tagging_spreadsheet, user: current_user)
 
-    redirect_to tagging_spreadsheet, success: I18n.t('tag_import.import_started')
+    redirect_to tagging_spreadsheet
   end
 
   def destroy

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -27,7 +27,6 @@ en:
     start_tagging: "Do tagging"
     import_created: Spreadsheet uploaded. It will be imported within a few minutes.
     import_refetched: The import will be imported again.
-    import_started: The tagging import has started. It can take a few minutes for the tags to be published.
     import_removed: Import has been removed.
     errors:
       invalid_content_id: We could not find this URL on GOV.UK.
@@ -69,7 +68,6 @@ en:
     bulk_taggings:
       failure: We could not perform search, please try again.
     tag_migrations:
-      import_started: The tag migration import has started. It can take a few minutes for the tags to be published.
       import_removed: Tag migration import has been removed.
     taxons:
       success: You have sucessfully deleted the taxon


### PR DESCRIPTION
We decided to remove this message because currently we have no way of telling when the building has finished, this
means the user will see a message saying it was started but will never see a message saying it was finished.