### PR TITLE
Copy changes to tag_migrations#new

### DIFF
--- a/app/views/tag_migrations/_items_tagged_to_item.html.erb
+++ b/app/views/tag_migrations/_items_tagged_to_item.html.erb
@@ -1,8 +1,11 @@
 <table class="table queries-list table-bordered" data-module="filterable-table">
   <thead>
     <tr class="table-header">
-      <th data-module="select-all"><%= check_box_tag 'select_all', nil, false %></th>
-      <th>Title</th>
+      <th data-module="select-all">
+        Select all
+        <%= check_box_tag 'select_all', nil, false %>
+      </th>
+      <th>Page</th>
       <th></th>
     </tr>
   </thead>

--- a/app/views/tag_migrations/new.html.erb
+++ b/app/views/tag_migrations/new.html.erb
@@ -1,5 +1,7 @@
 <%= display_header(
-  title: "Tag content from #{source_content_item.document_type.humanize.downcase} '#{source_content_item.title}'",
+  title: t('views.tag_migrations.title',
+           taxon: source_content_item.title,
+           type: source_content_item.document_type.humanize.downcase),
   breadcrumbs: [
     link_to(t('navigation.tag_search'), new_tag_search_path),
     "Retag content from '#{source_content_item.title}'"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,6 +44,7 @@ en:
   views:
     tag_update_progress_bar: "%{completed} of %{total} pages updated"
     tag_migrations:
+      title: "Select pages to tag from '%{taxon}' (%{type})"
       move_message: "Please note that moving these pages will remove them from the %{taxon_name} taxon."
     taxons:
       move_content: Move content


### PR DESCRIPTION
Changes include:

- Title changed to Select pages to tag from '[Title]' ([Type])
- Table column Title renamed to Page
- Table column with checkbox now includes "Select all"

Trello: https://trello.com/c/XZGZNtHb/213-content-tagger-updates-to-page-titles-and-labelling

<img width="1270" alt="screen shot 2016-10-25 at 17 08 52" src="https://cloud.githubusercontent.com/assets/416701/19694143/0ea0c9ec-9ad6-11e6-8862-56295c3a458b.png">
