### PR TITLE
Make minor text changes on the bulk tag pages

### DIFF
--- a/app/presenters/tag_migration_presenter.rb
+++ b/app/presenters/tag_migration_presenter.rb
@@ -6,6 +6,10 @@ class TagMigrationPresenter < SimpleDelegator
   end
 
   def state_title
-    state.humanize
+    case state
+    when "ready_to_import" then "Tagging incomplete"
+    when "imported" then "Tagging completed"
+    when "errored" then "Errored"
+    end
   end
 end

--- a/app/views/tagging_spreadsheets/index.html.erb
+++ b/app/views/tagging_spreadsheets/index.html.erb
@@ -7,11 +7,7 @@
     ) do %>
 
   <%= link_to I18n.t('tag_import.upload_sheet'), new_tagging_spreadsheet_path, class: 'btn btn-default' %>
-  <%= link_to copy_taxons_path, class: 'btn btn-default' do %>
-    <i class="glyphicon glyphicon-download-alt"></i>
-      Export taxons with IDs for spreadsheet
-    </i>
-  <% end %>
+  <%= link_to I18n.t('tag_import.view_taxons'), copy_taxons_path, class: 'btn btn-default' %>
 <% end %>
 
 <table class="table queries-list table-bordered table-striped" data-module="filterable-table">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,6 +23,7 @@ en:
     search_button: "Search"
     view_tagged_pages: "View tagged pages"
   tag_import:
+    view_taxons: View all taxon IDs
     upload_sheet: Upload spreadsheet
     upload: Upload
     refresh: Refresh import

--- a/spec/features/bulk_tagging_spec.rb
+++ b/spec/features/bulk_tagging_spec.rb
@@ -235,7 +235,7 @@ RSpec.feature "Bulk tagging", type: :feature do
 
     row = first('table tbody tr')
 
-    expect(row).to have_text(/imported/i)
+    expect(row).to have_text(/Tagging completed/i)
     expect(row).to have_text('Tax documents (Document collection)')
   end
 

--- a/spec/features/copy_taxons_spec.rb
+++ b/spec/features/copy_taxons_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe "Copying taxons for use in a spreadsheet" do
   end
 
   def and_i_click_to_copy_taxons
-    find_link(I18n.t('views.taxons.copy_taxon')).click
+    find_link(I18n.t('tag_import.view_taxons')).click
   end
 
   def then_i_can_see_a_table_with_taxons_to_copy

--- a/spec/presenters/tag_migration_presenter_spec.rb
+++ b/spec/presenters/tag_migration_presenter_spec.rb
@@ -19,10 +19,22 @@ RSpec.describe TagMigrationPresenter do
   end
 
   describe '#state_title' do
-    it 'humanizes the state' do
+    it "returns 'Tagging incomplete' if the state is 'ready_to_import'" do
+      tag_migration.state = 'ready_to_import'
+
+      expect(presenter.state_title).to eq('Tagging incomplete')
+    end
+
+    it "returns 'Tagging completed' if the state is 'imported'" do
       tag_migration.state = 'imported'
 
-      expect(presenter.state_title).to eq('Imported')
+      expect(presenter.state_title).to eq('Tagging completed')
+    end
+
+    it "returns 'Errored' if the state is 'errored'" do
+      tag_migration.state = 'errored'
+
+      expect(presenter.state_title).to eq('Errored')
     end
   end
 end


### PR DESCRIPTION
- On the 'bulk tag by upload' page the text on the 'Export taxons with
IDs for spreadsheet' button was changed and the icon removed.
- On the 'bulk tag history' page the label text for the upload state was
 changed to be more informative.

[Trello card](https://trello.com/c/gifTCGLV/374-content-tagger-lots-of-microcopy-changes-and-some-button-layout-tweaks)

#### Bulk tag by upload page:

![screen shot 2016-12-19 at 16 48 59](https://cloud.githubusercontent.com/assets/12881990/21321531/2cc8ffb8-c60d-11e6-89f5-0f0c77c34e93.png)

#### Bulk tag history page:

![screen shot 2016-12-19 at 16 33 56](https://cloud.githubusercontent.com/assets/12881990/21321558/4342864c-c60d-11e6-8f18-2a8767027c39.png)
