### PR TITLE
Fix style of taxon help text

### DIFF
--- a/app/views/taggings/_form_for_taxons.html.erb
+++ b/app/views/taggings/_form_for_taxons.html.erb
@@ -5,6 +5,6 @@
     placeholder: "Choose one...",
     input_html: { multiple: true, class: :select2 } %>
 
-<p class"explain">
+<p class="explain">
   This taxonomy is currently being developed by the Finding Things team.
 </p>


### PR DESCRIPTION
Help text should be in grey, which is controlled by the 'explain' CSS class. This wasn't working because of a typo.

Before:
<img width="1165" alt="screen shot 2016-12-13 at 10 46 32" src="https://cloud.githubusercontent.com/assets/87579/21137451/7c620650-c121-11e6-9afa-1bd947a6fceb.png">

After:
<img width="689" alt="screen shot 2016-12-13 at 10 45 49" src="https://cloud.githubusercontent.com/assets/87579/21137457/8214d4b0-c121-11e6-8a66-49b665b4a243.png">

Noticed while working on https://trello.com/c/D6TywAem/294-replace-panopticon-s-related-artefact-functionality-with-content-tagger
Paired with @suzannehamilton 