### PR TITLE
Remove feature flag for related links tagging

### DIFF
--- a/app/models/content_item_expanded_links.rb
+++ b/app/models/content_item_expanded_links.rb
@@ -2,22 +2,7 @@ class ContentItemExpandedLinks
   include ActiveModel::Model
   attr_accessor :content_id, :previous_version
 
-  # Temporarily disable ordered_related_items. We can't allow users
-  # to edit these in content tagger until the interface is removed from
-  # panopticon, because panopticon doesn't read tags from publishing api,
-  # and could overwrite them.
-  #
-  # We'll remove it from panopticon when the javascript is done.
-  # https://github.com/alphagov/content-tagger/pull/245
-  LIVE_TAG_TYPES = %i(
-    taxons
-    mainstream_browse_pages
-    parent
-    topics
-    organisations
-  ).freeze
-
-  TEST_TAG_TYPES = %i(
+  TAG_TYPES = %i(
     taxons
     ordered_related_items
     mainstream_browse_pages
@@ -25,8 +10,6 @@ class ContentItemExpandedLinks
     topics
     organisations
   ).freeze
-
-  TAG_TYPES = Rails.env.production? ? LIVE_TAG_TYPES : TEST_TAG_TYPES
 
   attr_accessor(*TAG_TYPES)
 


### PR DESCRIPTION
We're finishing this feature now. Because of the deploy freeze this is safe to merge now.

https://trello.com/c/D6TywAem