### PR TITLE
Fix progress bar styling

### DIFF
--- a/app/views/application/_tag_update_progress_bar.html.erb
+++ b/app/views/application/_tag_update_progress_bar.html.erb
@@ -2,7 +2,7 @@
 <div class="js-tag-update-progress" data-progress-path="<%= progress_path %>">
 
   <div class="progress">
-    <div class="progress-bar <%= 'progress-bar-striped active' if percentage_complete == 100 %>"
+    <div class="progress-bar <%= 'progress-bar-striped active' unless percentage_complete == 100 %>"
       role="progressbar"
       aria-valuenow="<%= completed_tag_mappings %>"
       aria-valuemin="0"


### PR DESCRIPTION
The progress bar should be styled with animated diagonal lines while in
progress and a solid color when finished. This commits fixes a previous
code change that swapped this behaviour.