### PR TITLE
Limit the number of fields from get_content_items

### DIFF
--- a/app/services/bulk_tagging/search.rb
+++ b/app/services/bulk_tagging/search.rb
@@ -26,7 +26,8 @@ module BulkTagging
       Services.publishing_api.get_content_items(
         document_type: document_type,
         page: page,
-        q: query
+        q: query,
+        fields: [:content_id, :document_type, :title, :base_path]
       )
     end
   end

--- a/spec/features/bulk_tagging_spec.rb
+++ b/spec/features/bulk_tagging_spec.rb
@@ -46,36 +46,30 @@ RSpec.feature "Bulk tagging", type: :feature do
       document_type: "document_collection",
     }
 
-    publishing_api_has_content(
+    publishing_api_has_content_items(
       [document_collection],
-      document_type: BulkTagging::Search.default_document_types,
-      page: 1,
       q: "Tax"
     )
 
     publishing_api_has_item(document_collection)
 
-    publishing_api_has_content(
+    publishing_api_has_content_items(
       [{
         content_id: "topic-id",
         title: "A Topic",
         base_path: "/a-topic",
         document_type: "topic",
       }],
-      document_type: BulkTagging::Search.default_document_types,
-      page: 1,
       q: "topic"
     )
 
-    publishing_api_has_content(
+    publishing_api_has_content_items(
       [{
         content_id: "browse-page-id",
         title: "A Mainstream Browse Page",
         base_path: "/a-maintstream-browse-page",
         document_type: "mainstream_browse_page",
       }],
-      document_type: BulkTagging::Search.default_document_types,
-      page: 1,
       q: "browse"
     )
 

--- a/spec/services/bulk_tagging/search_spec.rb
+++ b/spec/services/bulk_tagging/search_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe BulkTagging::Search do
       [basic_content_item('A content item')],
       q: 'tax',
       page: 1,
-      document_type: 'taxon'
+      document_type: 'taxon',
+      fields: [:content_id, :document_type, :title, :base_path]
     )
   end
 

--- a/spec/support/publishing_api_helper.rb
+++ b/spec/support/publishing_api_helper.rb
@@ -1,4 +1,18 @@
 module PublishingApiHelper
+  def publishing_api_has_content_items(items, options = {})
+    default_options = {
+      document_type: BulkTagging::Search.default_document_types,
+      page: 1,
+      q: '',
+      fields: [:content_id, :document_type, :title, :base_path]
+    }
+
+    publishing_api_has_content(
+      items,
+      default_options.merge(options)
+    )
+  end
+
   def publishing_api_has_taxons(taxons, options = {})
     default_options = {
       document_type: "taxon",


### PR DESCRIPTION
We have seen quite a few timeouts in integration when searching for
content items. That's partly due to the fact that we were asking for all
fields.

This change aims at speeding up the Bulk Tag queries so that we avoid
getting timeouts.