### PR TITLE
Copy updates to Edit Taxonomy pages

### DIFF
--- a/app/views/taxons/_search.html.erb
+++ b/app/views/taxons/_search.html.erb
@@ -2,7 +2,7 @@
   <div class="form-group">
     <%= f.input :query,
       input_html: { type: :text, class: 'form-control', value: query },
-      label: 'Query'%>
+      label: false %>
     <%= f.submit "Search taxons", class: "btn btn-md btn-success" %>
   </div>
 <% end %>

--- a/app/views/taxons/_tagged_content.html.erb
+++ b/app/views/taxons/_tagged_content.html.erb
@@ -2,7 +2,7 @@
   <table class="table queries-list table-bordered table-striped" data-module="filterable-table">
     <thead>
       <tr class="table-header">
-        <th>Title</th>
+        <th>Page</th>
         <th>Format</th>
         <th>Actions</th>
       </tr>
@@ -15,7 +15,7 @@
         <tr>
           <td><%= link_to content_item["title"], website_url(content_item["base_path"]) %></td>
           <td><%= content_item["document_type"].humanize %></td>
-          <td><%= link_to 'Update tags', tagging_url(content_item["content_id"]) %></td>
+          <td><%= link_to t('views.taxons.edit_tagging'), tagging_url(content_item["content_id"]) %></td>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/taxons/index.html.erb
+++ b/app/views/taxons/index.html.erb
@@ -1,4 +1,4 @@
-<%= display_header title: t('navigation.taxons'), breadcrumbs: [t('navigation.taxons')] do %>
+<%= display_header title: t('views.taxons.title'), breadcrumbs: [t('navigation.taxons')] do %>
   <%= link_to new_taxon_path, class: 'btn btn-default' do %>
     <i class="glyphicon glyphicon-plus"></i>
       <%= I18n.t('views.taxons.add_taxon') %>
@@ -11,7 +11,7 @@
 <table class="table queries-list table-bordered table-striped">
   <thead>
     <tr class="table-header">
-      <th>Title</th>
+      <th>Taxon</th>
       <th></th>
       <th></th>
     </tr>

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -18,11 +18,11 @@
   <% end %>
 <% end %>
 
-<h3>Tree</h3>
+<h3><%= t('views.taxons.tree') %></h3>
 
 <%= render 'taxonomy_tree', taxonomy_tree: taxonomy_tree %>
 
-<h3>Tagged content</h3>
+<h3><%= t('views.taxons.tagged_content') %></h3>
 
 <% if tagged.any? %>
   <%= render 'tagged_content', tagged: tagged %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -47,7 +47,11 @@ en:
       title: "Select pages to tag from '%{taxon}' (%{type})"
       move_message: "Please note that moving these pages will remove them from the %{taxon_name} taxon."
     taxons:
+      tree: Taxon hierarchy
+      tagged_content: Pages tagged to this taxon
+      edit_tagging: Edit tagging
       move_content: Move content
+      title: Taxons
       edit: Edit taxon
       view: View taxon
       add_taxon: Add a taxon

--- a/spec/features/taxon_search_spec.rb
+++ b/spec/features/taxon_search_spec.rb
@@ -144,7 +144,7 @@ RSpec.feature "Taxon Search" do
   end
 
   def when_i_search_for_taxons
-    fill_in 'Query', with: 'Taxon 2'
+    find('#taxon_search_query').set('Taxon 2')
     click_button 'Search taxons'
   end
 


### PR DESCRIPTION
These include:
- change title of index page to Taxons
- Remove "Query" label
- Rename column title: Title → Taxon
- Change subheading: Tree → Taxon hierarchy
- Change subheading: Tagged content → Pages tagged to this taxon
- Change column title: Title → Page
- Change link: Update tags → Edit tagging

Trello: https://trello.com/c/XZGZNtHb/213-content-tagger-updates-to-page-titles-and-labelling