### PR TITLE
Rework styling on taxonomy visualisation

### DIFF
--- a/app/assets/stylesheets/taxonomy-tree.scss
+++ b/app/assets/stylesheets/taxonomy-tree.scss
@@ -14,13 +14,16 @@ $blue-link: rgb(0, 0, 238);
     margin: auto;
     padding: 2em;
     position: relative;
+    width: 60%;
+    margin-top: -2px;
+    margin-bottom: -2px;
   }
 
-  .taxon-focus--has-parents {
+  .taxon-focus--multi-parents {
     border-top: 2px solid $gray;
   }
 
-  .taxon-focus--has-children {
+  .taxon-focus--multi-children {
     border-bottom: 2px solid $gray;
   }
 
@@ -44,6 +47,10 @@ $blue-link: rgb(0, 0, 238);
     bottom: 0;
   }
 
+  .taxon-depth-1 {
+    font-size: 1.5rem;
+  }
+
   .taxon-parents,
   .taxon-children {
     display: flex;
@@ -54,16 +61,38 @@ $blue-link: rgb(0, 0, 238);
     display: flex;
     flex-direction: column-reverse;
     position: relative;
+    padding: 0.5rem;
+    border-bottom: 2px solid $gray;
+
+    &:first-child {
+      padding: 0.5rem;
+      padding-left: 0;
+
+    }
+
+    &:last-child {
+      padding: 0.5rem;
+      padding-right: 0;
+    }
   }
 
   .child-expansion {
     display: flex;
     flex-direction: column;
     position: relative;
-  }
+    padding: 0.5rem;
+    border-top: 2px solid $gray;
 
-  .taxon-depth-1 {
-    font-size: 1.5rem;
+    &:first-child {
+      padding: 0.5rem;
+      padding-left: 0;
+
+    }
+
+    &:last-child {
+      padding: 0.5rem;
+      padding-right: 0;
+    }
   }
 
   .parent-expansion .taxon-depth-1 {
@@ -76,10 +105,9 @@ $blue-link: rgb(0, 0, 238);
     margin-top: 1.75rem;
   }
 
-  .parent-expansion .taxon-depth-1:before,
-  .child-expansion .taxon-depth-1:after {
+  .parent-expansion:before,
+  .child-expansion:before {
     border-left: 2px solid $gray;
-    bottom: 0;
     color: transparent;
     content: ".";
     height: 1.25em;
@@ -89,12 +117,34 @@ $blue-link: rgb(0, 0, 238);
     width: 0;
   }
 
-  .parent-expansion .taxon-depth-1:before {
+  .parent-expansion:before {
     bottom: 0;
   }
 
-  .child-expansion .taxon-depth-1:after {
+  .child-expansion:before {
     top: 0;
+  }
+
+  .parent-expansion:first-child:before {
+    left: 0;
+  }
+
+  .parent-expansion:last-child:before {
+    border-left: none;
+    border-right: 2px solid $gray;
+    left: 0;
+    width: 100%;
+  }
+
+  .child-expansion:first-child:before {
+    left: 0;
+  }
+
+  .child-expansion:last-child:before {
+    border-left: none;
+    border-right: 2px solid $gray;
+    left: 0;
+    width: 100%;
   }
 
   // A set of classes governing the degree of indent and styling of taxons,

--- a/app/models/expanded_taxonomy.rb
+++ b/app/models/expanded_taxonomy.rb
@@ -34,8 +34,16 @@ class ExpandedTaxonomy
     parent_expansion.children
   end
 
+  def multiple_immediate_parents?
+    immediate_parents.count > 1
+  end
+
   def immediate_children
     child_expansion.children
+  end
+
+  def multiple_immediate_children?
+    immediate_children.count > 1
   end
 
   def root_node

--- a/app/views/taxons/_taxonomy_tree.html.erb
+++ b/app/views/taxons/_taxonomy_tree.html.erb
@@ -19,10 +19,12 @@
     <% end %>
   </div>
 
-  <% parents_class = taxonomy_tree.immediate_parents.present? ? "taxon-focus--has-parents" : "" %>
-  <% children_class = taxonomy_tree.immediate_children.present? ? "taxon-focus--has-children" : "" %>
+  <% has_parents = taxonomy_tree.immediate_parents.present? ? "taxon-focus--has-parents" : "" %>
+  <% has_children = taxonomy_tree.immediate_children.present? ? "taxon-focus--has-children" : "" %>
+  <% multiple_parents = taxonomy_tree.multiple_immediate_parents? ? "taxon-focus--multi-parents" : "" %>
+  <% multiple_children = taxonomy_tree.multiple_immediate_children? ? "taxon-focus--multi-children" : "" %>
 
-  <div class="taxon-focus <%= parents_class %> <%= children_class %>">
+  <div class="taxon-focus <%= has_parents %> <%= has_children %> <%= multiple_parents %> <%= multiple_children %>">
     <div class="taxon-level taxon-depth-0">
        <span class="taxon-level-title">
          <%= taxonomy_tree.root_node.title %>


### PR DESCRIPTION
- Make the ends of branches fold inwards when displaying taxons at the
  very left or very right of the visualisation. This removes the
  impression that the taxonomy appears 'cut-off' and incomplete either
  side.
- Remove the unnecessarily long border above or below the taxon in focus
  when there is only one parent or child node.

![screen_shot_2016-10-28_at_11_19_51](https://cloud.githubusercontent.com/assets/519250/19809150/ee1e8276-9d1f-11e6-84a7-78c29394fd40.png)

---

![screen shot 2016-10-28 at 11 25 44](https://cloud.githubusercontent.com/assets/519250/19809152/f20f1760-9d1f-11e6-8345-1f60604407f0.png)
