### PR TITLE
Fix breadcrumbs within Bulk Tag tab

### DIFF
--- a/app/views/copy_taxons/index.html.erb
+++ b/app/views/copy_taxons/index.html.erb
@@ -1,4 +1,8 @@
-<%= display_header title: 'Copy Taxons', breadcrumbs: ['Copy Taxons'] %>
+<%= display_header title: 'Copy Taxons', breadcrumbs: [
+  link_to(I18n.t('navigation.tag_search'), new_tag_search_path),
+  link_to(I18n.t('navigation.tag_importer'), tagging_spreadsheets_path),
+  I18n.t('views.taxons.copy_taxon')
+  ] %>
 
 <table class="table queries-list table-bordered" data-module="filterable-table">
   <thead>

--- a/app/views/tagging_spreadsheets/index.html.erb
+++ b/app/views/tagging_spreadsheets/index.html.erb
@@ -1,4 +1,11 @@
-<%= display_header title: t('navigation.tag_importer'), breadcrumbs: [t('navigation.tag_importer')] do %>
+<%= display_header(
+      title: t('navigation.tag_importer'),
+      breadcrumbs: [
+        link_to(I18n.t('navigation.tag_search'), new_tag_search_path),
+        t('navigation.tag_importer')
+      ]
+    ) do %>
+
   <%= link_to I18n.t('tag_import.upload_sheet'), new_tagging_spreadsheet_path, class: 'btn btn-default' %>
   <%= link_to copy_taxons_path, class: 'btn btn-default' do %>
     <i class="glyphicon glyphicon-download-alt"></i>

--- a/app/views/tagging_spreadsheets/new.html.erb
+++ b/app/views/tagging_spreadsheets/new.html.erb
@@ -1,5 +1,9 @@
 <%= display_header title: I18n.t('tag_import.upload_sheet'),
-  breadcrumbs: [:tagging_spreadsheets, I18n.t('tag_import.upload')] %>
+  breadcrumbs: [
+    link_to(I18n.t('navigation.tag_search'), new_tag_search_path),
+    link_to(I18n.t('navigation.tag_importer'), tagging_spreadsheets_path),
+    I18n.t('tag_import.upload_sheet')
+  ] %>
 
 <div class="row">
   <div class="col-md-8">


### PR DESCRIPTION
Trello: https://trello.com/c/R15tsvBe/261-content-tagger-fixing-breadcrumbs-in-bulk-tag-tab

Moving 'Bulk tag by upload' into 'Bulk tag' has created some
inconsistent sets of breadcrumbs, this commit fixes that.

![screen shot 2016-10-21 at 12 11 58](https://cloud.githubusercontent.com/assets/136777/19597042/07741f88-978a-11e6-8c49-0ce1ea023973.png)
![screen shot 2016-10-21 at 12 11 45](https://cloud.githubusercontent.com/assets/136777/19597041/0773fb34-978a-11e6-9f0f-4ed4a8bc38ce.png)
![screen shot 2016-10-21 at 12 11 42](https://cloud.githubusercontent.com/assets/136777/19597043/07914c5c-978a-11e6-92d6-cc43de34228b.png)
![screen shot 2016-10-21 at 12 11 36](https://cloud.githubusercontent.com/assets/136777/19597044/0793cdb0-978a-11e6-8abd-c8c069f15a18.png)
