### PR TITLE
Make basepath visible

### DIFF
--- a/app/views/taxons/_form_fields.html.erb
+++ b/app/views/taxons/_form_fields.html.erb
@@ -1,3 +1,7 @@
+<%= f.input :base_path, input_html: { class: 'form-control' },
+  label: I18n.t('views.taxons.base_path'),
+  :readonly => true %>
+
 <%= f.input :internal_name, input_html: { class: 'form-control' },
   label: I18n.t('views.taxons.internal_name'),
   hint: I18n.t('views.taxons.internal_name_hint') %>

--- a/app/views/taxons/edit.html.erb
+++ b/app/views/taxons/edit.html.erb
@@ -3,7 +3,6 @@
 
 <%= simple_form_for taxon, url: taxon_path(taxon.content_id), method: :patch do |f| %>
   <%= f.hidden_field :content_id, value: taxon.content_id %>
-  <%= f.hidden_field :base_path, value: taxon.base_path %>
 
   <%= render partial: 'form_fields', locals: { taxons_for_select: taxons_for_select, f: f} %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -75,6 +75,7 @@ en:
       internal_name: 'Internal taxon name'
       internal_name_hint: 'Displayed in Content Tagger'
       external_name: 'External taxon name'
+      base_path: 'Base Path'
       displayed_on_govuk: 'Displayed on GOV.UK'
   controllers:
     bulk_taggings:


### PR DESCRIPTION
Make base path visible read only field in content tagger edit page.

Before:

<img width="1171" alt="screen shot 2016-11-29 at 17 07 05" src="https://cloud.githubusercontent.com/assets/11633362/20720292/82a2e76c-b656-11e6-86f7-35c1eb9e0424.png">

After:

<img width="1166" alt="screen shot 2016-11-29 at 17 07 27" src="https://cloud.githubusercontent.com/assets/11633362/20720297/88805142-b656-11e6-8dd7-f0e263c5b276.png">
