### PR TITLE
Add subtitle and move button - Edit taxonomy pages

### DIFF
--- a/app/views/taxons/index.html.erb
+++ b/app/views/taxons/index.html.erb
@@ -6,6 +6,10 @@
   <% end %>
 <% end %>
 
+<div class="lead">
+  Search for a taxon to see its place in the taxonomy, edit the taxon or move its content.
+</div>
+
 <%= render 'taxons/search', query: query %>
 
 <table class="table queries-list table-bordered table-striped">

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -1,6 +1,12 @@
 <%= display_header title: taxon.internal_name, breadcrumbs: [:taxons, taxon] do %>
   <%= link_to I18n.t('views.taxons.edit'), edit_taxon_path(taxon.content_id), class: "btn btn-default"%>
 
+  <%= link_to new_taxon_migration_path(source_content_id: taxon.content_id),
+    class: 'btn btn-md btn-default' do %>
+    <i class="glyphicon glyphicon-move"></i>
+    <%= I18n.t('views.taxons.move_content') %>
+  <% end %>
+
   <%= link_to taxonomy_path(taxon.content_id, format: :csv), class: "btn btn-default" do %>
     <i class="glyphicon glyphicon-download-alt"></i>
     <%= I18n.t('views.taxons.download_csv') %>
@@ -9,12 +15,6 @@
   <%= link_to taxon_confirm_delete_path(taxon.content_id), class: 'btn btn-md btn-default' do %>
     <i class="glyphicon glyphicon-trash"></i>
     <%= I18n.t('views.taxons.delete_taxon') %>
-  <% end %>
-
-  <%= link_to new_taxon_migration_path(source_content_id: taxon.content_id),
-    class: 'btn btn-md btn-default' do %>
-    <i class="glyphicon glyphicon-move"></i>
-    <%= I18n.t('views.taxons.move_content') %>
   <% end %>
 <% end %>
 


### PR DESCRIPTION
Minor content and layout changes were made to the edit taxonomy pages:
- Added a subtitle to the edit taxonomy index page.
- Re-ordered the buttons on the edit taxonomy show page.

[Trello card](https://trello.com/c/gifTCGLV/374-content-tagger-lots-of-microcopy-changes-and-some-button-layout-tweaks)

#### Edit taxonomy index page with subtitle added:
![screen shot 2016-12-20 at 12 26 59](https://cloud.githubusercontent.com/assets/12881990/21350522/a61b71b4-c6af-11e6-86ad-4e7a7299c77f.png)

#### Edit taxonomy show page with new button order:
![screen shot 2016-12-20 at 12 28 22](https://cloud.githubusercontent.com/assets/12881990/21350553/d103884e-c6af-11e6-9b2e-1955b374693d.png)
