### PR TITLE
Rename all instances of "Tag Search" to "Bulk Tag"

### DIFF
--- a/app/controllers/bulk_tags_controller.rb
+++ b/app/controllers/bulk_tags_controller.rb
@@ -1,4 +1,4 @@
-class TagSearchesController < ApplicationController
+class BulkTagsController < ApplicationController
   def new
     render :new, locals: {
       search_results: EmptySearchResponse.new,
@@ -21,10 +21,10 @@ private
   end
 
   def query
-    params[:tag_search][:query]
+    search_params[:query]
   end
 
   def search_params
-    params.require(:tag_search).permit(:query)
+    params.require(:bulk_tag).permit(:query)
   end
 end

--- a/app/controllers/tag_migrations_controller.rb
+++ b/app/controllers/tag_migrations_controller.rb
@@ -5,7 +5,7 @@ class TagMigrationsController < ApplicationController
 
   def new
     unless params[:source_content_id]
-      redirect_to new_tag_search_path
+      redirect_to new_bulk_tag_path
       return
     end
 

--- a/app/views/bulk_tags/_search_results.html.erb
+++ b/app/views/bulk_tags/_search_results.html.erb
@@ -7,7 +7,7 @@
           <small><%= tag.document_type.humanize %></small>
         </td>
         <td>
-          <%= link_to t("tag_search.bulk_tag"), new_tag_migration_path(source_content_id: tag.content_id) %>
+          <%= link_to t("bulk_tag.view_tagged_pages"), new_tag_migration_path(source_content_id: tag.content_id) %>
         </td>
       </tr>
     <% end %>

--- a/app/views/bulk_tags/new.html.erb
+++ b/app/views/bulk_tags/new.html.erb
@@ -1,4 +1,4 @@
-<%= display_header title: t('bulk_tagging.title'), breadcrumbs: [t('navigation.tag_search')] do %>
+<%= display_header title: t('bulk_tagging.title'), breadcrumbs: [t('navigation.bulk_tag')] do %>
   <%= link_to t('navigation.tag_importer'), tagging_spreadsheets_path, class: 'btn btn-default' %>
   <%= link_to t('navigation.tag_migration'), tag_migrations_path, class: 'btn btn-default' %>
 <% end %>
@@ -8,13 +8,13 @@
   bulk tag its content.
 </div>
 
-<%= simple_form_for :tag_search, url: results_of_tag_search_path, method: :get do |f| %>
+<%= simple_form_for :bulk_tag, url: search_results_for_bulk_tag_path, method: :get do |f| %>
   <div class="form-group">
     <%= f.input :query, label: false,
       input_html: { class: 'form-control', value: query }
     %>
 
-    <%= f.submit t('tag_search.search_button'), class: "btn btn-md btn-success" %>
+    <%= f.submit t('bulk_tag.search_button'), class: "btn btn-md btn-success" %>
   </div>
 <% end %>
 

--- a/app/views/copy_taxons/index.html.erb
+++ b/app/views/copy_taxons/index.html.erb
@@ -1,5 +1,5 @@
 <%= display_header title: 'Copy Taxons', breadcrumbs: [
-  link_to(I18n.t('navigation.tag_search'), new_tag_search_path),
+  link_to(I18n.t('navigation.bulk_tag'), new_bulk_tag_path),
   link_to(I18n.t('navigation.tag_importer'), tagging_spreadsheets_path),
   I18n.t('views.taxons.copy_taxon')
   ] %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,7 +10,7 @@
   </li>
 
   <li class='<%= active_navigation_item.in?(%w[tag_searches tag_migrations]) ? 'active' : nil %>'>
-    <%= link_to t('navigation.tag_search'), new_tag_search_path %>
+    <%= link_to t('navigation.bulk_tag'), new_bulk_tag_path %>
   </li>
 
   <li class='<%= active_navigation_item.in?(%w[taxons]) ? 'active' : nil %>'>

--- a/app/views/tag_migrations/index.html.erb
+++ b/app/views/tag_migrations/index.html.erb
@@ -1,5 +1,5 @@
 <%= display_header title: t('navigation.tag_migration'), breadcrumbs: [
-  link_to(t('navigation.tag_search'), new_tag_search_path), t('navigation.tag_migration')] %>
+  link_to(t('navigation.bulk_tag'), new_bulk_tag_path), t('navigation.tag_migration')] %>
 
 <% if tag_migrations.any? %>
   <%= render 'bulk_tagging_history_table', tag_migrations: tag_migrations %>

--- a/app/views/tag_migrations/new.html.erb
+++ b/app/views/tag_migrations/new.html.erb
@@ -3,7 +3,7 @@
            taxon: source_content_item.title,
            type: source_content_item.document_type.humanize.downcase),
   breadcrumbs: [
-    link_to(t('navigation.tag_search'), new_tag_search_path),
+    link_to(t('navigation.bulk_tag'), new_bulk_tag_path),
     "Retag content from '#{source_content_item.title}'"
   ]
 ) %>

--- a/app/views/tag_migrations/show.html.erb
+++ b/app/views/tag_migrations/show.html.erb
@@ -2,7 +2,7 @@
 
 <%= display_header title: t('views.tag_migrations.show.title', taxon: source_content_item.title, type: source_content_item.document_type.humanize.downcase),
     breadcrumbs: [
-    link_to(t('navigation.tag_search'), new_tag_search_path),
+    link_to(t('navigation.bulk_tag'), new_bulk_tag_path),
     link_to(t('navigation.tag_migration'), tag_migrations_path),
     tag_migration.source_description ] do %>
 <% end %>

--- a/app/views/tagging_spreadsheets/index.html.erb
+++ b/app/views/tagging_spreadsheets/index.html.erb
@@ -1,7 +1,7 @@
 <%= display_header(
       title: t('navigation.tag_importer'),
       breadcrumbs: [
-        link_to(I18n.t('navigation.tag_search'), new_tag_search_path),
+        link_to(I18n.t('navigation.bulk_tag'), new_bulk_tag_path),
         t('navigation.tag_importer')
       ]
     ) do %>

--- a/app/views/tagging_spreadsheets/new.html.erb
+++ b/app/views/tagging_spreadsheets/new.html.erb
@@ -1,6 +1,6 @@
 <%= display_header title: I18n.t('tag_import.upload_sheet'),
   breadcrumbs: [
-    link_to(I18n.t('navigation.tag_search'), new_tag_search_path),
+    link_to(I18n.t('navigation.bulk_tag'), new_bulk_tag_path),
     link_to(I18n.t('navigation.tag_importer'), tagging_spreadsheets_path),
     I18n.t('tag_import.upload_sheet')
   ] %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,7 +4,7 @@ en:
     tagging_title: Which page do you want to tag?
     tagging_label: Enter the URL or path of a GOV.UK page
     taxons: 'Edit taxonomy'
-    tag_search: 'Bulk tag'
+    bulk_tag: 'Bulk tag'
     tag_migration: 'Bulk tag history'
     tag_importer: 'Bulk tag by upload'
   errors:
@@ -19,9 +19,9 @@ en:
   taggings:
     update_tags: Update tagging
     search: Edit tagging
-  tag_search:
+  bulk_tag:
     search_button: "Search"
-    bulk_tag: "View tagged pages"
+    view_tagged_pages: "View tagged pages"
   tag_import:
     upload_sheet: Upload spreadsheet
     upload: Upload

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,8 +28,8 @@ Rails.application.routes.draw do
     get  'progress'
   end
 
-  resource :tag_search, only: [:new] do
-    get 'results' => 'tag_searches#results', as: "results_of"
+  resource :bulk_tag, only: [:new] do
+    get 'results' => 'bulk_tags#results', as: "search_results_for"
   end
 
   get '/healthcheck', to: proc { [200, {}, ['OK']] }

--- a/spec/features/bulk_tagging_spec.rb
+++ b/spec/features/bulk_tagging_spec.rb
@@ -100,18 +100,18 @@ RSpec.feature "Bulk tagging", type: :feature do
   end
 
   def when_i_search_for_the_collection
-    visit new_tag_search_path
+    visit new_bulk_tag_path
 
-    fill_in "tag_search_query", with: "topic"
-    click_button I18n.t('tag_search.search_button')
+    fill_in "bulk_tag_query", with: "topic"
+    click_button I18n.t('bulk_tag.search_button')
     expect(page).to have_text("A Topic")
 
-    fill_in "tag_search_query", with: "browse"
-    click_button I18n.t('tag_search.search_button')
+    fill_in "bulk_tag_query", with: "browse"
+    click_button I18n.t('bulk_tag.search_button')
     expect(page).to have_text("A Mainstream Browse Page")
 
-    fill_in "tag_search_query", with: "Tax"
-    click_button I18n.t('tag_search.search_button')
+    fill_in "bulk_tag_query", with: "Tax"
+    click_button I18n.t('bulk_tag.search_button')
     expect(page).to have_text("Tax documents")
     expect(page).to have_text('Document collection')
     expect(page).to have_link(
@@ -122,7 +122,7 @@ RSpec.feature "Bulk tagging", type: :feature do
 
   def then_i_can_see_the_content_items_in_this_collection
     within "main" do
-      click_link I18n.t("tag_search.bulk_tag")
+      click_link I18n.t("bulk_tag.view_tagged_pages")
     end
 
     within "form.new_tag_migration" do

--- a/spec/features/tag_importer_spec.rb
+++ b/spec/features/tag_importer_spec.rb
@@ -88,7 +88,7 @@ RSpec.feature "Tag importer", type: :feature do
 
   def when_i_provide_the_public_uri_of_this_spreadsheet
     visit root_path
-    click_link I18n.t('navigation.tag_search')
+    click_link I18n.t('navigation.bulk_tag')
 
     click_link I18n.t("navigation.tag_importer")
     click_link I18n.t('tag_import.upload_sheet')
@@ -241,7 +241,7 @@ RSpec.feature "Tag importer", type: :feature do
     state = tagging_spreadsheet.state.humanize
 
     visit root_path
-    click_link I18n.t('navigation.tag_search')
+    click_link I18n.t('navigation.bulk_tag')
 
     click_link I18n.t("navigation.tag_importer")
     row = first('table tbody tr')


### PR DESCRIPTION
"Bulk Tag" is used for the UI, so this commit ensures that Bulk Tag is
always used in the code too.

Part of [this Trello card.](https://trello.com/c/Erx6NIwe/151-rename-code-in-content-tagger)