### PR TITLE
Change bulk tag table link text

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -17,7 +17,7 @@ en:
     search: Edit tagging
   tag_search:
     search_button: "Search"
-    bulk_tag: "Bulk tag"
+    bulk_tag: "View tagged pages"
   tag_import:
     upload_sheet: Upload spreadsheet
     upload: Upload

--- a/spec/features/bulk_tagging_spec.rb
+++ b/spec/features/bulk_tagging_spec.rb
@@ -121,7 +121,7 @@ RSpec.feature "Bulk tagging", type: :feature do
     expect(page).to have_text("Tax documents")
     expect(page).to have_text('Document collection')
     expect(page).to have_link(
-      "Bulk tag",
+      "View tagged pages",
       href: new_tag_migration_path(source_content_id: "collection-id")
     )
   end


### PR DESCRIPTION
- Text changed from "Bulk tag" to "View tagged pages"
- [Trello card](https://trello.com/c/XZGZNtHb/213-content-tagger-updates-to-page-titles-and-labelling)

Before:
![screen shot 2016-10-20 at 16 17 41](https://cloud.githubusercontent.com/assets/12881990/19566070/f03e1e4e-96e0-11e6-918c-25fa5a0f883c.png)

After:
![screen shot 2016-10-20 at 16 21 08](https://cloud.githubusercontent.com/assets/12881990/19566191/4aa3ca14-96e1-11e6-8e57-32724c2b020d.png)
