### PR TITLE
Make basepath visible

### DIFF
--- a/app/views/taxons/edit.html.erb
+++ b/app/views/taxons/edit.html.erb
@@ -3,7 +3,9 @@
 
 <%= simple_form_for taxon, url: taxon_path(taxon.content_id), method: :patch do |f| %>
   <%= f.hidden_field :content_id, value: taxon.content_id %>
-  <%= f.hidden_field :base_path, value: taxon.base_path %>
+  <%= f.input :base_path, input_html: { class: 'form-control' },
+  	label: I18n.t('views.taxons.base_path'),
+  	:readonly => true %>
 
   <%= render partial: 'form_fields', locals: { taxons_for_select: taxons_for_select, f: f} %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -75,6 +75,7 @@ en:
       internal_name: 'Internal taxon name'
       internal_name_hint: 'Displayed in Content Tagger'
       external_name: 'External taxon name'
+      base_path: 'Base Path'
       displayed_on_govuk: 'Displayed on GOV.UK'
   controllers:
     bulk_taggings:


### PR DESCRIPTION
Make base path visible read only field on editing page.

Before:

<img width="1171" alt="screen shot 2016-11-29 at 17 07 05" src="https://cloud.githubusercontent.com/assets/11633362/20722082/2e8470cc-b65d-11e6-9398-7cdaaf647241.png">

After:

<img width="1166" alt="screen shot 2016-11-29 at 17 07 27" src="https://cloud.githubusercontent.com/assets/11633362/20722089/3cb73706-b65d-11e6-9641-dab95b7b4dce.png">
