### PR TITLE
Correct ordering of tag types on the tagging form

### DIFF
--- a/app/models/content_item_expanded_links.rb
+++ b/app/models/content_item_expanded_links.rb
@@ -2,7 +2,7 @@ class ContentItemExpandedLinks
   include ActiveModel::Model
   attr_accessor :content_id, :previous_version
 
-  TAG_TYPES = %i(topics mainstream_browse_pages organisations taxons parent).freeze
+  TAG_TYPES = %i(taxons mainstream_browse_pages parent topics organisations).freeze
   attr_accessor(*TAG_TYPES)
 
   # Find the links for a content item by its content ID

--- a/spec/features/tag_a_page_spec.rb
+++ b/spec/features/tag_a_page_spec.rb
@@ -22,11 +22,11 @@ RSpec.describe "Tagging content", type: :feature do
     and_i_submit_the_form
 
     then_the_publishing_api_is_sent(
-      topics: ["e1d6b771-a692-4812-a4e7-7562214286ef", example_topic['content_id']],
-      mainstream_browse_pages: [],
-      organisations: [],
       taxons: [],
+      mainstream_browse_pages: [],
       parent: [],
+      topics: ["e1d6b771-a692-4812-a4e7-7562214286ef", example_topic['content_id']],
+      organisations: [],
     )
   end
 
@@ -38,11 +38,11 @@ RSpec.describe "Tagging content", type: :feature do
     and_i_submit_the_form
 
     then_the_publishing_api_is_sent(
-      topics: ["e1d6b771-a692-4812-a4e7-7562214286ef"],
-      mainstream_browse_pages: [],
-      organisations: [],
       taxons: [],
+      mainstream_browse_pages: [],
       parent: [],
+      topics: ["e1d6b771-a692-4812-a4e7-7562214286ef"],
+      organisations: [],
     )
   end
 


### PR DESCRIPTION
In https://github.com/alphagov/content-tagger/pull/241 we accidentally reordered the fields. This changes them back to the ordering used on production.

The ordering reflects how much we expect the different tag types
to be used.