### PR TITLE
Render 404 page for invalid taxons

### DIFF
--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -42,6 +42,8 @@ class TaxonsController < ApplicationController
       tagged: tagged,
       taxonomy_tree: taxonomy_tree,
     }
+  rescue Taxonomy::BuildTaxon::TaxonNotFoundError
+    render "taxon_not_found", status: 404
   end
 
   def edit

--- a/app/services/taxonomy/build_taxon.rb
+++ b/app/services/taxonomy/build_taxon.rb
@@ -2,6 +2,8 @@ module Taxonomy
   class BuildTaxon
     attr_reader :content_id
 
+    class TaxonNotFoundError < StandardError; end
+
     def initialize(content_id:)
       @content_id = content_id
     end
@@ -30,7 +32,9 @@ module Taxonomy
     end
 
     def content_item
-      @content_item ||= Services.publishing_api.get_content(content_id)
+      @content_item ||= Services.publishing_api.get_content!(content_id)
+    rescue GdsApi::HTTPNotFound => e
+      raise(TaxonNotFoundError, e.message)
     end
 
     def links

--- a/app/views/taxons/taxon_not_found.html.erb
+++ b/app/views/taxons/taxon_not_found.html.erb
@@ -1,0 +1,5 @@
+<%= display_header title: "Page not found", breadcrumbs: [t('navigation.taxons')] %>
+
+<p class='lead'>
+  Sorry, that taxon wasn't found. <%= link_to "Try searching again", taxons_path %>.
+</p>

--- a/spec/controllers/taxons_controller_spec.rb
+++ b/spec/controllers/taxons_controller_spec.rb
@@ -15,6 +15,17 @@ RSpec.describe TaxonsController, type: :controller do
     end
   end
 
+  describe "#show" do
+    it "renders 404 for unknown taxons" do
+      stub_request(:get, "https://publishing-api.test.gov.uk/v2/content/does-not-exist")
+        .to_return(status: 404)
+
+      get :show, id: "does-not-exist"
+
+      expect(response.code).to eql "404"
+    end
+  end
+
   describe "#destroy" do
     it "sends a request to Publishing API to mark the taxon as 'gone'" do
       taxon = { title: "foo", base_path: "/foo", content_id: SecureRandom.uuid }

--- a/spec/services/taxonomy/build_taxon_spec.rb
+++ b/spec/services/taxonomy/build_taxon_spec.rb
@@ -96,5 +96,17 @@ RSpec.describe Taxonomy::BuildTaxon do
         expect(taxon.parent_taxons).to eq(parent_taxons)
       end
     end
+
+    context 'with an invalid taxon' do
+      before do
+        publishing_api_does_not_have_item(content_id)
+      end
+
+      it 'raises an exception' do
+        expect { taxon }.to raise_error(
+          Taxonomy::BuildTaxon::TaxonNotFoundError
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
Currently, attempting to access an invalid taxon displays an application error. This commit adds exception handling to catch such requests and display a 404 error page.

Trello: https://trello.com/c/3oEY4cUZ/354-fix-crash-in-content-tagger