### PR TITLE
Add ordered related links to tagging form (version without JS)

### DIFF
--- a/app/forms/tagging_update_form.rb
+++ b/app/forms/tagging_update_form.rb
@@ -4,6 +4,13 @@ class TaggingUpdateForm
 
   attr_accessor(*ContentItemExpandedLinks::TAG_TYPES)
 
+  # The number of extra empty form fields to add to a link section when the link
+  # section shows an individual form input for each value. This allows users to
+  # append new links to the end of the existing list.
+  EXTRA_TEXT_FIELD_COUNT = 5
+
+  validate :related_item_paths_should_be_valid
+
   # Return a new LinkUpdate object with topics, mainstream_browse_pages,
   # organisations and content_item set.
   def self.from_content_item_links(content_item_links)
@@ -14,26 +21,60 @@ class TaggingUpdateForm
       organisations: extract_content_ids(content_item_links.organisations),
       mainstream_browse_pages: extract_content_ids(content_item_links.mainstream_browse_pages),
       parent: extract_content_ids(content_item_links.parent),
-      taxons: extract_content_ids(content_item_links.taxons)
+      taxons: extract_content_ids(content_item_links.taxons),
+      ordered_related_items: pad_with_empty_items(extract_base_paths(content_item_links.ordered_related_items))
     )
   end
 
   def links_payload(tag_types)
     tag_types.each_with_object({}) do |tag_type, payload|
-      content_ids = send(tag_type)
-      payload[tag_type] = clean_content_ids(content_ids)
+      field_value = send(tag_type)
+
+      payload[tag_type] =
+        if tag_type == :ordered_related_items
+          related_content_items.map(&:content_id)
+        else
+          clean_input_array(field_value)
+        end
     end
+  end
+
+  def related_content_items
+    @related_content_items ||= BasePathLookup.find_by_base_paths(
+      clean_input_array(ordered_related_items)
+    )
   end
 
   def self.extract_content_ids(links_hashes)
     links_hashes.map { |links_hash| links_hash["content_id"] }
   end
 
+  def self.extract_base_paths(links_hashes)
+    unless links_hashes.nil?
+      links_hashes.map { |links_hash| links_hash["base_path"] }
+    end
+  end
+
+  def self.pad_with_empty_items(items)
+    (items || []) + [""] * EXTRA_TEXT_FIELD_COUNT
+  end
+
+  private_class_method(:extract_content_ids, :extract_base_paths, :pad_with_empty_items)
+
 private
 
-  private_class_method :extract_content_ids
-
-  def clean_content_ids(select_form_input)
+  def clean_input_array(select_form_input)
     Array(select_form_input).select(&:present?)
+  end
+
+  def related_item_paths_should_be_valid
+    unless ordered_related_items.nil?
+      related_content_items.each do |ri|
+        if ri.content_id.nil?
+          index = ordered_related_items.index(ri.base_path)
+          errors[:"ordered_related_items[#{index}]"] << "Could not find content item with this URL or path"
+        end
+      end
+    end
   end
 end

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -1,4 +1,5 @@
 class ContentItem
+
   attr_reader :content_id, :title, :base_path, :publishing_app, :document_type
 
   def initialize(data)

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -1,12 +1,12 @@
 class ContentItem
-
-  attr_reader :content_id, :title, :base_path, :publishing_app, :document_type
+  attr_reader :content_id, :title, :base_path, :publishing_app, :rendering_app, :document_type
 
   def initialize(data)
     @content_id = data.fetch('content_id')
     @title = data.fetch('title')
     @base_path = data.fetch('base_path')
     @publishing_app = data.fetch('publishing_app', nil)
+    @rendering_app = data.fetch('rendering_app', nil)
     @document_type = data.fetch('document_type')
   end
 
@@ -24,7 +24,14 @@ class ContentItem
 
   def blacklisted_tag_types
     blacklist = YAML.load_file("#{Rails.root}/config/blacklisted-tag-types.yml")
-    Array(blacklist[publishing_app]).map(&:to_sym) + additional_temporary_blacklist
+    document_blacklist = Array(blacklist[publishing_app]).map(&:to_sym)
+    document_blacklist += additional_temporary_blacklist
+
+    unless related_links_are_renderable
+      document_blacklist += [:ordered_related_items]
+    end
+
+    document_blacklist
   end
 
   def allowed_tag_types
@@ -35,6 +42,18 @@ class ContentItem
   end
 
 private
+
+  def related_links_are_renderable
+    %w(
+      calendars
+      smartanswers
+      licencefinder
+      frontend
+      multipage-frontend
+      businesssupportfinder
+      calculators
+    ).include?(rendering_app)
+  end
 
   def additional_temporary_blacklist
     publishing_app == 'specialist-publisher' && document_type == 'finder' ? [:topics] : []

--- a/app/models/content_item_expanded_links.rb
+++ b/app/models/content_item_expanded_links.rb
@@ -2,7 +2,8 @@ class ContentItemExpandedLinks
   include ActiveModel::Model
   attr_accessor :content_id, :previous_version
 
-  TAG_TYPES = %i(taxons mainstream_browse_pages parent topics organisations).freeze
+  TAG_TYPES = %i(taxons ordered_related_items mainstream_browse_pages parent topics organisations).freeze
+
   attr_accessor(*TAG_TYPES)
 
   # Find the links for a content item by its content ID
@@ -19,6 +20,7 @@ class ContentItemExpandedLinks
       mainstream_browse_pages: links.fetch('mainstream_browse_pages', []),
       parent: links.fetch('parent', []),
       taxons: links.fetch('taxons', []),
+      ordered_related_items: links.fetch('ordered_related_items', [])
     )
   end
 end

--- a/app/models/content_item_expanded_links.rb
+++ b/app/models/content_item_expanded_links.rb
@@ -2,7 +2,31 @@ class ContentItemExpandedLinks
   include ActiveModel::Model
   attr_accessor :content_id, :previous_version
 
-  TAG_TYPES = %i(taxons ordered_related_items mainstream_browse_pages parent topics organisations).freeze
+  # Temporarily disable ordered_related_items. We can't allow users
+  # to edit these in content tagger until the interface is removed from
+  # panopticon, because panopticon doesn't read tags from publishing api,
+  # and could overwrite them.
+  #
+  # We'll remove it from panopticon when the javascript is done.
+  # https://github.com/alphagov/content-tagger/pull/245
+  LIVE_TAG_TYPES = %i(
+    taxons
+    mainstream_browse_pages
+    parent
+    topics
+    organisations
+  ).freeze
+
+  TEST_TAG_TYPES = %i(
+    taxons
+    ordered_related_items
+    mainstream_browse_pages
+    parent
+    topics
+    organisations
+  ).freeze
+
+  TAG_TYPES = Rails.env.production? ? LIVE_TAG_TYPES : TEST_TAG_TYPES
 
   attr_accessor(*TAG_TYPES)
 

--- a/app/services/base_path_lookup.rb
+++ b/app/services/base_path_lookup.rb
@@ -1,0 +1,14 @@
+class BasePathLookup
+  RelatedContentItem = Struct.new("RelatedContentItem", :content_id, :base_path)
+
+  def self.find_by_base_paths(base_paths_or_urls)
+    return [] if base_paths_or_urls.empty?
+
+    base_paths = base_paths_or_urls.map { |ri| URI.parse(ri).path }
+    content_id_by_path = Services.publishing_api.lookup_content_ids(
+      base_paths: base_paths
+    )
+
+    base_paths.map { |path| RelatedContentItem.new(content_id_by_path[path], path) }
+  end
+end

--- a/app/views/taggings/_form_for_ordered_related_items.html.erb
+++ b/app/views/taggings/_form_for_ordered_related_items.html.erb
@@ -1,0 +1,17 @@
+<h3>Related content items</h3>
+
+<p class="explain">
+  Related items are displayed in the sidebar. Enter the URL or path of a GOV.UK
+  page, such as /pay-vat or /benefit-cap-calculator
+</p>
+
+<% @tagging_update.ordered_related_items.each_with_index do |related_item, index| %>
+  <% link_has_error = !@tagging_update.errors[:"ordered_related_items[#{index}]"].empty? %>
+
+  <div class="form-group related-item <%= link_has_error ? 'has-error' : '' %>">
+    <%= text_field_tag "tagging_update_form[ordered_related_items][]", related_item, class: ["form-control", "related-item-path"] %>
+    <% @tagging_update.errors[:"ordered_related_items[#{index}]"].each do |error| %>
+      <span class="help-block"><%= error %></span>
+    <% end %>
+  </div>
+<% end %>

--- a/config/blacklisted-tag-types.yml
+++ b/config/blacklisted-tag-types.yml
@@ -51,3 +51,4 @@ test-app-that-can-be-tagged-to-topics-only:
   - mainstream_browse_pages
   - organisations
   - parent
+  - ordered_related_items

--- a/spec/features/tag_a_page_spec.rb
+++ b/spec/features/tag_a_page_spec.rb
@@ -109,6 +109,7 @@ RSpec.describe "Tagging content", type: :feature do
     stub_request(:get, "#{PUBLISHING_API}/v2/content/MY-CONTENT-ID")
       .to_return(body: {
         publishing_app: "a-migrated-app",
+        rendering_app: "frontend",
         content_id: "MY-CONTENT-ID",
         base_path: '/my-content-item',
         document_type: 'mainstream_browse_page',

--- a/spec/features/tag_a_page_spec.rb
+++ b/spec/features/tag_a_page_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe "Tagging content", type: :feature do
 
     then_the_publishing_api_is_sent(
       taxons: [],
+      ordered_related_items: [],
       mainstream_browse_pages: [],
       parent: [],
       topics: ["e1d6b771-a692-4812-a4e7-7562214286ef", example_topic['content_id']],
@@ -39,6 +40,7 @@ RSpec.describe "Tagging content", type: :feature do
 
     then_the_publishing_api_is_sent(
       taxons: [],
+      ordered_related_items: [],
       mainstream_browse_pages: [],
       parent: [],
       topics: ["e1d6b771-a692-4812-a4e7-7562214286ef"],
@@ -68,6 +70,18 @@ RSpec.describe "Tagging content", type: :feature do
     when_i_type_its_basepath_in_the_url_directly
     then_i_am_on_the_page_for_the_item
     and_the_expected_navigation_link_is_highlighted
+  end
+
+  scenario "User tries to tag a content item with a non-existent related item" do
+    given_there_is_a_content_item_with_expanded_links(topics: [example_topic])
+    given_there_is_related_content_with_matching_base_paths
+
+    when_i_type_its_basepath_in_the_url_directly
+    and_i_add_a_valid_related_content_item_path
+    and_i_add_a_path_which_does_not_match_a_content_item
+    and_i_submit_the_form
+
+    then_i_see_a_highlighted_error_for_the_missing_path
   end
 
   def when_i_visit_the_homepage
@@ -107,6 +121,12 @@ RSpec.describe "Tagging content", type: :feature do
         expanded_links: expanded_links,
         version: 54_321,
       }.to_json)
+  end
+
+  def given_there_is_related_content_with_matching_base_paths
+    stub_request(:post, "https://publishing-api.test.gov.uk/lookup-by-base-path")
+      .with(body: { "base_paths" => ["/pay-vat", "/no-such-path"] })
+      .to_return(body: { "/pay-vat" => "a484eaea-eeb6-48fa-92a7-b67c6cd414f6" }.to_json)
   end
 
   def and_i_submit_the_url_of_the_content_item
@@ -196,6 +216,21 @@ RSpec.describe "Tagging content", type: :feature do
         "/browse/driving/car-tax-discs",
       ]
     )
+  end
+
+  def and_i_add_a_valid_related_content_item_path
+    all(".related-item-path")[0].set("/pay-vat")
+  end
+
+  def and_i_add_a_path_which_does_not_match_a_content_item
+    all(".related-item-path")[1].set("/no-such-path")
+  end
+
+  def then_i_see_a_highlighted_error_for_the_missing_path
+    related_items = all(".related-item")
+
+    expect(related_items[0]["class"]).not_to include("has-error")
+    expect(related_items[1]["class"]).to include("has-error")
   end
 
   def example_topic

--- a/spec/forms/tagging_update_form_spec.rb
+++ b/spec/forms/tagging_update_form_spec.rb
@@ -1,6 +1,56 @@
 require 'rails_helper'
 
 RSpec.describe TaggingUpdateForm do
+  describe '#valid?' do
+    it "is valid if content item has no links" do
+      form = TaggingUpdateForm.new
+
+      expect(form).to be_valid
+    end
+
+    it "is valid if related item paths exist" do
+      form = TaggingUpdateForm.new(
+        ordered_related_items: ["/bank-holidays", "/pay-vat"],
+      )
+
+      stub_request(:post, "https://publishing-api.test.gov.uk/lookup-by-base-path")
+        .with(body: { "base_paths" => ["/bank-holidays", "/pay-vat"] })
+        .to_return(body: {
+          "/bank-holidays" => "58f79dbd-e57f-4ab2-ae96-96df5767d1b2",
+          "/pay-vat" => "a484eaea-eeb6-48fa-92a7-b67c6cd414f6",
+        }.to_json)
+
+      expect(form).to be_valid
+    end
+
+    it "is not valid if related item paths do not exist" do
+      form = TaggingUpdateForm.new(
+        ordered_related_items: ["/no-such-path"],
+      )
+
+      stub_request(:post, "https://publishing-api.test.gov.uk/lookup-by-base-path")
+        .with(body: { "base_paths" => ["/no-such-path"] })
+        .to_return(body: {}.to_json)
+
+      expect(form).to_not be_valid
+    end
+
+    it "is not valid if only some of the paths exist" do
+      form = TaggingUpdateForm.new(
+        ordered_related_items: ["/pay-vat", "/no-such-path", "/bank-holidays"],
+      )
+
+      stub_request(:post, "https://publishing-api.test.gov.uk/lookup-by-base-path")
+        .with(body: { "base_paths" => ["/pay-vat", "/no-such-path", "/bank-holidays"] })
+        .to_return(body: {
+          "/pay-vat" => "a484eaea-eeb6-48fa-92a7-b67c6cd414f6",
+          "/bank-holidays" => "58f79dbd-e57f-4ab2-ae96-96df5767d1b2",
+        }.to_json)
+
+      expect(form).to_not be_valid
+    end
+  end
+
   describe '#links_payload' do
     it 'generates a payload with links' do
       form = TaggingUpdateForm.new(
@@ -9,6 +59,7 @@ RSpec.describe TaggingUpdateForm do
         organisations: [''],
         taxons: [''],
         parent: [''],
+        ordered_related_items: [''],
       )
 
       links_payload = form.links_payload(ContentItemExpandedLinks::TAG_TYPES)
@@ -19,6 +70,7 @@ RSpec.describe TaggingUpdateForm do
         organisations: [],
         taxons: [],
         parent: [],
+        ordered_related_items: [],
       )
     end
 
@@ -37,6 +89,7 @@ RSpec.describe TaggingUpdateForm do
         organisations: [],
         taxons: [],
         parent: [],
+        ordered_related_items: [],
       )
     end
 
@@ -56,6 +109,78 @@ RSpec.describe TaggingUpdateForm do
         organisations: [],
         taxons: [],
         parent: [],
+        ordered_related_items: [],
+      )
+    end
+
+    it "converts base paths of related items into content IDs" do
+      form = TaggingUpdateForm.new(
+        ordered_related_items: ['/bank-holidays', '/pay-vat'],
+      )
+
+      stub_request(:post, "https://publishing-api.test.gov.uk/lookup-by-base-path")
+        .with(body: { "base_paths" => ["/bank-holidays", "/pay-vat"] })
+        .to_return(body: {
+          "/bank-holidays" => "58f79dbd-e57f-4ab2-ae96-96df5767d1b2",
+          "/pay-vat" => "a484eaea-eeb6-48fa-92a7-b67c6cd414f6",
+        }.to_json)
+
+      links_payload = form.links_payload([:ordered_related_items])
+
+      expect(links_payload).to eql(
+        ordered_related_items: [
+          "58f79dbd-e57f-4ab2-ae96-96df5767d1b2",
+          "a484eaea-eeb6-48fa-92a7-b67c6cd414f6",
+        ],
+      )
+    end
+
+    it "converts absolute paths of related items into content IDs" do
+      form = TaggingUpdateForm.new(
+        ordered_related_items: [
+          'https://www.gov.uk/bank-holidays',
+          'https://www-origin.staging.publishing.service.gov.uk/pay-vat',
+        ],
+      )
+
+      stub_request(:post, "https://publishing-api.test.gov.uk/lookup-by-base-path")
+        .with(body: { "base_paths" => ["/bank-holidays", "/pay-vat"] })
+        .to_return(body: {
+          "/bank-holidays" => "58f79dbd-e57f-4ab2-ae96-96df5767d1b2",
+          "/pay-vat" => "a484eaea-eeb6-48fa-92a7-b67c6cd414f6",
+        }.to_json)
+
+      links_payload = form.links_payload([:ordered_related_items])
+
+      expect(links_payload).to eql(
+        ordered_related_items: [
+          "58f79dbd-e57f-4ab2-ae96-96df5767d1b2",
+          "a484eaea-eeb6-48fa-92a7-b67c6cd414f6",
+        ],
+      )
+    end
+
+    it "preserves the order of related content items" do
+      form = TaggingUpdateForm.new(
+        ordered_related_items: ['/bank-holidays', '/pay-vat', '/additional-state-pension'],
+      )
+
+      stub_request(:post, "https://publishing-api.test.gov.uk/lookup-by-base-path")
+        .with(body: { "base_paths" => ["/bank-holidays", "/pay-vat", "/additional-state-pension"] })
+        .to_return(body: {
+          "/pay-vat" => "a484eaea-eeb6-48fa-92a7-b67c6cd414f6",
+          "/additional-state-pension" => "e78637eb-3be4-408c-9f9c-d2336635c0ca",
+          "/bank-holidays" => "58f79dbd-e57f-4ab2-ae96-96df5767d1b2",
+        }.to_json)
+
+      links_payload = form.links_payload([:ordered_related_items])
+
+      expect(links_payload).to eql(
+        ordered_related_items: [
+          "58f79dbd-e57f-4ab2-ae96-96df5767d1b2",
+          "a484eaea-eeb6-48fa-92a7-b67c6cd414f6",
+          "e78637eb-3be4-408c-9f9c-d2336635c0ca",
+        ],
       )
     end
   end

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe ContentItem do
       'title'          => 'A content item',
       'document_type'  => 'placeholder',
       'base_path'      => '/a-content-item',
-      'publishing_app' => 'whitehall'
+      'publishing_app' => 'publisher',
+      'rendering_app'  => 'frontend',
     }
   end
 
@@ -33,6 +34,30 @@ RSpec.describe ContentItem do
 
       it "returns an empty list" do
         expect(content_item.blacklisted_tag_types).to eq []
+      end
+    end
+
+    context "for rendering apps with a sidebar" do
+      let(:content_item) do
+        ContentItem.new(
+          content_item_params.merge('publishing_app' => 'not-in-the-blacklist', 'rendering_app' => 'frontend')
+        )
+      end
+
+      it "returns an empty list" do
+        expect(content_item.blacklisted_tag_types).to eq []
+      end
+    end
+
+    context "for rendering apps without a sidebar" do
+      let(:content_item) do
+        ContentItem.new(
+          content_item_params.merge('publishing_app' => 'not-in-the-blacklist', 'rendering_app' => 'whitehall-frontend')
+        )
+      end
+
+      it "blacklists related items" do
+        expect(content_item.blacklisted_tag_types).to eq [:ordered_related_items]
       end
     end
 


### PR DESCRIPTION
@tijmenb and I discussed deploying this on its own before https://github.com/alphagov/content-tagger/pull/245 is ready. See that PR for screenshots of what it will look like when done.

The downside is that it will be harder to reorder related links, and the inputs will take up a lot of vertical space.

If we decide against deploying this I think it would still be useful to code review this separately.

Screenshot:
<img width="1296" alt="screen shot 2016-12-16 at 11 51 05" src="https://cloud.githubusercontent.com/assets/87579/21261916/437dd78a-c386-11e6-9f93-caea72b08492.png">

5 blank fields are included each time you edit the form. There isn't a way to add more without javascript so if you want to add more links you need to save the form to do the next 5.