### PR TITLE
Change label text for 'Bulk tag by upload' page

### DIFF
--- a/app/presenters/tag_migration_presenter.rb
+++ b/app/presenters/tag_migration_presenter.rb
@@ -6,10 +6,6 @@ class TagMigrationPresenter < SimpleDelegator
   end
 
   def state_title
-    case state
-    when "ready_to_import" then "Tagging incomplete"
-    when "imported" then "Tagging completed"
-    when "errored" then "Errored"
-    end
+    I18n.t("bulk_tagging.state.#{state}")
   end
 end

--- a/app/presenters/tagging_spreadsheet_presenter.rb
+++ b/app/presenters/tagging_spreadsheet_presenter.rb
@@ -7,7 +7,7 @@ class TaggingSpreadsheetPresenter < SimpleDelegator
   end
 
   def state_title
-    state.humanize
+    I18n.t("bulk_tagging.state.#{state}")
   end
 
   def errored?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -43,6 +43,10 @@ en:
     update_tags:
       no_taxons: No taxons selected.
       no_content_items: No content items selected.
+    state:
+      ready_to_import: Tagging incomplete
+      imported: Tagging completed
+      errored: Errored
   views:
     tag_update_progress_bar: "%{completed} of %{total} pages updated"
     tag_migrations:

--- a/spec/features/tag_importer_spec.rb
+++ b/spec/features/tag_importer_spec.rb
@@ -219,10 +219,12 @@ RSpec.feature "Tag importer", type: :feature do
   def then_i_can_see_it_is_ready_for_importing
     visit tagging_spreadsheets_path
     tagging_spreadsheet = TaggingSpreadsheet.first
-    state = tagging_spreadsheet.state.humanize
+    state = tagging_spreadsheet.state
+    state_message = I18n.t("bulk_tagging.state.#{state}")
+
     row = first('table tbody tr')
 
-    expect(row).to have_selector('.label-warning', text: state)
+    expect(row).to have_selector('.label-warning', text: state_message)
     visit tagging_spreadsheet_path(tagging_spreadsheet)
   end
 
@@ -238,7 +240,8 @@ RSpec.feature "Tag importer", type: :feature do
 
   def and_the_state_of_the_import_is_successful
     tagging_spreadsheet = TaggingSpreadsheet.first
-    state = tagging_spreadsheet.state.humanize
+    state = tagging_spreadsheet.state
+    state_message = I18n.t("bulk_tagging.state.#{state}")
 
     visit root_path
     click_link I18n.t('navigation.bulk_tag')
@@ -246,7 +249,7 @@ RSpec.feature "Tag importer", type: :feature do
     click_link I18n.t("navigation.tag_importer")
     row = first('table tbody tr')
 
-    expect(row).to have_selector('.label-success', text: state)
+    expect(row).to have_selector('.label-success', text: state_message)
   end
 
   def when_the_last_tag_mapping_has_errored


### PR DESCRIPTION
The labels on the 'bulk tag by upload' page (/tag-importer) should
contain the same text as the labels on the 'bulk tag history' page
(/tag_migrations).

- Changed the labels to be consistent on both pages.
- Also changed the TagMigrationPresenter to keep both presenters
consistent.

[Trello card](https://trello.com/c/gifTCGLV/374-content-tagger-lots-of-microcopy-changes-and-some-button-layout-tweaks)

![screen shot 2016-12-21 at 12 03 49](https://cloud.githubusercontent.com/assets/12881990/21388761/a06cb28e-c775-11e6-8092-61e189116210.png)
