### PR TITLE
Fix 'addEventListener' used before it was defined

### DIFF
--- a/app/assets/javascripts/select-all.js
+++ b/app/assets/javascripts/select-all.js
@@ -5,8 +5,6 @@
     var that = this;
 
     that.start = function(element) {
-      addEventListener();
-
       function addEventListener() {
         var selectAll = element.find('#select_all');
         if (selectAll != undefined) {
@@ -17,6 +15,8 @@
           });
         }
       }
+
+      addEventListener();
     }
   };
 })(window.GOVUKAdmin.Modules);


### PR DESCRIPTION
In JavaScript, prior to ES6, variable and function declarations are hoisted to the top of a scope,
so it's possible to use identifiers before their formal declarations in code.

This can be confusing and some believe it is best to always declare variables and functions before using them.

Source: http://eslint.org/docs/rules/no-use-before-define