### PR TITLE
Change text and layout on spreadsheet upload pages

### DIFF
--- a/app/views/tagging_spreadsheets/show.html.erb
+++ b/app/views/tagging_spreadsheets/show.html.erb
@@ -1,7 +1,10 @@
 <%= display_header title: tagging_spreadsheet.description, breadcrumbs: [:tagging_spreadsheets, "Preview"] do %>
-  <%= link_to "Do tagging", tagging_spreadsheet_publish_tags_path(tagging_spreadsheet), method: :post, class: "btn btn-md btn-default" %>
   <%= link_to I18n.t('tag_import.refresh'), tagging_spreadsheet_refetch_path(tagging_spreadsheet), method: :post, class: "btn btn-md btn-default" %>
 <% end %>
+
+  <p>
+    <%= link_to I18n.t('tag_import.start_tagging'), tagging_spreadsheet_publish_tags_path(tagging_spreadsheet), method: :post, class: "btn btn-lg btn-success" %>
+  </p>
 
 <% if tagging_spreadsheet.state == "errored" %>
   <p class="alert alert-danger">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -25,12 +25,12 @@ en:
     view_taxons: View all taxon IDs
     upload_sheet: Upload spreadsheet
     upload: Upload
-    refresh: Refresh import
+    refresh: Re-upload spreadsheet
     sheet_url: Spreadsheet URL
     delete: Delete
-    start_tagging: "Do tagging"
-    import_created: Spreadsheet uploaded. It will be imported within a few minutes.
-    import_refetched: The import will be imported again.
+    start_tagging: "Start tagging"
+    import_created: Your spreadsheet is now uploading. This can take a few minutes. Refresh this page to see which pages are ready to tag.
+    import_refetched: Your spreadsheet is now re-uploading. This can take a few minutes. Refresh this page to see which pages are ready to tag.
     import_removed: Import has been removed.
     errors:
       invalid_content_id: We could not find this URL on GOV.UK.


### PR DESCRIPTION
- Flash message text for spreadsheet upload and re-upload changed.
- Button text for spreadsheet upload pages changed.
- Position and style of 'Start tagging' button changed to be similar in
style to button on the tag migrations pages.

[Trello card](https://trello.com/c/gifTCGLV/374-content-tagger-lots-of-microcopy-changes-and-some-button-layout-tweaks)

#### Spreadsheet uploading:
![screen shot 2016-12-20 at 14 25 05](https://cloud.githubusercontent.com/assets/12881990/21353980/2e22da7e-c6c0-11e6-97ab-5185717a4723.png)

#### Spreadsheet uploaded (the page above refreshed):
![screen shot 2016-12-20 at 14 26 11](https://cloud.githubusercontent.com/assets/12881990/21354027/50e71aa2-c6c0-11e6-9948-007fa708506b.png)

#### Spreadsheet re-uploading:
![screen shot 2016-12-20 at 14 27 22](https://cloud.githubusercontent.com/assets/12881990/21354069/774f1712-c6c0-11e6-9ad3-987aef39a820.png)
