### PR TITLE
Update taxonomy visualisation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ group :development, :test do
   gem 'govuk-content-schema-test-helpers', '~> 1.4'
   gem 'govuk-lint'
   gem 'factory_girl_rails'
+  gem 'awesome_print'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,7 @@ GEM
     ast (2.3.0)
     autoprefixer-rails (6.4.1.1)
       execjs
+    awesome_print (1.7.0)
     better_errors (2.1.1)
       coderay (>= 1.0.0)
       erubis (>= 2.6.6)
@@ -347,6 +348,7 @@ PLATFORMS
 
 DEPENDENCIES
   airbrake (~> 4.3.1)
+  awesome_print
   better_errors
   bootstrap-kaminari-views (~> 0.0.5)
   capybara
@@ -379,4 +381,4 @@ DEPENDENCIES
   webmock (~> 1.22)
 
 BUNDLED WITH
-   1.11.2
+   1.13.5

--- a/app/assets/stylesheets/taxonomy-tree.scss
+++ b/app/assets/stylesheets/taxonomy-tree.scss
@@ -1,46 +1,135 @@
-// A set of classes governing the degree of indent depending on the depth of a
-// given node in the taxonomy. 20 has no special significance. It's large
-// enough that we're unlikely to ever need to update this rule, but small
-// enough that we don't end up creating large amounts of unnecessary CSS.
-@for $i from 1 through 20 {
-  .taxon-depth-#{$i} {
-    margin-left: 4rem * $i;
-  }
-}
-
-$taxon-level-font-size-lg: 16px;
-$taxon-level-font-size-sm: 13px;
 $gray: #bfc1c3;
 
-.taxon-level {
-  padding: 0.5rem;
-  border-left: 1px solid $gray;
-  border-bottom: 1px solid $gray;
-  margin-bottom: 1rem;
-  max-width: 40%;
+.taxonomy-tree {
+  a, a:visited { color: rgb(0, 0, 238) }
 
-  .btn {
-    padding: 1px 4px;
+  .taxon-focus {
+    display: flex;
+    justify-content: center;
+    position: relative;
+    padding: 2em;
+    margin: auto;
+    font-weight: bold;
+  }
+
+  .taxon-focus--has-parents {
+    border-top: 2px solid $gray;
+  }
+
+  .taxon-focus--has-children{
+    border-bottom: 2px solid $gray;
+  }
+
+  .taxon-focus--has-parents:before,
+  .taxon-focus--has-children:after {
+     content: ".";
+     color: transparent;
+     position: absolute;
+     overflow: hidden;
+     height: 1.75em;
+     width: 0;
+     left: 50%;
+     border-left: 2px solid $gray;
+  }
+
+  .taxon-focus--has-parents:before {
+     top: 0;
+  }
+
+  .taxon-focus--has-children:after {
+     bottom: 0;
+  }
+
+  .taxon-parents, .taxon-children {
+    display: flex;
+    justify-content: space-around;
+  }
+
+  .parent-expansion {
+    display: flex;
+    flex-direction: column-reverse;
+    position: relative;
+  }
+
+  .child-expansion {
+    display: flex;
+    flex-direction: column;
+    position: relative;
+  }
+
+  .taxon-depth-1 {
+    font-size: 1.5rem;
+  }
+
+  .parent-expansion .taxon-depth-1 {
+    margin-top: 0.5rem;
+    margin-bottom: 1.75rem;
+  }
+
+  .child-expansion .taxon-depth-1 {
     margin-bottom: 0.5rem;
-  }
-}
-
-.taxon-level-title {
-  font-size: $taxon-level-font-size-lg;
-}
-
-.taxon-level-edit {
-  font-size: $taxon-level-font-size-sm;
-}
-
-.taxon-level-parent-links {
-  font-size: $taxon-level-font-size-sm;
-
-  span {
-    margin-bottom: 0.8rem;
+    margin-top: 1.75rem;
   }
 
-  p {
-    margin-bottom: 0;
+  .parent-expansion .taxon-depth-1:before,
+  .child-expansion .taxon-depth-1:after {
+    content: ".";
+    color: transparent;
+    position: absolute;
+    overflow: hidden;
+    height: 1.25em;
+    bottom: 0;
+    left: 1.5em;
+    width: 0;
+    border-left: 2px solid $gray;
+  }
+
+  .parent-expansion .taxon-depth-1:before {
+    bottom: 0;
+  }
+
+  .child-expansion .taxon-depth-1:after {
+    top: 0;
+  }
+
+  // A set of classes governing the degree of indent and styling of taxons,
+  // depending on their depth relative to a node in the taxonomy. The number 20
+  // has no special significance. It's large enough that we're unlikely to ever
+  // need to update this rule, but small enough that we don't end up generating
+  // lots of unnecessary CSS.
+  @for $i from 2 through 20 {
+    .taxon-depth-#{$i} {
+      margin-left: 1rem * $i;
+      margin-top: 1rem;
+      font-size: 1.2rem;
+      position: relative;
+      max-width: 25rem;
+    }
+
+   .parent-expansion .taxon-depth-#{$i}:before {
+       content: ".";
+       color: transparent;
+       position: absolute;
+       overflow: hidden;
+       left: -0.85rem;
+       width: 0.5rem;
+       border-left: 1px solid #bfc1c3;
+       top: 0.5rem;
+       bottom: -1rem;
+       border-top: 1px solid #bfc1c3;
+    }
+
+    .child-expansion .taxon-depth-#{$i}:before {
+       content: ".";
+       color: transparent;
+       position: absolute;
+       overflow: hidden;
+       left: -0.85rem;
+       width: 0.5rem;
+       border-left: 1px solid #bfc1c3;
+       top: -1.2rem;
+       bottom: 1rem;
+       border-bottom: 1px solid #bfc1c3;
+    }
   }
 }

--- a/app/assets/stylesheets/taxonomy-tree.scss
+++ b/app/assets/stylesheets/taxonomy-tree.scss
@@ -1,46 +1,51 @@
 $gray: #bfc1c3;
+$blue-link: rgb(0, 0, 238);
 
 .taxonomy-tree {
-  a, a:visited { color: rgb(0, 0, 238) }
+  a,
+  a:visited {
+    color: $blue-link;
+  }
 
   .taxon-focus {
     display: flex;
-    justify-content: center;
-    position: relative;
-    padding: 2em;
-    margin: auto;
     font-weight: bold;
+    justify-content: center;
+    margin: auto;
+    padding: 2em;
+    position: relative;
   }
 
   .taxon-focus--has-parents {
     border-top: 2px solid $gray;
   }
 
-  .taxon-focus--has-children{
+  .taxon-focus--has-children {
     border-bottom: 2px solid $gray;
   }
 
   .taxon-focus--has-parents:before,
   .taxon-focus--has-children:after {
-     content: ".";
-     color: transparent;
-     position: absolute;
-     overflow: hidden;
-     height: 1.75em;
-     width: 0;
-     left: 50%;
-     border-left: 2px solid $gray;
+    border-left: 2px solid $gray;
+    color: transparent;
+    content: ".";
+    height: 1.75em;
+    left: 50%;
+    overflow: hidden;
+    position: absolute;
+    width: 0;
   }
 
   .taxon-focus--has-parents:before {
-     top: 0;
+    top: 0;
   }
 
   .taxon-focus--has-children:after {
-     bottom: 0;
+    bottom: 0;
   }
 
-  .taxon-parents, .taxon-children {
+  .taxon-parents,
+  .taxon-children {
     display: flex;
     justify-content: space-around;
   }
@@ -62,8 +67,8 @@ $gray: #bfc1c3;
   }
 
   .parent-expansion .taxon-depth-1 {
-    margin-top: 0.5rem;
     margin-bottom: 1.75rem;
+    margin-top: 0.5rem;
   }
 
   .child-expansion .taxon-depth-1 {
@@ -73,15 +78,15 @@ $gray: #bfc1c3;
 
   .parent-expansion .taxon-depth-1:before,
   .child-expansion .taxon-depth-1:after {
-    content: ".";
-    color: transparent;
-    position: absolute;
-    overflow: hidden;
-    height: 1.25em;
-    bottom: 0;
-    left: 1.5em;
-    width: 0;
     border-left: 2px solid $gray;
+    bottom: 0;
+    color: transparent;
+    content: ".";
+    height: 1.25em;
+    left: 1.5em;
+    overflow: hidden;
+    position: absolute;
+    width: 0;
   }
 
   .parent-expansion .taxon-depth-1:before {
@@ -99,37 +104,37 @@ $gray: #bfc1c3;
   // lots of unnecessary CSS.
   @for $i from 2 through 20 {
     .taxon-depth-#{$i} {
+      font-size: 1.2rem;
       margin-left: 1rem * $i;
       margin-top: 1rem;
-      font-size: 1.2rem;
-      position: relative;
       max-width: 25rem;
+      position: relative;
     }
 
-   .parent-expansion .taxon-depth-#{$i}:before {
-       content: ".";
-       color: transparent;
-       position: absolute;
-       overflow: hidden;
-       left: -0.85rem;
-       width: 0.5rem;
-       border-left: 1px solid #bfc1c3;
-       top: 0.5rem;
-       bottom: -1rem;
-       border-top: 1px solid #bfc1c3;
+    .parent-expansion .taxon-depth-#{$i}:before {
+      border-left: 1px solid $gray;
+      border-top: 1px solid $gray;
+      bottom: -1rem;
+      color: transparent;
+      content: ".";
+      left: -0.85rem;
+      overflow: hidden;
+      position: absolute;
+      top: 0.5rem;
+      width: 0.5rem;
     }
 
     .child-expansion .taxon-depth-#{$i}:before {
-       content: ".";
-       color: transparent;
-       position: absolute;
-       overflow: hidden;
-       left: -0.85rem;
-       width: 0.5rem;
-       border-left: 1px solid #bfc1c3;
-       top: -1.2rem;
-       bottom: 1rem;
-       border-bottom: 1px solid #bfc1c3;
+      border-left: 1px solid $gray;
+      border-top: 1px solid $gray;
+      bottom: 1rem;
+      color: transparent;
+      content: ".";
+      left: -0.85rem;
+      overflow: hidden;
+      position: absolute;
+      top: -1.2rem;
+      width: 0.5rem;
     }
   }
 }

--- a/app/controllers/taxonomies_controller.rb
+++ b/app/controllers/taxonomies_controller.rb
@@ -6,8 +6,8 @@ class TaxonomiesController < ApplicationController
     respond_to do |format|
       format.csv do
         send_data(
-          CsvTreePresenter.new(@taxonomy).present,
-          filename: @taxonomy.tree.first.title + ".csv"
+          CsvTreePresenter.new(@taxonomy.child_expansion).present,
+          filename: @taxonomy.root_node.title + ".csv"
         )
       end
     end

--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -51,12 +51,12 @@ class TaxonsController < ApplicationController
   end
 
   def confirm_delete
-    tree = ExpandedTaxonomy.new(taxon.content_id).build
+    expanded_taxonomy = ExpandedTaxonomy.new(taxon.content_id).build
 
     render :confirm_delete, locals: {
-      taxon: tree.taxon,
+      taxon: taxon,
       tagged: tagged,
-      children: tree.children,
+      children: expanded_taxonomy.child_expansion.children,
     }
   end
 

--- a/app/models/expanded_taxonomy.rb
+++ b/app/models/expanded_taxonomy.rb
@@ -1,42 +1,62 @@
 class ExpandedTaxonomy
+  attr_reader :root_node, :parent_expansion, :child_expansion
+
   def initialize(content_id)
     @content_id = content_id
   end
 
   def build
     root_content_item = Services.publishing_api.get_content(@content_id)
-    root_node = tree_node_based_on(root_content_item)
-    expand_tree_from(root_node)
-    root_node
+    @root_node = tree_node_based_on(root_content_item)
+
+    parent_taxons = Services.publishing_api.get_expanded_links(
+      @root_node.content_id
+    )["expanded_links"]["parent_taxons"]
+
+    @parent_expansion = expand_parent_nodes(
+      start_node: tree_node_based_on(root_content_item),
+      parent_taxons: parent_taxons,
+    )
+    @child_expansion = expand_child_nodes(
+      start_node: tree_node_based_on(root_content_item)
+    )
+
+    self
+  end
+
+  def immediate_parents
+    @parent_expansion.children
+  end
+
+  def immediate_children
+    @child_expansion.children
   end
 
 private
 
-  def expand_tree_from(node)
-    expanded_links = Services.publishing_api.get_expanded_links(
-      node.content_id
-    )["expanded_links"]
+  def expand_child_nodes(start_node:)
+    child_taxons = Services.publishing_api.get_expanded_links(
+      start_node.content_id
+    )["expanded_links"]["child_taxons"]
 
-    add_parent_details(node, expanded_links)
-    add_children(node, expanded_links)
-  end
-
-  def add_parent_details(node, expanded_links)
-    # Collect identifying info about the node's parent taxons and store this on
-    # the node itself.
-    node.parent_taxons = Array(expanded_links["parent_taxons"]).map do |parent_taxon|
-      Taxon.new(parent_taxon.to_hash.slice('title', 'content_id'))
-    end
-  end
-
-  def add_children(node, expanded_links)
-    # Derive a tree node from each child taxon, attach it to the parent, and
-    # recursively expand from the child node downwards.
-    Array(expanded_links["child_taxons"]).each do |child_taxon|
+    Array(child_taxons).each do |child_taxon|
       child_node = tree_node_based_on(child_taxon)
-      node << child_node
-      expand_tree_from(child_node)
+      start_node << child_node
+      expand_child_nodes(start_node: child_node)
     end
+    start_node
+  end
+
+  def expand_parent_nodes(start_node:, parent_taxons:)
+    Array(parent_taxons).each do |parent_taxon|
+      parent_node = tree_node_based_on(parent_taxon)
+      start_node << parent_node
+      expand_parent_nodes(
+        start_node: parent_node,
+        parent_taxons: parent_taxon.dig("links", "parent_taxons")
+      )
+    end
+    start_node
   end
 
   def tree_node_based_on(content_item)

--- a/app/models/tree_node.rb
+++ b/app/models/tree_node.rb
@@ -1,7 +1,7 @@
 class TreeNode
   attr_reader :taxon, :children
-  attr_accessor :parent
   delegate :title, :base_path, :content_id, :parent_taxons, :parent_taxons=, to: :taxon
+  attr_accessor :parent_node
   delegate :map, :each, to: :tree
 
   def initialize(title:, content_id:)
@@ -10,7 +10,7 @@ class TreeNode
   end
 
   def <<(child_node)
-    child_node.parent = self
+    child_node.parent_node = self
     @children << child_node
   end
 
@@ -27,11 +27,11 @@ class TreeNode
   end
 
   def root?
-    parent.nil?
+    parent_node.nil?
   end
 
   def node_depth
     return 0 if root?
-    1 + parent.node_depth
+    1 + parent_node.node_depth
   end
 end

--- a/app/models/tree_node.rb
+++ b/app/models/tree_node.rb
@@ -1,7 +1,7 @@
 class TreeNode
   attr_reader :taxon, :children
-  delegate :title, :base_path, :content_id, :parent_taxons, :parent_taxons=, to: :taxon
   attr_accessor :parent_node
+  delegate :title, :base_path, :content_id, to: :taxon
   delegate :map, :each, to: :tree
 
   def initialize(title:, content_id:)

--- a/app/views/taxons/_taxonomy_tree.html.erb
+++ b/app/views/taxons/_taxonomy_tree.html.erb
@@ -1,22 +1,52 @@
 <div class="taxonomy-tree">
-  <% taxonomy_tree.each do |tree_node| %>
-    <div class="taxon-level taxon-depth-<%= tree_node.node_depth %>">
-      <span class="taxon-level-title">
-        <%= link_to tree_node.title, taxon_path(tree_node.content_id) %>
-      </span>
-
-      <% parent_taxons = tree_node.parent_taxons %>
-
-      <% if parent_taxons.present? && (parent_taxons.count > 1 || tree_node.node_depth == 0) %>
-        <br/><strong>Parents:</strong>
-        <div class="taxon-level-parent-links">
-          <% parent_taxons.each do |parent_taxon| %>
-            <p>
-              ↰ <%= link_to parent_taxon.internal_name, taxon_path(parent_taxon.content_id) %>
-            </p>
-          <% end %>
+  <div class="taxon-parents">
+    <% taxonomy_tree.immediate_parents.each do |parent_node| %>
+      <div class="parent-expansion">
+        <div class="taxon-level taxon-depth-1">
+          <span class="taxon-level-title">
+            <%= link_to parent_node.title, taxon_path(parent_node.content_id) %>
+          </span>
         </div>
-      <% end %>
+        <% parent_node.each do |parent_ancestor| %>
+          <% next if parent_ancestor.node_depth == 1 %>
+          <div class="taxon-level taxon-depth-<%= parent_ancestor.node_depth %>">
+            <span class="taxon-level-title">
+              <%= link_to parent_ancestor.title, taxon_path(parent_ancestor.content_id) %>
+            </span>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+
+  <% parents_class = taxonomy_tree.immediate_parents.present? ? "taxon-focus--has-parents" : "" %>
+  <% children_class = taxonomy_tree.immediate_children.present? ? "taxon-focus--has-children" : "" %>
+
+  <div class="taxon-focus <%= parents_class %> <%= children_class %>">
+    <div class="taxon-level taxon-depth-0">
+       <span class="taxon-level-title">
+         <%= taxonomy_tree.root_node.title %>
+       </span>
     </div>
-  <% end %>
+  </div>
+
+  <div class="taxon-children">
+    <% taxonomy_tree.immediate_children.each do |child_node| %>
+      <div class="child-expansion">
+        <div class="taxon-level taxon-depth-1">
+          <span class="taxon-level-title">
+            <%= link_to child_node.title, taxon_path(child_node.content_id) %>
+          </span>
+        </div>
+        <% child_node.each do |child_successor| %>
+          <% next if child_successor.node_depth == 1 %>
+          <div class="taxon-level taxon-depth-<%= child_successor.node_depth %>">
+            <span class="taxon-level-title">
+              <%= link_to child_successor.title, taxon_path(child_successor.content_id) %>
+            </span>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
 </div>

--- a/spec/features/delete_taxon_spec.rb
+++ b/spec/features/delete_taxon_spec.rb
@@ -75,7 +75,7 @@ RSpec.feature "Delete Taxon", type: :feature do
   end
 
   def then_i_see_a_basic_prompt_to_delete
-    expect(page).to have_text('You are about to delete "Taxon 1"')
+    expect(page).to have_text('You are about to delete "internal name for Taxon 1"')
     expect(page).to_not have_text("Before you delete this taxon, make sure you've")
     expect(page).to have_link('Cancel')
     expect(page).to have_link('I understand and I want to delete it')
@@ -105,7 +105,7 @@ RSpec.feature "Delete Taxon", type: :feature do
   end
 
   def then_i_see_a_prompt_to_delete_with_a_warning_message
-    expect(page).to have_text('You are about to delete "Taxon 1"')
+    expect(page).to have_text('You are about to delete "internal name for Taxon 1"')
     expect(page).to have_text("Before you delete this taxon, make sure you've")
     expect(page).to have_link('Cancel')
     expect(page).to have_link('I understand and I want to delete it')

--- a/spec/models/expanded_taxonomy_spec.rb
+++ b/spec/models/expanded_taxonomy_spec.rb
@@ -1,54 +1,79 @@
 require "rails_helper"
 
 RSpec.describe ExpandedTaxonomy do
+  def fake_taxon(title)
+    { "title" => title, "content_id" => "#{title.parameterize}-id" }
+  end
+
+  # parent taxons
+  let(:red_things) { fake_taxon("Red-Things") }
+  let(:food) { fake_taxon("Food") }
+  let(:fruits) do
+    fake_taxon("Fruits").merge(
+      "links" => {
+        "parent_taxons" => [food]
+      }
+    )
+  end
+
+  # our 'root' taxon
+  let(:apples) { fake_taxon("Apples") }
+
+  # child taxons
+  let(:bramley) { fake_taxon("Bramley") }
+  let(:cox) { fake_taxon("Cox") }
+
+  before do
+    publishing_api_has_item(apples)
+
+    publishing_api_has_expanded_links(
+      content_id: apples["content_id"],
+      expanded_links: {
+        parent_taxons: [fruits, red_things],
+        child_taxons: [bramley, cox],
+      },
+    )
+
+    publishing_api_has_expanded_links(
+      content_id: bramley["content_id"],
+      expanded_links: {
+        parent_taxons: [apples]
+      }
+    )
+
+    publishing_api_has_expanded_links(
+      content_id: cox["content_id"],
+      expanded_links: {
+        parent_taxons: [apples]
+      }
+    )
+  end
+
   describe "#build" do
-    def fake_taxon(title)
-      { "title" => title, "content_id" => "#{title.parameterize}-id" }
+    it "returns a representation of the taxonomy, with both parent and child taxons expanded" do
+      taxonomy = ExpandedTaxonomy.new(apples["content_id"]).build
+
+      expect(taxonomy.root_node.title).to eq apples["title"]
+      expect(taxonomy.parent_expansion.map(&:title)).to eq %w(Apples Fruits Food Red-Things)
+      expect(taxonomy.parent_expansion.map(&:node_depth)).to eq [0, 1, 2, 1]
+      expect(taxonomy.child_expansion.map(&:title)).to eq %w(Apples Bramley Cox)
+      expect(taxonomy.child_expansion.map(&:node_depth)).to eq [0, 1, 1]
     end
+  end
 
-    let(:food)   { fake_taxon("Food") }
-    let(:fruits) { fake_taxon("Fruits") }
-    let(:apples) { fake_taxon("Apples") }
-    let(:pears)  { fake_taxon("Pears") }
+  describe "#immediate_parents" do
+    it "returns immediate parents of the root node" do
+      taxonomy = ExpandedTaxonomy.new(apples["content_id"]).build
 
-    before do
-      publishing_api_has_item(food)
-
-      publishing_api_has_expanded_links(
-        content_id: food["content_id"],
-        expanded_links: {
-          child_taxons: [fruits]
-        },
-      )
-      publishing_api_has_expanded_links(
-        content_id: fruits["content_id"],
-        expanded_links: {
-          parent_taxons: [food],
-          child_taxons: [apples, pears]
-        },
-      )
-      publishing_api_has_expanded_links(
-        content_id: pears["content_id"],
-        expanded_links: {
-          parent_taxons: [fruits],
-        },
-      )
-      publishing_api_has_expanded_links(
-        content_id: apples["content_id"],
-        expanded_links: {
-          parent_taxons: [fruits]
-        },
-      )
+      expect(taxonomy.immediate_parents.map(&:title)).to eq %w(Fruits Red-Things)
     end
+  end
 
-    context "given a starting taxon" do
-      let(:taxonomy) { ExpandedTaxonomy.new(food["content_id"]).build }
+  describe "#immediate_children" do
+    it "returns immediate children of the root node" do
+      taxonomy = ExpandedTaxonomy.new(apples["content_id"]).build
 
-      it "returns a tree object representing the taxonomy from the starting taxon down" do
-        expect(taxonomy.count).to eq 4
-        expect(taxonomy.map(&:title)).to eq %w( Food Fruits Apples Pears)
-        expect(taxonomy.map(&:node_depth)).to eq [0, 1, 2, 2]
-      end
+      expect(taxonomy.immediate_children.map(&:title)).to eq %w(Bramley Cox)
     end
   end
 end

--- a/spec/models/tree_node_spec.rb
+++ b/spec/models/tree_node_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe TreeNode do
       root_node << child_node_1
 
       expect(root_node.tree).to include child_node_1
-      expect(child_node_1.parent).to eq root_node
+      expect(child_node_1.parent_node).to eq root_node
     end
   end
 


### PR DESCRIPTION
This commit updates the front end code and underlying data structure of
the taxonomy visualisation feature. Previously we could only see a basic
tree structure detailing the child taxons and immediate parents of a
given taxon. The updated design allows us to see all ancestors and all
successors in a clearer layout.

- Update ExpandedTaxonomy so that it now provides an abstraction over
  two trees - the fully expanded set of parents and the fully expanded
  set of children. Also includes convenience methods for querying data
  about the root node and its immediate parents/children.
- Rework the HTML and CSS to accommodate the new design and additional
  data being displayed.
- Update the viewing_taxons feature spec to reflect the new behaviour.
- Some minor naming clarification in the TreeNode class.

See individual commits for details of other, smaller changes.

https://trello.com/b/GBkshanv/taxonomy-team

Below are some screenshots of different shapes the visualisation can take depending on the structure of the taxonomy. There are some differences from the original design, largely to make the markup more robust when dealing with wildly different structures and multiple levels of nesting.

## Multiple parents

![screen shot 2016-10-21 at 10 08 44](https://cloud.githubusercontent.com/assets/519250/19593185/366f5f7c-9777-11e6-8717-ae4e6a90da9b.png)

## Single parent

![screen shot 2016-10-21 at 10 09 07](https://cloud.githubusercontent.com/assets/519250/19593190/3b1512b0-9777-11e6-9fc1-fee564eda67b.png)

## Large imbalance in the number of child nodes

![screen shot 2016-10-21 at 10 13 56](https://cloud.githubusercontent.com/assets/519250/19593193/40009344-9777-11e6-8f42-290230c9f37e.png)
