### PR TITLE
Add label text for spreadsheets in 'upload' state

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -45,6 +45,7 @@ en:
       no_content_items: No content items selected.
     state:
       ready_to_import: Tagging incomplete
+      uploaded: Uploaded
       imported: Tagging completed
       errored: Errored
   views:


### PR DESCRIPTION
Commit 62802f7 changed the way that label text for uploaded spreadsheets
was rendered but missed spreadsheets in the 'upload' state. This commit
adds label text for a TaggingSpreadsheet whose state is 'upload'.

[Trello](https://trello.com/c/gifTCGLV/374-content-tagger-lots-of-microcopy-changes-and-some-button-layout-tweaks)