### PR TITLE
Change headings and label text on 'Tag a page'

### DIFF
--- a/app/views/taggings/lookup.html.erb
+++ b/app/views/taggings/lookup.html.erb
@@ -1,17 +1,20 @@
 <%= display_header title: t('navigation.tagging_title'),
   breadcrumbs: [t('navigation.tagging_content')] %>
 
+<div class="lead">
+  Enter the URL or path of a GOV.UK page to edit its tagging or related links.
+</div>
+
 <%= simple_form_for @lookup, url: lookup_taggings_path do |f| %>
   <div class="form-group">
     <%= f.input :base_path,
-      label: t('navigation.tagging_label'),
+      label: false,
       required: false,
       input_html: { class: 'form-control' }
     %>
 
-    For example: <% ['/pay-vat', '/benefit-cap-calculator', '/bank-holidays'].each do |example| %>
-      <%= link_to example, "/taggings/lookup#{example}" %>
-    <% end %>
+    For example: <%= link_to "https://www.gov.uk/pay-vat", "/taggings/lookup/pay-vat" %>
+    or <%= link_to "/bank-holidays", "/taggings/lookup/bank-holidays" %>
   </div>
 
   <%= submit_tag I18n.t('taggings.search'), class: 'btn btn-success btn-md' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,8 +1,7 @@
 en:
   navigation:
-    tagging_content: Tag a page
-    tagging_title: Which page do you want to tag?
-    tagging_label: Enter the URL or path of a GOV.UK page
+    tagging_content: Edit a page
+    tagging_title: Which page do you want to edit?
     taxons: 'Edit taxonomy'
     bulk_tag: 'Bulk tag'
     tag_migration: 'Bulk tag history'
@@ -18,7 +17,7 @@ en:
       on_self: "Includes the taxon being edited - you can't set a taxon as the parent of itself."
   taggings:
     update_tags: Update tagging
-    search: Edit tagging
+    search: Edit page
   bulk_tag:
     search_button: "Search"
     view_tagged_pages: "View tagged pages"


### PR DESCRIPTION
- Renamed the page and menu button.
- Changed the page title and added a subtitle to replace the
form label.
- Changed the example text beneath the text field.
- Changed the button text from 'Edit tagging' to 'Edit page'.

[Trello card](https://trello.com/c/gifTCGLV/374-content-tagger-lots-of-microcopy-changes-and-some-button-layout-tweaks)

#### Page after changes:

![screen shot 2016-12-19 at 16 26 30](https://cloud.githubusercontent.com/assets/12881990/21320198/09e66b7a-c608-11e6-8264-8ca9e13513bd.png)
