### PR TITLE
Fix menubar selection highlighting

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,11 +9,11 @@
     <%= link_to t('navigation.tagging_content'), lookup_taggings_path %>
   </li>
 
-  <li class='<%= active_navigation_item.in?(%w[tag_searches tag_migrations]) ? 'active' : nil %>'>
+  <li class='<%= active_navigation_item.in?(%w[bulk_tags tag_migrations copy_taxons tagging_spreadsheets]) ? 'active' : nil %>'>
     <%= link_to t('navigation.bulk_tag'), new_bulk_tag_path %>
   </li>
 
-  <li class='<%= active_navigation_item.in?(%w[taxons]) ? 'active' : nil %>'>
+  <li class='<%= active_navigation_item.in?(%w[taxons taxon_migrations]) ? 'active' : nil %>'>
     <%= link_to t('navigation.taxons'), taxons_path %>
   </li>
 <% end %>


### PR DESCRIPTION
- Previously, when viewing some pages there was no menu item that
appeared to be active.
- Every page now has one menu item highlighted.

Trello: https://trello.com/c/gifTCGLV/374-content-tagger-lots-of-microcopy-changes-and-some-button-layout-tweaks