### PR TITLE
Rework styling on taxonomy visualisation

### DIFF
--- a/app/assets/stylesheets/taxonomy-tree.scss
+++ b/app/assets/stylesheets/taxonomy-tree.scss
@@ -14,13 +14,17 @@ $blue-link: rgb(0, 0, 238);
     margin: auto;
     padding: 2em;
     position: relative;
+
+    width: 60%;
+    margin-top: -2px;
+    margin-bottom: -2px;
   }
 
-  .taxon-focus--has-parents {
+  .taxon-focus--multi-parents {
     border-top: 2px solid $gray;
   }
 
-  .taxon-focus--has-children {
+  .taxon-focus--multi-children {
     border-bottom: 2px solid $gray;
   }
 
@@ -35,14 +39,17 @@ $blue-link: rgb(0, 0, 238);
     position: absolute;
     width: 0;
   }
-
   .taxon-focus--has-parents:before {
     top: 0;
   }
-
   .taxon-focus--has-children:after {
     bottom: 0;
   }
+
+  .taxon-depth-1 {
+    font-size: 1.5rem;
+  }
+
 
   .taxon-parents,
   .taxon-children {
@@ -54,16 +61,32 @@ $blue-link: rgb(0, 0, 238);
     display: flex;
     flex-direction: column-reverse;
     position: relative;
+
+    padding: 0.5rem;
+    border-bottom: 2px solid $gray;
+
+    &:first-child {
+      padding: 0.5rem 0.5rem 0.5rem 0rem;
+    }
+    &:last-child {
+      padding: 0.5rem 0.5rem 0.5rem 0rem;
+    }
   }
 
   .child-expansion {
     display: flex;
     flex-direction: column;
     position: relative;
-  }
 
-  .taxon-depth-1 {
-    font-size: 1.5rem;
+    padding: 0.5rem;
+    border-top: 2px solid $gray;
+
+    &:first-child {
+      padding: 0.5rem 0.5rem 0.5rem 0rem;
+    }
+    &:last-child {
+      padding: 0.5rem 0rem 0.5rem 0.5rem;
+    }
   }
 
   .parent-expansion .taxon-depth-1 {
@@ -76,10 +99,9 @@ $blue-link: rgb(0, 0, 238);
     margin-top: 1.75rem;
   }
 
-  .parent-expansion .taxon-depth-1:before,
-  .child-expansion .taxon-depth-1:after {
+  .parent-expansion:before,
+  .child-expansion:before {
     border-left: 2px solid $gray;
-    bottom: 0;
     color: transparent;
     content: ".";
     height: 1.25em;
@@ -88,13 +110,30 @@ $blue-link: rgb(0, 0, 238);
     position: absolute;
     width: 0;
   }
-
-  .parent-expansion .taxon-depth-1:before {
+  .parent-expansion:before {
     bottom: 0;
   }
-
-  .child-expansion .taxon-depth-1:after {
+  .child-expansion:before {
     top: 0;
+  }
+
+  .parent-expansion:first-child:before {
+    left: 0rem;
+  }
+  .parent-expansion:last-child:before {
+    border-left: none;
+    border-right: 2px solid $gray;
+    left: 0rem;
+    width: 100%;
+  }
+  .child-expansion:first-child:before {
+    left: 0rem;
+  }
+  .child-expansion:last-child:before {
+    border-left: none;
+    border-right: 2px solid $gray;
+    left: 0rem;
+    width: 100%;
   }
 
   // A set of classes governing the degree of indent and styling of taxons,

--- a/app/assets/stylesheets/taxonomy-tree.scss
+++ b/app/assets/stylesheets/taxonomy-tree.scss
@@ -14,7 +14,6 @@ $blue-link: rgb(0, 0, 238);
     margin: auto;
     padding: 2em;
     position: relative;
-
     width: 60%;
     margin-top: -2px;
     margin-bottom: -2px;
@@ -39,9 +38,11 @@ $blue-link: rgb(0, 0, 238);
     position: absolute;
     width: 0;
   }
+
   .taxon-focus--has-parents:before {
     top: 0;
   }
+
   .taxon-focus--has-children:after {
     bottom: 0;
   }
@@ -49,7 +50,6 @@ $blue-link: rgb(0, 0, 238);
   .taxon-depth-1 {
     font-size: 1.5rem;
   }
-
 
   .taxon-parents,
   .taxon-children {
@@ -61,15 +61,18 @@ $blue-link: rgb(0, 0, 238);
     display: flex;
     flex-direction: column-reverse;
     position: relative;
-
     padding: 0.5rem;
     border-bottom: 2px solid $gray;
 
     &:first-child {
-      padding: 0.5rem 0.5rem 0.5rem 0rem;
+      padding: 0.5rem;
+      padding-left: 0;
+
     }
+
     &:last-child {
-      padding: 0.5rem 0.5rem 0.5rem 0rem;
+      padding: 0.5rem;
+      padding-right: 0;
     }
   }
 
@@ -77,15 +80,18 @@ $blue-link: rgb(0, 0, 238);
     display: flex;
     flex-direction: column;
     position: relative;
-
     padding: 0.5rem;
     border-top: 2px solid $gray;
 
     &:first-child {
-      padding: 0.5rem 0.5rem 0.5rem 0rem;
+      padding: 0.5rem;
+      padding-left: 0;
+
     }
+
     &:last-child {
-      padding: 0.5rem 0rem 0.5rem 0.5rem;
+      padding: 0.5rem;
+      padding-right: 0;
     }
   }
 
@@ -110,29 +116,34 @@ $blue-link: rgb(0, 0, 238);
     position: absolute;
     width: 0;
   }
+
   .parent-expansion:before {
     bottom: 0;
   }
+
   .child-expansion:before {
     top: 0;
   }
 
   .parent-expansion:first-child:before {
-    left: 0rem;
+    left: 0;
   }
+
   .parent-expansion:last-child:before {
     border-left: none;
     border-right: 2px solid $gray;
-    left: 0rem;
+    left: 0;
     width: 100%;
   }
+
   .child-expansion:first-child:before {
-    left: 0rem;
+    left: 0;
   }
+
   .child-expansion:last-child:before {
     border-left: none;
     border-right: 2px solid $gray;
-    left: 0rem;
+    left: 0;
     width: 100%;
   }
 

--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -28,10 +28,7 @@ class TaxonsController < ApplicationController
       redirect_to(taxons_path)
     else
       error_messages = taxon.errors.full_messages.join('; ')
-      locals = {
-        taxon: taxon,
-        taxons_for_select: taxons_for_select,
-      }
+      locals = { taxon: taxon, taxons_for_select: taxons_for_select }
       render :new, locals: locals, flash: { error: error_messages }
     end
   rescue Taxonomy::PublishTaxon::InvalidTaxonError => e
@@ -62,10 +59,7 @@ class TaxonsController < ApplicationController
       redirect_to(taxons_path)
     else
       error_messages = taxon.errors.full_messages.join('; ')
-      locals = {
-        taxon: taxon,
-        taxons_for_select: taxons_for_select(exclude_ids: taxon.content_id)
-      }
+      locals = { taxon: taxon, taxons_for_select: taxons_for_select(exclude_ids: taxon.content_id) }
       render :edit, locals: locals, flash: { error: error_messages }
     end
   rescue Taxonomy::PublishTaxon::InvalidTaxonError => e
@@ -74,7 +68,6 @@ class TaxonsController < ApplicationController
 
   def destroy
     response_code = Services.publishing_api.unpublish(params[:id], type: "gone").code
-
     redirect_to taxons_path, flash: destroy_flash_message(response_code)
   end
 
@@ -99,7 +92,7 @@ private
   end
 
   def taxons_for_select(exclude_ids: nil)
-    selectable_taxons = Linkables.new.taxons(exclude_ids: exclude_ids)
+    Linkables.new.taxons(exclude_ids: exclude_ids)
   end
 
   def remote_taxons
@@ -121,7 +114,6 @@ private
 
   def query
     return '' unless params[:taxon_search].present?
-
     params[:taxon_search][:query]
   end
 end

--- a/app/models/expanded_taxonomy.rb
+++ b/app/models/expanded_taxonomy.rb
@@ -1,38 +1,74 @@
 class ExpandedTaxonomy
-  attr_reader :root_node, :parent_expansion, :child_expansion
+  attr_reader :parent_expansion, :child_expansion
 
   def initialize(content_id)
     @content_id = content_id
   end
 
   def build
-    root_content_item = Services.publishing_api.get_content(@content_id)
-    @root_node = tree_node_based_on(root_content_item)
+    build_parent_expansion
+    build_child_expansion
+    self
+  end
 
+  def build_parent_expansion
     parent_taxons = Services.publishing_api.get_expanded_links(
-      @root_node.content_id
+      root_node.content_id
     )["expanded_links"]["parent_taxons"]
 
     @parent_expansion = expand_parent_nodes(
       start_node: tree_node_based_on(root_content_item),
       parent_taxons: parent_taxons,
     )
+    self
+  end
+
+  def build_child_expansion
     @child_expansion = expand_child_nodes(
       start_node: tree_node_based_on(root_content_item)
     )
-
     self
   end
 
   def immediate_parents
-    @parent_expansion.children
+    parent_expansion.children
   end
 
   def immediate_children
-    @child_expansion.children
+    child_expansion.children
+  end
+
+  def root_node
+    @root_node ||= tree_node_based_on(root_content_item)
+  end
+
+  def parent_expansion
+    if instance_variable_defined?(:@parent_expansion)
+      @parent_expansion
+    else
+      raise ExpansionNotBuiltError
+    end
+  end
+
+  def child_expansion
+    if instance_variable_defined?(:@child_expansion)
+      @child_expansion
+    else
+      raise ExpansionNotBuiltError
+    end
+  end
+
+  class ExpansionNotBuiltError < StandardError
+    def message
+      "Call the appropriate build method to see a parent or child expansion"
+    end
   end
 
 private
+
+  def root_content_item
+    @root_content_item ||= Services.publishing_api.get_content(@content_id)
+  end
 
   def expand_child_nodes(start_node:)
     child_taxons = Services.publishing_api.get_expanded_links(

--- a/app/models/expanded_taxonomy.rb
+++ b/app/models/expanded_taxonomy.rb
@@ -34,8 +34,16 @@ class ExpandedTaxonomy
     parent_expansion.children
   end
 
+  def multiple_immediate_parents?
+    immediate_parents.count > 1
+  end
+
   def immediate_children
     child_expansion.children
+  end
+
+  def multiple_immediate_children?
+    immediate_children.count > 1
   end
 
   def root_node

--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -14,6 +14,7 @@ class Taxon
   include ActiveModel::Model
 
   validates_presence_of :title, :internal_name
+  validates_with CircularDependencyValidator
 
   def parent_taxons
     @parent_taxons ||= []

--- a/app/services/linkables.rb
+++ b/app/services/linkables.rb
@@ -3,8 +3,15 @@ class Linkables
     @topics ||= for_nested_document_type('topic')
   end
 
-  def taxons
-    @taxons ||= for_document_type('taxon')
+  def taxons(exclude_ids: [])
+    @taxons ||=
+      begin
+        items = for_document_type('taxon')
+        if Array(exclude_ids).present?
+          items.delete_if { |item| item.last.in? Array(exclude_ids) }
+        end
+        items
+      end
   end
 
   def organisations

--- a/app/validators/circular_dependency_validator.rb
+++ b/app/validators/circular_dependency_validator.rb
@@ -1,0 +1,7 @@
+class CircularDependencyValidator < ActiveModel::Validator
+  def validate(record)
+    if record.content_id.in? record.parent_taxons
+      record.errors[:parent_taxons] << I18n.t("errors.circular_dependency.on_self")
+    end
+  end
+end

--- a/app/views/taxons/_taxonomy_tree.html.erb
+++ b/app/views/taxons/_taxonomy_tree.html.erb
@@ -19,10 +19,12 @@
     <% end %>
   </div>
 
-  <% parents_class = taxonomy_tree.immediate_parents.present? ? "taxon-focus--has-parents" : "" %>
-  <% children_class = taxonomy_tree.immediate_children.present? ? "taxon-focus--has-children" : "" %>
+  <% has_parents = taxonomy_tree.immediate_parents.present? ? "taxon-focus--has-parents" : "" %>
+  <% has_children = taxonomy_tree.immediate_children.present? ? "taxon-focus--has-children" : "" %>
+  <% multiple_parents = taxonomy_tree.multiple_immediate_parents? ? "taxon-focus--multi-parents" : "" %>
+  <% multiple_children = taxonomy_tree.multiple_immediate_children? ? "taxon-focus--multi-children" : "" %>
 
-  <div class="taxon-focus <%= parents_class %> <%= children_class %>">
+  <div class="taxon-focus <%= has_parents %> <%= has_children %> <%= multiple_parents %> <%= multiple_children %>">
     <div class="taxon-level taxon-depth-0">
        <span class="taxon-level-title">
          <%= taxonomy_tree.root_node.title %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,6 +12,8 @@ en:
     missing_gid: Is missing a Google Spreadsheet ID parameter (gid)
     missing_output: Is missing the parameter output as TSV
     spreadsheet_download_error: There is a problem downloading the spreadsheet, please make sure the URL works.
+    circular_dependency:
+      on_self: "Includes the taxon being edited - you can't set a taxon as the parent of itself."
   taggings:
     update_tags: Update tagging
     search: Edit tagging

--- a/spec/models/expanded_taxonomy_spec.rb
+++ b/spec/models/expanded_taxonomy_spec.rb
@@ -76,4 +76,46 @@ RSpec.describe ExpandedTaxonomy do
       expect(taxonomy.immediate_children.map(&:title)).to eq %w(Bramley Cox)
     end
   end
+
+  describe "#child_expansion" do
+    let(:taxonomy) { ExpandedTaxonomy.new(apples["content_id"]) }
+
+    context "when the expansion hasn't been built yet" do
+      it "raises an error" do
+        expect { taxonomy.child_expansion }.to raise_error(
+          ExpandedTaxonomy::ExpansionNotBuiltError
+        )
+      end
+    end
+
+    context "when the expansion has been built" do
+      it "returns the expansion" do
+        taxonomy.build_child_expansion
+
+        expect(taxonomy.child_expansion.map(&:title)).to eq %w(Apples Bramley Cox)
+        expect(taxonomy.child_expansion.map(&:node_depth)).to eq [0, 1, 1]
+      end
+    end
+  end
+
+  describe "#parent_expansion" do
+    let(:taxonomy) { ExpandedTaxonomy.new(apples["content_id"]) }
+
+    context "when the expansion hasn't been built yet" do
+      it "raises an error" do
+        expect { taxonomy.parent_expansion }.to raise_error(
+          ExpandedTaxonomy::ExpansionNotBuiltError
+        )
+      end
+    end
+
+    context "when the expansion has been built" do
+      it "returns the expansion" do
+        taxonomy.build_parent_expansion
+
+        expect(taxonomy.parent_expansion.map(&:title)).to eq %w(Apples Fruits Food Red-Things)
+        expect(taxonomy.parent_expansion.map(&:node_depth)).to eq [0, 1, 2, 1]
+      end
+    end
+  end
 end

--- a/spec/models/expanded_taxonomy_spec.rb
+++ b/spec/models/expanded_taxonomy_spec.rb
@@ -96,6 +96,30 @@ RSpec.describe ExpandedTaxonomy do
         expect(taxonomy.child_expansion.map(&:node_depth)).to eq [0, 1, 1]
       end
     end
+
+    context "given a circular dependency between taxons" do
+      before do
+        publishing_api_has_expanded_links(
+          content_id: bramley["content_id"],
+          expanded_links: {
+            parent_taxons: [apples],
+            child_taxons: [apples],
+          }
+        )
+      end
+
+      it "ensures the same traversal isn't rendered more than once" do
+        taxonomy.build_child_expansion
+
+        tree = taxonomy.child_expansion.map do |child_node|
+          [child_node.node_depth, child_node.title]
+        end
+
+        expect(tree).to eq(
+          [[0, "Apples"], [1, "Bramley"], [2, "Apples"], [1, "Cox"]]
+        )
+      end
+    end
   end
 
   describe "#parent_expansion" do

--- a/spec/services/linkables_spec.rb
+++ b/spec/services/linkables_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Linkables do
   let(:linkables) { Linkables.new }
 
   describe '.taxons' do
-    it 'returns an array of hashes with only valid taxons' do
+    before do
       publishing_api_has_linkables(
         [
           build_linkable(
@@ -22,14 +22,27 @@ RSpec.describe Linkables do
           build_linkable(
             content_id: 'valid-1',
             publication_state: 'live',
-            internal_name: 'Valid!',
+            internal_name: 'Valid-1!',
+          ),
+          build_linkable(
+            content_id: 'valid-2',
+            publication_state: 'live',
+            internal_name: 'Valid-2!',
           ),
         ],
         document_type: 'taxon'
       )
+    end
 
+    it 'returns an array of hashes with only valid taxons' do
       expect(linkables.taxons).to eq(
-        [['Valid!', 'valid-1']]
+        [%w(Valid-1! valid-1), %w(Valid-2! valid-2)]
+      )
+    end
+
+    it 'filters out excluded IDs' do
+      expect(linkables.taxons(exclude_ids: 'valid-2')).to eq(
+        [%w(Valid-1! valid-1)]
       )
     end
   end

--- a/spec/validators/circular_dependency_validator_spec.rb
+++ b/spec/validators/circular_dependency_validator_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe CircularDependencyValidator do
+  it "errors if the parent_taxons contain the record" do
+    record = double(
+      content_id: "foo",
+      parent_taxons: %w(bar foo baz),
+      errors: { parent_taxons: [] }
+    )
+    described_class.new.validate(record)
+
+    expect(record.errors[:parent_taxons]).to include(/you can't set a taxon as the parent of itself/i)
+  end
+
+  it "does nothing if the parent_taxons don't contain the record" do
+    record = double(
+      content_id: "foo",
+      parent_taxons: %w(bar baz),
+      errors: { parent_taxons: [] }
+    )
+    described_class.new.validate(record)
+
+    expect(record.errors[:parent_taxons]).to be_empty
+  end
+end


### PR DESCRIPTION
- Make the ends of branches fold inwards when displaying taxons at the
  very left or very right of the visualisation. This removes the
  impression that the taxonomy appears 'cut-off' and incomplete either
  side.
- Remove the unnecessarily long border above or below the taxon in focus
  when there is only one parent or child node.

![screen_shot_2016-10-28_at_11_19_51](https://cloud.githubusercontent.com/assets/519250/19803552/4f0e8622-9d01-11e6-9f0d-468650e083a7.png)


![screen shot 2016-10-28 at 11 25 44](https://cloud.githubusercontent.com/assets/519250/19803557/523e62d6-9d01-11e6-874d-915aaadafe68.png)
