### PR TITLE
[WIP]  Proof of concept of a way to manage ordered tags in the tagging form

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem 'airbrake', '~> 4.3.1'
 gem 'sass-rails', '~> 5.0'
 gem 'uglifier', '>= 1.3.0'
 gem 'select2-rails', '~> 3.5.9'
+gem 'jquery-ui-rails', '6.0.1'
 
 gem 'govuk_sidekiq', '~> 0.0.4'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,6 +134,8 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    jquery-ui-rails (6.0.1)
+      railties (>= 3.2.16)
     json (1.8.3)
     json-schema (2.5.2)
       addressable (~> 2.3.8)
@@ -362,6 +364,7 @@ DEPENDENCIES
   govuk_admin_template (~> 4.4)
   govuk_sidekiq (~> 0.0.4)
   headless
+  jquery-ui-rails (= 6.0.1)
   kaminari (~> 0.17)
   logstasher (= 0.6.2)
   pg

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,6 +1,7 @@
 //= require_tree .
 //= require select2
 //= require_self
+//= require jquery-ui
 
 $(document).ready(function() {
   $(".select2").select2({ allowClear: true });

--- a/app/assets/javascripts/views/taggings_show.js
+++ b/app/assets/javascripts/views/taggings_show.js
@@ -1,0 +1,5 @@
+$(document).ready(function() {
+  "use strict";
+
+  $(".sortable-inputs").sortable();
+});

--- a/app/assets/javascripts/views/taggings_show.js
+++ b/app/assets/javascripts/views/taggings_show.js
@@ -1,5 +1,51 @@
 $(document).ready(function() {
   "use strict";
 
+  $(".sortable-inputs .title").show();
+  $(".sortable-inputs .value").hide();
+  $(".add-sortable-input").show();
   $(".sortable-inputs").sortable();
+
+  $("#ordered_related_items").on('click', ".select2-search-choice-close", function() {
+    $(this).parents("li").remove();
+    return false;
+  });
+
+  // Prevent default behaviour of submitting form on enter, when adding
+  // a new related link.
+  // TODO: don't make this part of the main form in the first place
+  $('#related_item_new_base_path').on('keypress', function() {
+    if(event.keyCode === 13) {
+      $("#lookup_base_path_button").click();
+      return false;
+    } else {
+      return true;
+    }
+  });
+
+  $("#lookup_base_path_button").on('click', function() {
+    var basePathInput = $("#related_item_new_base_path");
+    var basePath = basePathInput.val();
+    if (basePath !== "") {
+      $.get({
+        url: "/taggings/lookup/" + encodeURIComponent(basePath.replace(/^\//, "")),
+        dataType: "json"
+      }).done(function(lookup, textStatus, jqXHR) {
+        if (jqXHR.status === 200) {
+          // TODO: use a template instead of this (share template between front and backend)
+          var existing = $("#ordered_related_items li");
+          var lastTag = existing.first();
+          var newTag = lastTag.clone().appendTo("#ordered_related_items ul");
+          newTag.find("input").attr("value", lookup.base_path);
+          newTag.find(".js-artefact-name").text(lookup.title).attr("href", "https://www.gov.uk" + lookup.base_path);
+
+          basePathInput.val("");
+        } else {
+          // TODO: display errors
+        }
+      }).fail(function() {
+        // TODO: display errors
+      });
+    }
+  });
 });

--- a/app/forms/tagging_update_form.rb
+++ b/app/forms/tagging_update_form.rb
@@ -4,6 +4,13 @@ class TaggingUpdateForm
 
   attr_accessor(*ContentItemExpandedLinks::TAG_TYPES)
 
+  # The number of extra empty form fields to add to a link section when the link
+  # section shows an individual form input for each value. This allows users to
+  # append new links to the end of the existing list.
+  EXTRA_TEXT_FIELD_COUNT = 5
+
+  validate :related_item_paths_should_be_valid
+
   # Return a new LinkUpdate object with topics, mainstream_browse_pages,
   # organisations and content_item set.
   def self.from_content_item_links(content_item_links)
@@ -14,26 +21,60 @@ class TaggingUpdateForm
       organisations: extract_content_ids(content_item_links.organisations),
       mainstream_browse_pages: extract_content_ids(content_item_links.mainstream_browse_pages),
       parent: extract_content_ids(content_item_links.parent),
-      taxons: extract_content_ids(content_item_links.taxons)
+      taxons: extract_content_ids(content_item_links.taxons),
+      ordered_related_items: pad_with_empty_items(extract_base_paths(content_item_links.ordered_related_items))
     )
   end
 
   def links_payload(tag_types)
     tag_types.each_with_object({}) do |tag_type, payload|
-      content_ids = send(tag_type)
-      payload[tag_type] = clean_content_ids(content_ids)
+      field_value = send(tag_type)
+
+      payload[tag_type] =
+        if tag_type == :ordered_related_items
+          related_content_items.map(&:content_id)
+        else
+          clean_input_array(field_value)
+        end
     end
+  end
+
+  def related_content_items
+    @related_content_items ||= BasePathLookup.find_by_base_paths(
+      clean_input_array(ordered_related_items)
+    )
   end
 
   def self.extract_content_ids(links_hashes)
     links_hashes.map { |links_hash| links_hash["content_id"] }
   end
 
+  def self.extract_base_paths(links_hashes)
+    unless links_hashes.nil?
+      links_hashes.map { |links_hash| links_hash["base_path"] }
+    end
+  end
+
+  def self.pad_with_empty_items(items)
+    (items || []) + [""] * EXTRA_TEXT_FIELD_COUNT
+  end
+
+  private_class_method(:extract_content_ids, :extract_base_paths, :pad_with_empty_items)
+
 private
 
-  private_class_method :extract_content_ids
-
-  def clean_content_ids(select_form_input)
+  def clean_input_array(select_form_input)
     Array(select_form_input).select(&:present?)
+  end
+
+  def related_item_paths_should_be_valid
+    unless ordered_related_items.nil?
+      related_content_items.each do |ri|
+        if ri.content_id.nil?
+          index = ordered_related_items.index(ri.base_path)
+          errors[:"ordered_related_items[#{index}]"] << "Could not find content item with this URL or path"
+        end
+      end
+    end
   end
 end

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -1,4 +1,5 @@
 class ContentItem
+
   attr_reader :content_id, :title, :base_path, :publishing_app, :document_type
 
   def initialize(data)

--- a/app/models/content_item_expanded_links.rb
+++ b/app/models/content_item_expanded_links.rb
@@ -2,7 +2,8 @@ class ContentItemExpandedLinks
   include ActiveModel::Model
   attr_accessor :content_id, :previous_version
 
-  TAG_TYPES = %i(taxons mainstream_browse_pages parent topics organisations).freeze
+  TAG_TYPES = %i(taxons ordered_related_items mainstream_browse_pages parent topics organisations).freeze
+
   attr_accessor(*TAG_TYPES)
 
   # Find the links for a content item by its content ID
@@ -19,6 +20,7 @@ class ContentItemExpandedLinks
       mainstream_browse_pages: links.fetch('mainstream_browse_pages', []),
       parent: links.fetch('parent', []),
       taxons: links.fetch('taxons', []),
+      ordered_related_items: links.fetch('ordered_related_items', [])
     )
   end
 end

--- a/app/services/base_path_lookup.rb
+++ b/app/services/base_path_lookup.rb
@@ -1,0 +1,14 @@
+class BasePathLookup
+  RelatedContentItem = Struct.new("RelatedContentItem", :content_id, :base_path)
+
+  def self.find_by_base_paths(base_paths_or_urls)
+    return [] if base_paths_or_urls.empty?
+
+    base_paths = base_paths_or_urls.map { |ri| URI.parse(ri).path }
+    content_id_by_path = Services.publishing_api.lookup_content_ids(
+      base_paths: base_paths
+    )
+
+    base_paths.map { |path| RelatedContentItem.new(content_id_by_path[path], path) }
+  end
+end

--- a/app/services/base_path_lookup.rb
+++ b/app/services/base_path_lookup.rb
@@ -1,6 +1,10 @@
 class BasePathLookup
   RelatedContentItem = Struct.new("RelatedContentItem", :content_id, :base_path)
 
+  def self.find_by_base_path(base_path)
+    self.find_by_base_paths([base_path]).first
+  end
+
   def self.find_by_base_paths(base_paths_or_urls)
     return [] if base_paths_or_urls.empty?
 

--- a/app/views/taggings/_form_for_ordered_related_items.html.erb
+++ b/app/views/taggings/_form_for_ordered_related_items.html.erb
@@ -5,13 +5,21 @@
   page, such as /pay-vat or /benefit-cap-calculator
 </p>
 
-<% @tagging_update.ordered_related_items.each_with_index do |related_item, index| %>
-  <% link_has_error = !@tagging_update.errors[:"ordered_related_items[#{index}]"].empty? %>
+<div class="sortable-inputs">
 
-  <div class="form-group related-item <%= link_has_error ? 'has-error' : '' %>">
-    <%= text_field_tag "tagging_update_form[ordered_related_items][]", related_item, class: ["form-control", "related-item-path"] %>
-    <% @tagging_update.errors[:"ordered_related_items[#{index}]"].each do |error| %>
-      <span class="help-block"><%= error %></span>
-    <% end %>
+</div>
+
+<fieldset class="sortable-inputs">
+  <% @tagging_update.ordered_related_items.each_with_index do |related_item, index| %>
+    <% link_has_error = !@tagging_update.errors[:"ordered_related_items[#{index}]"].empty? %>
+    <div class="well" style="padding:13px;">
+    <div class="form-group related-item <%= link_has_error ? 'has-error' : '' %>">
+      <%= text_field_tag "tagging_update_form[ordered_related_items][]", related_item, class: ["form-control", "related-item-path"], style: "display:inline-block;vertical-align:middle;width:95%" %>
+      <% @tagging_update.errors[:"ordered_related_items[#{index}]"].each do |error| %>
+        <span class="help-block"><%= error %></span>
+      <% end %>
+      <span class="glyphicon glyphicon-resize-vertical" aria-hidden="true" style="padding-left:10px;font-size:20px;vertical-align:middle;"></span>
+    </div>
   </div>
-<% end %>
+  <% end %>
+</fieldset>

--- a/app/views/taggings/_form_for_ordered_related_items.html.erb
+++ b/app/views/taggings/_form_for_ordered_related_items.html.erb
@@ -1,0 +1,17 @@
+<h3>Related content items</h3>
+
+<p class="explain">
+  Related items are displayed in the sidebar. Enter the URL or path of a GOV.UK
+  page, such as /pay-vat or /benefit-cap-calculator
+</p>
+
+<% @tagging_update.ordered_related_items.each_with_index do |related_item, index| %>
+  <% link_has_error = !@tagging_update.errors[:"ordered_related_items[#{index}]"].empty? %>
+
+  <div class="form-group related-item <%= link_has_error ? 'has-error' : '' %>">
+    <%= text_field_tag "tagging_update_form[ordered_related_items][]", related_item, class: ["form-control", "related-item-path"] %>
+    <% @tagging_update.errors[:"ordered_related_items[#{index}]"].each do |error| %>
+      <span class="help-block"><%= error %></span>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/taggings/_form_for_ordered_related_items.html.erb
+++ b/app/views/taggings/_form_for_ordered_related_items.html.erb
@@ -1,25 +1,35 @@
 <h3>Related content items</h3>
 
-<p class="explain">
-  Related items are displayed in the sidebar. Enter the URL or path of a GOV.UK
-  page, such as /pay-vat or /benefit-cap-calculator
-</p>
-
-<div class="sortable-inputs">
-
-</div>
-
-<fieldset class="sortable-inputs">
-  <% @tagging_update.ordered_related_items.each_with_index do |related_item, index| %>
-    <% link_has_error = !@tagging_update.errors[:"ordered_related_items[#{index}]"].empty? %>
-    <div class="well" style="padding:13px;">
-    <div class="form-group related-item <%= link_has_error ? 'has-error' : '' %>">
-      <%= text_field_tag "tagging_update_form[ordered_related_items][]", related_item, class: ["form-control", "related-item-path"], style: "display:inline-block;vertical-align:middle;width:95%" %>
-      <% @tagging_update.errors[:"ordered_related_items[#{index}]"].each do |error| %>
-        <span class="help-block"><%= error %></span>
-      <% end %>
-      <span class="glyphicon glyphicon-resize-vertical" aria-hidden="true" style="padding-left:10px;font-size:20px;vertical-align:middle;"></span>
-    </div>
+<fieldset id="ordered_related_items" class="select2-container select2-container-multi" style="width:100%">
+  <ul class="select2-choices ui-sortable sortable-inputs" style="background-image:none; margin-bottom:20px;">
+    <% @tagging_update.related_content_items.each_with_index do |related_item, index| %>
+      <% link_has_error = !@tagging_update.errors[:"ordered_related_items[#{index}]"].empty? %>
+      <li style="width:100%;">
+        <% unless related_item.title.blank? %>
+        <div class="title select2-search-choice ui-sortable-handle" style="display:none;">
+          <a href="http://gov.uk<%= related_item.base_path %>" class="js-artefact-name"><%= related_item.title %></a>
+          <a href="#" class="select2-search-choice-close" tabindex="-1"></a>
+          <span class="glyphicon glyphicon-resize-vertical" aria-hidden="true" style="padding-left:10px;vertical-align:middle;float:right"></span>
+        </div>
+        <% end %>
+        <div class="value <%= link_has_error ? 'has-error' : '' %>", style="padding-top:5px; padding-bottom:5px">
+          <%= text_field_tag "tagging_update_form[ordered_related_items][]", related_item.base_path, class: ["form-control", "related-item-path"], style:"margin-left: 10px; width:95%" %>
+          <% @tagging_update.errors[:"ordered_related_items[#{index}]"].each do |error| %>
+            <div class="help-block" style="margin-left:10px"><%= error %></p>
+          <% end %>
+        </div>
+      </li>
+    <% end %>
+  </ul>
+  <div class="input-group add-sortable-input" style="margin-top:-10px; margin-bottom:20px; display:none">
+    <input id="related_item_new_base_path" name="_new_base_path" type="text" class="form-control" placeholder="URL or path">
+    <span class="input-group-btn">
+      <button id="lookup_base_path_button" class="btn btn-default" type="button">Add</button>
+    </span>
   </div>
-  <% end %>
-</fieldset>
+
+  <p class="explain">
+    Related items are displayed in the sidebar. Enter the URL or path of a GOV.UK
+    page, such as /pay-vat or /benefit-cap-calculator
+  </p>
+</div>

--- a/config/blacklisted-tag-types.yml
+++ b/config/blacklisted-tag-types.yml
@@ -51,3 +51,4 @@ test-app-that-can-be-tagged-to-topics-only:
   - mainstream_browse_pages
   - organisations
   - parent
+  - ordered_related_items

--- a/spec/features/tag_a_page_spec.rb
+++ b/spec/features/tag_a_page_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe "Tagging content", type: :feature do
 
     then_the_publishing_api_is_sent(
       taxons: [],
+      ordered_related_items: [],
       mainstream_browse_pages: [],
       parent: [],
       topics: ["e1d6b771-a692-4812-a4e7-7562214286ef", example_topic['content_id']],
@@ -39,6 +40,7 @@ RSpec.describe "Tagging content", type: :feature do
 
     then_the_publishing_api_is_sent(
       taxons: [],
+      ordered_related_items: [],
       mainstream_browse_pages: [],
       parent: [],
       topics: ["e1d6b771-a692-4812-a4e7-7562214286ef"],
@@ -68,6 +70,18 @@ RSpec.describe "Tagging content", type: :feature do
     when_i_type_its_basepath_in_the_url_directly
     then_i_am_on_the_page_for_the_item
     and_the_expected_navigation_link_is_highlighted
+  end
+
+  scenario "User tries to tag a content item with a non-existent related item" do
+    given_there_is_a_content_item_with_expanded_links(topics: [example_topic])
+    given_there_is_related_content_with_matching_base_paths
+
+    when_i_type_its_basepath_in_the_url_directly
+    and_i_add_a_valid_related_content_item_path
+    and_i_add_a_path_which_does_not_match_a_content_item
+    and_i_submit_the_form
+
+    then_i_see_a_highlighted_error_for_the_missing_path
   end
 
   def when_i_visit_the_homepage
@@ -107,6 +121,12 @@ RSpec.describe "Tagging content", type: :feature do
         expanded_links: expanded_links,
         version: 54_321,
       }.to_json)
+  end
+
+  def given_there_is_related_content_with_matching_base_paths
+    stub_request(:post, "https://publishing-api.test.gov.uk/lookup-by-base-path")
+      .with(body: { "base_paths" => ["/pay-vat", "/no-such-path"] })
+      .to_return(body: { "/pay-vat" => "a484eaea-eeb6-48fa-92a7-b67c6cd414f6" }.to_json)
   end
 
   def and_i_submit_the_url_of_the_content_item
@@ -196,6 +216,21 @@ RSpec.describe "Tagging content", type: :feature do
         "/browse/driving/car-tax-discs",
       ]
     )
+  end
+
+  def and_i_add_a_valid_related_content_item_path
+    all(".related-item-path")[0].set("/pay-vat")
+  end
+
+  def and_i_add_a_path_which_does_not_match_a_content_item
+    all(".related-item-path")[1].set("/no-such-path")
+  end
+
+  def then_i_see_a_highlighted_error_for_the_missing_path
+    related_items = all(".related-item")
+
+    expect(related_items[0]["class"]).not_to include("has-error")
+    expect(related_items[1]["class"]).to include("has-error")
   end
 
   def example_topic

--- a/spec/forms/tagging_update_form_spec.rb
+++ b/spec/forms/tagging_update_form_spec.rb
@@ -1,6 +1,56 @@
 require 'rails_helper'
 
 RSpec.describe TaggingUpdateForm do
+  describe '#valid?' do
+    it "is valid if content item has no links" do
+      form = TaggingUpdateForm.new
+
+      expect(form).to be_valid
+    end
+
+    it "is valid if related item paths exist" do
+      form = TaggingUpdateForm.new(
+        ordered_related_items: ["/bank-holidays", "/pay-vat"],
+      )
+
+      stub_request(:post, "https://publishing-api.test.gov.uk/lookup-by-base-path")
+        .with(body: { "base_paths" => ["/bank-holidays", "/pay-vat"] })
+        .to_return(body: {
+          "/bank-holidays" => "58f79dbd-e57f-4ab2-ae96-96df5767d1b2",
+          "/pay-vat" => "a484eaea-eeb6-48fa-92a7-b67c6cd414f6",
+        }.to_json)
+
+      expect(form).to be_valid
+    end
+
+    it "is not valid if related item paths do not exist" do
+      form = TaggingUpdateForm.new(
+        ordered_related_items: ["/no-such-path"],
+      )
+
+      stub_request(:post, "https://publishing-api.test.gov.uk/lookup-by-base-path")
+        .with(body: { "base_paths" => ["/no-such-path"] })
+        .to_return(body: {}.to_json)
+
+      expect(form).to_not be_valid
+    end
+
+    it "is not valid if only some of the paths exist" do
+      form = TaggingUpdateForm.new(
+        ordered_related_items: ["/pay-vat", "/no-such-path", "/bank-holidays"],
+      )
+
+      stub_request(:post, "https://publishing-api.test.gov.uk/lookup-by-base-path")
+        .with(body: { "base_paths" => ["/pay-vat", "/no-such-path", "/bank-holidays"] })
+        .to_return(body: {
+          "/pay-vat" => "a484eaea-eeb6-48fa-92a7-b67c6cd414f6",
+          "/bank-holidays" => "58f79dbd-e57f-4ab2-ae96-96df5767d1b2",
+        }.to_json)
+
+      expect(form).to_not be_valid
+    end
+  end
+
   describe '#links_payload' do
     it 'generates a payload with links' do
       form = TaggingUpdateForm.new(
@@ -9,6 +59,7 @@ RSpec.describe TaggingUpdateForm do
         organisations: [''],
         taxons: [''],
         parent: [''],
+        ordered_related_items: [''],
       )
 
       links_payload = form.links_payload(ContentItemExpandedLinks::TAG_TYPES)
@@ -19,6 +70,7 @@ RSpec.describe TaggingUpdateForm do
         organisations: [],
         taxons: [],
         parent: [],
+        ordered_related_items: [],
       )
     end
 
@@ -37,6 +89,7 @@ RSpec.describe TaggingUpdateForm do
         organisations: [],
         taxons: [],
         parent: [],
+        ordered_related_items: [],
       )
     end
 
@@ -56,6 +109,78 @@ RSpec.describe TaggingUpdateForm do
         organisations: [],
         taxons: [],
         parent: [],
+        ordered_related_items: [],
+      )
+    end
+
+    it "converts base paths of related items into content IDs" do
+      form = TaggingUpdateForm.new(
+        ordered_related_items: ['/bank-holidays', '/pay-vat'],
+      )
+
+      stub_request(:post, "https://publishing-api.test.gov.uk/lookup-by-base-path")
+        .with(body: { "base_paths" => ["/bank-holidays", "/pay-vat"] })
+        .to_return(body: {
+          "/bank-holidays" => "58f79dbd-e57f-4ab2-ae96-96df5767d1b2",
+          "/pay-vat" => "a484eaea-eeb6-48fa-92a7-b67c6cd414f6",
+        }.to_json)
+
+      links_payload = form.links_payload([:ordered_related_items])
+
+      expect(links_payload).to eql(
+        ordered_related_items: [
+          "58f79dbd-e57f-4ab2-ae96-96df5767d1b2",
+          "a484eaea-eeb6-48fa-92a7-b67c6cd414f6",
+        ],
+      )
+    end
+
+    it "converts absolute paths of related items into content IDs" do
+      form = TaggingUpdateForm.new(
+        ordered_related_items: [
+          'https://www.gov.uk/bank-holidays',
+          'https://www-origin.staging.publishing.service.gov.uk/pay-vat',
+        ],
+      )
+
+      stub_request(:post, "https://publishing-api.test.gov.uk/lookup-by-base-path")
+        .with(body: { "base_paths" => ["/bank-holidays", "/pay-vat"] })
+        .to_return(body: {
+          "/bank-holidays" => "58f79dbd-e57f-4ab2-ae96-96df5767d1b2",
+          "/pay-vat" => "a484eaea-eeb6-48fa-92a7-b67c6cd414f6",
+        }.to_json)
+
+      links_payload = form.links_payload([:ordered_related_items])
+
+      expect(links_payload).to eql(
+        ordered_related_items: [
+          "58f79dbd-e57f-4ab2-ae96-96df5767d1b2",
+          "a484eaea-eeb6-48fa-92a7-b67c6cd414f6",
+        ],
+      )
+    end
+
+    it "preserves the order of related content items" do
+      form = TaggingUpdateForm.new(
+        ordered_related_items: ['/bank-holidays', '/pay-vat', '/additional-state-pension'],
+      )
+
+      stub_request(:post, "https://publishing-api.test.gov.uk/lookup-by-base-path")
+        .with(body: { "base_paths" => ["/bank-holidays", "/pay-vat", "/additional-state-pension"] })
+        .to_return(body: {
+          "/pay-vat" => "a484eaea-eeb6-48fa-92a7-b67c6cd414f6",
+          "/additional-state-pension" => "e78637eb-3be4-408c-9f9c-d2336635c0ca",
+          "/bank-holidays" => "58f79dbd-e57f-4ab2-ae96-96df5767d1b2",
+        }.to_json)
+
+      links_payload = form.links_payload([:ordered_related_items])
+
+      expect(links_payload).to eql(
+        ordered_related_items: [
+          "58f79dbd-e57f-4ab2-ae96-96df5767d1b2",
+          "a484eaea-eeb6-48fa-92a7-b67c6cd414f6",
+          "e78637eb-3be4-408c-9f9c-d2336635c0ca",
+        ],
       )
     end
   end


### PR DESCRIPTION
We're moving tagging of ordered related items from panoption to tagger. These are the links to other pages on GOV.UK that sometimes get shown in a sidebar.
https://trello.com/c/D6TywAem/294-replace-panopticon-s-related-artefact-functionality-with-content-tagger

If possible we want to show this in the same form as all the other tags, so that the user can easily see all the tags for a content item and understand how the content will be linked to/from on GOV.UK.

This commit enhances the fixed length list of inputs added in the previous commit when javascript is enabled.

To get this to work, I've implemented a new widget with:

- Drag and drop to reorder
- A way to look up a related item by base path and add it to the links if it exists
- A button to remove each tag
- Similar look and feel to the other tagging widgets
- A way to preview what the link will look like

**This is nowhere near done.** I'd like this to be reviewed for the overall approach taken. Please do not review the code itself yet. Can also go through this at my desk if it's easier.

# What it looks like

## With javascript
<img width="1260" alt="screen shot 2016-12-14 at 17 43 16" src="https://cloud.githubusercontent.com/assets/87579/21193747/33c5aafa-c225-11e6-9db2-e97e47e275a4.png">

(please ignore the weird icon in the input, that's lastpass)

## Without javascript
<img width="1210" alt="screen shot 2016-12-14 at 17 48 16" src="https://cloud.githubusercontent.com/assets/87579/21193835/8b2c5ece-c225-11e6-9996-5ae097b8a340.png">

# What panopticon looked like
<img width="773" alt="screen shot 2016-12-14 at 17 47 34" src="https://cloud.githubusercontent.com/assets/87579/21193799/6ee0ee06-c225-11e6-9ad4-a27f3ff0551d.png">

#  How the widget is intended to work
- The ordered related links are rendered in a `ul` (on reflection, this should probably be a `ol`)
- Each list item contains two divs:
    1. A text input that holds the `base_path` values passed back to the backend
    2. A div representing the actual tag, like what we show in the `select2` widgets
- If javascript is disabled, the user sees the text inputs
- If javascript is enabled the user sees the tags
- Drag and drop reorders the whole list item in the DOM
- All the text inputs have the same name, and rails reads them into an array

## Why I can't use the existing widget content tagger uses for other tag types
- It's built on select2, and assumes you have a fixed list of options. For related items you should be able to tag to any content item.
- It doesn't have an ordering to it, and we need to be able to set the order links will appear in the sidebar.

 ## Why I didn't reuse the related artefacts widget from panopticon
- It's still not a free choice of any GOV.UK content. It autocompletes from a huge list, and this is quite unresponsive in panopticon.
- We decided for this ticket that autocomplete was not needed, which is why there is a separate field for looking up new items.
- It's not hugely obvious that the tags are orderable - we have to explain it in text
- I wasn't aware of it when we started, and the panopticon one does a different thing (progressive enhancement of a comma separated value field instead of multiple text boxes). I'm not sure at this point how to reuse any part of the panopticon solution without keeping the whole thing.

# What's left
## Not done yet
- When there is an error in the form, we need to refetch the titles of all related links since we only submit the base paths. Note that in this case we may have a mix of valid and invalid base paths.
- Problems looking up a tag are currently ignored - we should show errors if there are errors.
- On the backend, we should be restricting this tagging to formats that show related links in the rendering app.
- Non GOV.UK URLs can be normalised to valid GOV.UK base paths - this is a bug.

## Needs improving:
- The CSS needs to be extracted into classes
- Some things that should be full width, aren't, because I wasn't sure how to do the CSS
- There are multiple places responsible for rendering the same HTML; I think we should create a shared template for a related link, that the javascript can use for dynamically add
- All references to artefacts/panopticon stuff should be removed
- There is duplication of base path lookup functionality between `/taggings/lookup` and `/taggings/<content_id>`
- The templates should use `govuk_admin_templates` stuff for showing the flash in a standard way and including analytics
- On the backend, there are a lot of different Structs and value classes used for similar things, which could be simplified
- It looks weird when there are no related links tagged to a content item.