### PR TITLE
Better handling of circular dependencies

### DIFF
--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -28,10 +28,7 @@ class TaxonsController < ApplicationController
       redirect_to(taxons_path)
     else
       error_messages = taxon.errors.full_messages.join('; ')
-      locals = {
-        taxon: taxon,
-        taxons_for_select: taxons_for_select,
-      }
+      locals = { taxon: taxon, taxons_for_select: taxons_for_select }
       render :new, locals: locals, flash: { error: error_messages }
     end
   rescue Taxonomy::PublishTaxon::InvalidTaxonError => e
@@ -62,10 +59,7 @@ class TaxonsController < ApplicationController
       redirect_to(taxons_path)
     else
       error_messages = taxon.errors.full_messages.join('; ')
-      locals = {
-        taxon: taxon,
-        taxons_for_select: taxons_for_select(exclude_ids: taxon.content_id)
-      }
+      locals = { taxon: taxon, taxons_for_select: taxons_for_select(exclude_ids: taxon.content_id) }
       render :edit, locals: locals, flash: { error: error_messages }
     end
   rescue Taxonomy::PublishTaxon::InvalidTaxonError => e
@@ -74,7 +68,6 @@ class TaxonsController < ApplicationController
 
   def destroy
     response_code = Services.publishing_api.unpublish(params[:id], type: "gone").code
-
     redirect_to taxons_path, flash: destroy_flash_message(response_code)
   end
 
@@ -99,7 +92,7 @@ private
   end
 
   def taxons_for_select(exclude_ids: nil)
-    selectable_taxons = Linkables.new.taxons(exclude_ids: exclude_ids)
+    Linkables.new.taxons(exclude_ids: exclude_ids)
   end
 
   def remote_taxons
@@ -121,7 +114,6 @@ private
 
   def query
     return '' unless params[:taxon_search].present?
-
     params[:taxon_search][:query]
   end
 end

--- a/app/models/expanded_taxonomy.rb
+++ b/app/models/expanded_taxonomy.rb
@@ -1,38 +1,74 @@
 class ExpandedTaxonomy
-  attr_reader :root_node, :parent_expansion, :child_expansion
+  attr_reader :parent_expansion, :child_expansion
 
   def initialize(content_id)
     @content_id = content_id
   end
 
   def build
-    root_content_item = Services.publishing_api.get_content(@content_id)
-    @root_node = tree_node_based_on(root_content_item)
+    build_parent_expansion
+    build_child_expansion
+    self
+  end
 
+  def build_parent_expansion
     parent_taxons = Services.publishing_api.get_expanded_links(
-      @root_node.content_id
+      root_node.content_id
     )["expanded_links"]["parent_taxons"]
 
     @parent_expansion = expand_parent_nodes(
       start_node: tree_node_based_on(root_content_item),
       parent_taxons: parent_taxons,
     )
+    self
+  end
+
+  def build_child_expansion
     @child_expansion = expand_child_nodes(
       start_node: tree_node_based_on(root_content_item)
     )
-
     self
   end
 
   def immediate_parents
-    @parent_expansion.children
+    parent_expansion.children
   end
 
   def immediate_children
-    @child_expansion.children
+    child_expansion.children
+  end
+
+  def root_node
+    @root_node ||= tree_node_based_on(root_content_item)
+  end
+
+  def parent_expansion
+    if instance_variable_defined?(:@parent_expansion)
+      @parent_expansion
+    else
+      raise ExpansionNotBuiltError
+    end
+  end
+
+  def child_expansion
+    if instance_variable_defined?(:@child_expansion)
+      @child_expansion
+    else
+      raise ExpansionNotBuiltError
+    end
+  end
+
+  class ExpansionNotBuiltError < StandardError
+    def message
+      "Call the appropriate build method to see a parent or child expansion"
+    end
   end
 
 private
+
+  def root_content_item
+    @root_content_item ||= Services.publishing_api.get_content(@content_id)
+  end
 
   def expand_child_nodes(start_node:)
     child_taxons = Services.publishing_api.get_expanded_links(

--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -14,6 +14,7 @@ class Taxon
   include ActiveModel::Model
 
   validates_presence_of :title, :internal_name
+  validates_with CircularDependencyValidator
 
   def parent_taxons
     @parent_taxons ||= []

--- a/app/services/linkables.rb
+++ b/app/services/linkables.rb
@@ -3,8 +3,12 @@ class Linkables
     @topics ||= for_nested_document_type('topic')
   end
 
-  def taxons
-    @taxons ||= for_document_type('taxon')
+  def taxons(exclude_ids: [])
+    @taxons ||= for_document_type('taxon').tap do |items|
+      if Array(exclude_ids).present?
+        items.delete_if { |item| item.second.in? Array(exclude_ids) }
+      end
+    end
   end
 
   def organisations

--- a/app/validators/circular_dependency_validator.rb
+++ b/app/validators/circular_dependency_validator.rb
@@ -1,0 +1,7 @@
+class CircularDependencyValidator < ActiveModel::Validator
+  def validate(record)
+    if record.content_id.in? record.parent_taxons
+      record.errors[:parent_taxons] << I18n.t("errors.circular_dependency.on_self")
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -14,6 +14,8 @@ en:
     missing_gid: Is missing a Google Spreadsheet ID parameter (gid)
     missing_output: Is missing the parameter output as TSV
     spreadsheet_download_error: There is a problem downloading the spreadsheet, please make sure the URL works.
+    circular_dependency:
+      on_self: "Includes the taxon being edited - you can't set a taxon as the parent of itself."
   taggings:
     update_tags: Update tagging
     search: Edit tagging

--- a/spec/models/expanded_taxonomy_spec.rb
+++ b/spec/models/expanded_taxonomy_spec.rb
@@ -76,4 +76,46 @@ RSpec.describe ExpandedTaxonomy do
       expect(taxonomy.immediate_children.map(&:title)).to eq %w(Bramley Cox)
     end
   end
+
+  describe "#child_expansion" do
+    let(:taxonomy) { ExpandedTaxonomy.new(apples["content_id"]) }
+
+    context "when the expansion hasn't been built yet" do
+      it "raises an error" do
+        expect { taxonomy.child_expansion }.to raise_error(
+          ExpandedTaxonomy::ExpansionNotBuiltError
+        )
+      end
+    end
+
+    context "when the expansion has been built" do
+      it "returns the expansion" do
+        taxonomy.build_child_expansion
+
+        expect(taxonomy.child_expansion.map(&:title)).to eq %w(Apples Bramley Cox)
+        expect(taxonomy.child_expansion.map(&:node_depth)).to eq [0, 1, 1]
+      end
+    end
+  end
+
+  describe "#parent_expansion" do
+    let(:taxonomy) { ExpandedTaxonomy.new(apples["content_id"]) }
+
+    context "when the expansion hasn't been built yet" do
+      it "raises an error" do
+        expect { taxonomy.parent_expansion }.to raise_error(
+          ExpandedTaxonomy::ExpansionNotBuiltError
+        )
+      end
+    end
+
+    context "when the expansion has been built" do
+      it "returns the expansion" do
+        taxonomy.build_parent_expansion
+
+        expect(taxonomy.parent_expansion.map(&:title)).to eq %w(Apples Fruits Food Red-Things)
+        expect(taxonomy.parent_expansion.map(&:node_depth)).to eq [0, 1, 2, 1]
+      end
+    end
+  end
 end

--- a/spec/models/expanded_taxonomy_spec.rb
+++ b/spec/models/expanded_taxonomy_spec.rb
@@ -96,6 +96,30 @@ RSpec.describe ExpandedTaxonomy do
         expect(taxonomy.child_expansion.map(&:node_depth)).to eq [0, 1, 1]
       end
     end
+
+    context "given a circular dependency between taxons" do
+      before do
+        publishing_api_has_expanded_links(
+          content_id: bramley["content_id"],
+          expanded_links: {
+            parent_taxons: [apples],
+            child_taxons: [apples],
+          }
+        )
+      end
+
+      it "ensures the same traversal isn't rendered more than once" do
+        taxonomy.build_child_expansion
+
+        tree = taxonomy.child_expansion.map do |child_node|
+          [child_node.node_depth, child_node.title]
+        end
+
+        expect(tree).to eq(
+          [[0, "Apples"], [1, "Bramley"], [2, "Apples"], [1, "Cox"]]
+        )
+      end
+    end
   end
 
   describe "#parent_expansion" do

--- a/spec/services/linkables_spec.rb
+++ b/spec/services/linkables_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Linkables do
   let(:linkables) { Linkables.new }
 
   describe '.taxons' do
-    it 'returns an array of hashes with only valid taxons' do
+    before do
       publishing_api_has_linkables(
         [
           build_linkable(
@@ -22,14 +22,27 @@ RSpec.describe Linkables do
           build_linkable(
             content_id: 'valid-1',
             publication_state: 'live',
-            internal_name: 'Valid!',
+            internal_name: 'Valid-1!',
+          ),
+          build_linkable(
+            content_id: 'valid-2',
+            publication_state: 'live',
+            internal_name: 'Valid-2!',
           ),
         ],
         document_type: 'taxon'
       )
+    end
 
+    it 'returns an array of hashes with only valid taxons' do
       expect(linkables.taxons).to eq(
-        [['Valid!', 'valid-1']]
+        [%w(Valid-1! valid-1), %w(Valid-2! valid-2)]
+      )
+    end
+
+    it 'filters out excluded IDs' do
+      expect(linkables.taxons(exclude_ids: 'valid-2')).to eq(
+        [%w(Valid-1! valid-1)]
       )
     end
   end

--- a/spec/validators/circular_dependency_validator_spec.rb
+++ b/spec/validators/circular_dependency_validator_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe CircularDependencyValidator do
+  it "errors if the parent_taxons contain the record" do
+    record = double(
+      content_id: "foo",
+      parent_taxons: %w(bar foo baz),
+      errors: { parent_taxons: [] }
+    )
+    described_class.new.validate(record)
+
+    expect(record.errors[:parent_taxons]).to include(/you can't set a taxon as the parent of itself/i)
+  end
+
+  it "does nothing if the parent_taxons don't contain the record" do
+    record = double(
+      content_id: "foo",
+      parent_taxons: %w(bar baz),
+      errors: { parent_taxons: [] }
+    )
+    described_class.new.validate(record)
+
+    expect(record.errors[:parent_taxons]).to be_empty
+  end
+end


### PR DESCRIPTION
Make the taxonomy visualisation more robust to errors caused by circular relationships between taxons. Specifically, by:

1. Adding a history of expanded nodes when building out the tree of child taxons in ExpandedTaxonomy.
2. Some basic validation and UI changes to prevent a taxon accidentally being made a parent of itself.

Further details in each commit. 

https://trello.com/c/FI9NYgiz/264-correctly-handle-circular-dependencies-when-linking-taxons