### PR TITLE
Add taxon base paths to expanded taxonomy

### DIFF
--- a/app/models/expanded_taxonomy.rb
+++ b/app/models/expanded_taxonomy.rb
@@ -116,7 +116,7 @@ private
     taxon = Taxon.new(
       content_id: content_item.fetch('content_id'),
       title: content_item.fetch('title'),
-      base_path: "", # client code isn't expected to require this at present
+      base_path: content_item.fetch('base_path'),
       internal_name: content_item.fetch('details').fetch('internal_name'),
     )
     TreeNode.new(


### PR DESCRIPTION
These weren't needed initially by the content-tagger frontend, but are
useful when debugging on the console.