### PR TITLE
Add 'Move content' links to the taxons index page

### DIFF
--- a/app/views/taxons/index.html.erb
+++ b/app/views/taxons/index.html.erb
@@ -14,6 +14,7 @@
       <th>Taxon</th>
       <th></th>
       <th></th>
+      <th></th>
     </tr>
   </thead>
 
@@ -23,6 +24,7 @@
         <td><%= taxon.internal_name %></td>
         <td><%= link_to I18n.t('views.taxons.view'), taxon_path(taxon.content_id) %></td>
         <td><%= link_to I18n.t('views.taxons.edit'), edit_taxon_path(taxon.content_id) %></td>
+        <td><%= link_to I18n.t('views.taxons.move_content'), new_taxon_migration_path(source_content_id: taxon.content_id) %></td>
       </tr>
     <% end %>
   </tbody>


### PR DESCRIPTION
Links to 'Move content' were added to the taxons index page to make this
option easier to find.

[Trello card](https://trello.com/c/vpviEqKv/372-content-tagger-increase-the-prominence-of-the-move-content-link)

![screen shot 2016-12-20 at 15 43 55](https://cloud.githubusercontent.com/assets/12881990/21356895/281fef12-c6cb-11e6-9963-75577296a519.png)
