### PR TITLE
Add defensive code when resolving user name

### DIFF
--- a/app/views/tagging_spreadsheets/index.html.erb
+++ b/app/views/tagging_spreadsheets/index.html.erb
@@ -30,8 +30,12 @@
     <% tagging_spreadsheets.each do |spreadsheet| %>
       <tr>
         <td>
-          <%= state_label_for(label_type: spreadsheet.label_type,
-                                title: spreadsheet.state_title) %>
+          <%=
+            state_label_for(
+              label_type: spreadsheet.label_type,
+              title: spreadsheet.state_title
+            )
+          %>
         </td>
         <td>
           <%= spreadsheet.description %>
@@ -40,7 +44,7 @@
           <%= time_tag_for(spreadsheet.created_at) %>
         </td>
         <td>
-          <%= spreadsheet.added_by.name %>
+          <%= spreadsheet.added_by.present? ? spreadsheet.added_by.name : "unknown user"  %>
         </td>
         <td>
           <%= link_to "View", tagging_spreadsheet_path(spreadsheet) %>


### PR DESCRIPTION
On the index page for uploaded tagging spreadsheets we display the name
of the user who added each spreadsheet. Occasionally, user UIDs on staging and
integration can become out of sync with production. Typically this
happens after a password reset on either of the non-production
environments. This can cause TaggingSpreadsheet#added_by to return nil
until the next time the production database sync happens, resulting in
nil errors from any subsequent method calls.

Add a defensive check to eliminate this sporadic error.

https://trello.com/c/MgipqHWy/256-fix-content-tagger-on-integration