### PR TITLE
Text changes to "Tag a page"

### DIFF
--- a/app/views/taggings/lookup.html.erb
+++ b/app/views/taggings/lookup.html.erb
@@ -1,9 +1,11 @@
-<%= display_header title: t('navigation.tagging_content'), breadcrumbs: [t('navigation.tagging_content')] %>
+<%= display_header title: t('navigation.tagging_title'),
+  breadcrumbs: [t('navigation.tagging_content')] %>
 
 <%= simple_form_for @lookup, url: lookup_taggings_path do |f| %>
   <div class="form-group">
     <%= f.input :base_path,
-      label: "Path or URL of a page on GOV.UK (eg. /book-driving-test)",
+      label: t('navigation.tagging_label'),
+      required: false,
       input_html: { class: 'form-control' }
     %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,6 +1,8 @@
 en:
   navigation:
-    tagging_content: 'Tag a page'
+    tagging_content: Tag a page
+    tagging_title: Which page do you want to tag?
+    tagging_label: Enter the URL or path of a GOV.UK page
     taxons: 'Edit taxonomy'
     tag_search: 'Bulk tag'
     tag_migration: 'Bulk tag history'


### PR DESCRIPTION
Changes are:

- title changed to "Which page do you want to tag?"
- label changed to "Enter the URL or path of a GOV.UK page"

Trello: https://trello.com/c/XZGZNtHb/213-content-tagger-updates-to-page-titles-and-labelling

<img width="1241" alt="screen shot 2016-10-25 at 15 20 24" src="https://cloud.githubusercontent.com/assets/416701/19689843/9b4c865c-9ac6-11e6-8588-372c49121ad4.png">
