### PR TITLE
[DO NOT MERGE] Use internal name in taxonomy visualisation

### DIFF
--- a/app/models/expanded_taxonomy.rb
+++ b/app/models/expanded_taxonomy.rb
@@ -105,6 +105,6 @@ private
   end
 
   def tree_node_based_on(content_item)
-    TreeNode.new(title: content_item["title"], content_id: content_item["content_id"])
+    TreeNode.new(title: content_item["details"]["internal_name"], content_id: content_item["content_id"])
   end
 end


### PR DESCRIPTION
For consistency with the taxons index page, use the internal name field
when displaying a taxonomy visualisation.

Needs https://github.com/alphagov/publishing-api/commit/93917e6993fa64bdf7a1479d0a9191ea908ad0bd deployed first.