### PR TITLE
Labelling changes to page 2 of "Tag a page" tab

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -1,5 +1,5 @@
 class ContentItem
-  TAG_TYPES = %w(mainstream_browse_pages parent topics organisations taxons).freeze
+  TAG_TYPES = %w(taxons mainstream_browse_pages parent topics organisations).freeze
 
   attr_reader :content_id, :title, :base_path, :publishing_app, :document_type
 

--- a/app/views/taggings/_form_for_organisations.html.erb
+++ b/app/views/taggings/_form_for_organisations.html.erb
@@ -1,4 +1,4 @@
-<h3>Publishing organisation</h3>
+<h3>Organisations</h3>
 
 <%= f.input :organisations,
     collection: linkables.organisations,

--- a/app/views/taggings/_form_for_taxons.html.erb
+++ b/app/views/taggings/_form_for_taxons.html.erb
@@ -1,4 +1,4 @@
-<h3>Taxonomy</h3>
+<h3>Taxons</h3>
 
 <%= f.input :taxons,
     collection: linkables.taxons,

--- a/app/views/taggings/show.html.erb
+++ b/app/views/taggings/show.html.erb
@@ -1,4 +1,4 @@
-<%= display_header title: @content_item.title,
+<%= display_header title: "Add or remove tags from #{@content_item.title}",
   breadcrumbs: [link_to(t('navigation.tagging_content'), lookup_taggings_path), @content_item] %>
 
 <div class='view-on-site'>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,7 +13,7 @@ en:
     missing_output: Is missing the parameter output as TSV
     spreadsheet_download_error: There is a problem downloading the spreadsheet, please make sure the URL works.
   taggings:
-    update_tags: Update tags
+    update_tags: Update tagging
     search: Edit tagging
   tag_search:
     search_button: "Search"
@@ -45,7 +45,6 @@ en:
       move_message: "Please note that moving these pages will remove them from the %{taxon_name} taxon."
     taxons:
       move_content: Move content
-      update_tags: Update tags
       edit: Edit taxon
       view: View taxon
       add_taxon: Add a taxon

--- a/spec/features/tagging_during_migration_spec.rb
+++ b/spec/features/tagging_during_migration_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe "Tagging content during migration", type: :feature do
     @tagging_request = stub_request(:patch, "#{PUBLISHING_API}/v2/links/MY-CONTENT-ID")
       .to_return(status: 200)
 
-    click_on I18n.t('views.taxons.update_tags')
+    click_on I18n.t('taggings.update_tags')
   end
 
   def then_only_that_link_type_is_sent_to_the_publishing_api


### PR DESCRIPTION
Content changes made as part of [this Trello card.](https://trello.com/c/XZGZNtHb/213-content-tagger-updates-to-page-titles-and-labelling)

- Switched order of fields on page
- Changed labels of 2 fields
- Changed button text from "Update tags" to "Update tagging"
- Changed title text

Before:

![screen shot 2016-10-19 at 16 11 59](https://cloud.githubusercontent.com/assets/12881990/19563973/df82af86-96d9-11e6-96d5-6855b4477275.png)

After:

![screen shot 2016-10-20 at 16 41 32](https://cloud.githubusercontent.com/assets/12881990/19566999/21546eae-96e4-11e6-81b6-68f3482e49ed.png)
