### PR TITLE
Add more testing for related item tagging

### DIFF
--- a/spec/features/related_item_tagging_spec.rb
+++ b/spec/features/related_item_tagging_spec.rb
@@ -1,0 +1,109 @@
+require "rails_helper"
+
+RSpec.describe "Tagging content", type: :feature do
+  include PublishingApiHelper
+
+  before do
+    given_we_can_populate_the_dropdowns_with_content_from_publishing_api
+  end
+
+  scenario "User tags a page with related content item" do
+    given_a_content_item_exists
+    and_i_navigate_to_tagging_page_for_item
+    when_i_add_a_valid_related_content_item_path
+    and_i_submit_the_form
+    then_the_publishing_api_is_sent_the_related_item
+  end
+
+  scenario "User tries to tag a content item with a non-existent related item" do
+    given_a_content_item_exists
+    and_i_navigate_to_tagging_page_for_item
+    when_i_add_a_path_which_does_not_match_a_content_item
+    and_i_submit_the_form
+    then_i_see_a_highlighted_error_for_the_missing_path
+  end
+
+  def then_the_publishing_api_is_sent(**links)
+    body = {
+      links: links,
+      previous_version: 54_321,
+    }
+
+    expect(@tagging_request.with(body: body.to_json)).to have_been_made
+  end
+
+  def and_i_navigate_to_tagging_page_for_item
+    visit "/taggings/MY-CONTENT-ID"
+  end
+
+  def given_a_content_item_exists
+    publishing_api_has_lookups(
+      '/my-content-item' => 'MY-CONTENT-ID'
+    )
+
+    stub_request(:get, "#{PUBLISHING_API}/v2/content/MY-CONTENT-ID")
+      .to_return(body: {
+        publishing_app: "a-migrated-app",
+        rendering_app: "frontend",
+        content_id: "MY-CONTENT-ID",
+        base_path: '/my-content-item',
+        document_type: 'mainstream_browse_page',
+        title: 'This Is A Content Item',
+      }.to_json)
+
+    stub_request(:get, "#{PUBLISHING_API}/v2/expanded-links/MY-CONTENT-ID")
+      .to_return(body: {
+        content_id: "MY-CONTENT-ID",
+        expanded_links: {},
+        version: 54_321,
+      }.to_json)
+  end
+
+  def given_we_can_populate_the_dropdowns_with_content_from_publishing_api
+    # In this test we don't care about empty dropdowns
+    %w(topic taxon organisation mainstream_browse_page).each do |document_type|
+      publishing_api_has_linkables([], document_type: document_type)
+    end
+  end
+
+  def when_i_add_a_valid_related_content_item_path
+    stub_request(:post, "https://publishing-api.test.gov.uk/lookup-by-base-path")
+      .with(body: { "base_paths" => ["/pay-vat"] })
+      .to_return(body: { "/pay-vat" => "a484eaea-eeb6-48fa-92a7-b67c6cd414f6" }.to_json)
+
+    @tagging_request = stub_request(:patch, "#{PUBLISHING_API}/v2/links/MY-CONTENT-ID")
+      .to_return(status: 200)
+
+    all(".related-item-path")[0].set("/pay-vat")
+  end
+
+  def when_i_add_a_path_which_does_not_match_a_content_item
+    stub_request(:post, "https://publishing-api.test.gov.uk/lookup-by-base-path")
+      .with(body: { "base_paths" => ["/pay-vat", "/no-such-path"] })
+      .to_return(body: { "/pay-vat" => "a484eaea-eeb6-48fa-92a7-b67c6cd414f6" }.to_json)
+
+    all(".related-item-path")[1].set("/no-such-path")
+  end
+
+  def then_i_see_a_highlighted_error_for_the_missing_path
+    related_items = all(".related-item")
+
+    expect(related_items[0]["class"]).not_to include("has-error")
+    expect(related_items[1]["class"]).to include("has-error")
+  end
+
+  def and_i_submit_the_form
+    click_on I18n.t('taggings.update_tags')
+  end
+
+  def then_the_publishing_api_is_sent_the_related_item
+    then_the_publishing_api_is_sent(
+      taxons: [],
+      ordered_related_items: ['a484eaea-eeb6-48fa-92a7-b67c6cd414f6'],
+      mainstream_browse_pages: [],
+      parent: [],
+      topics: [],
+      organisations: [],
+    )
+  end
+end

--- a/spec/features/tag_a_page_spec.rb
+++ b/spec/features/tag_a_page_spec.rb
@@ -72,18 +72,6 @@ RSpec.describe "Tagging content", type: :feature do
     and_the_expected_navigation_link_is_highlighted
   end
 
-  scenario "User tries to tag a content item with a non-existent related item" do
-    given_there_is_a_content_item_with_expanded_links(topics: [example_topic])
-    given_there_is_related_content_with_matching_base_paths
-
-    when_i_type_its_basepath_in_the_url_directly
-    and_i_add_a_valid_related_content_item_path
-    and_i_add_a_path_which_does_not_match_a_content_item
-    and_i_submit_the_form
-
-    then_i_see_a_highlighted_error_for_the_missing_path
-  end
-
   def when_i_visit_the_homepage
     visit root_path
   end
@@ -122,12 +110,6 @@ RSpec.describe "Tagging content", type: :feature do
         expanded_links: expanded_links,
         version: 54_321,
       }.to_json)
-  end
-
-  def given_there_is_related_content_with_matching_base_paths
-    stub_request(:post, "https://publishing-api.test.gov.uk/lookup-by-base-path")
-      .with(body: { "base_paths" => ["/pay-vat", "/no-such-path"] })
-      .to_return(body: { "/pay-vat" => "a484eaea-eeb6-48fa-92a7-b67c6cd414f6" }.to_json)
   end
 
   def and_i_submit_the_url_of_the_content_item
@@ -217,21 +199,6 @@ RSpec.describe "Tagging content", type: :feature do
         "/browse/driving/car-tax-discs",
       ]
     )
-  end
-
-  def and_i_add_a_valid_related_content_item_path
-    all(".related-item-path")[0].set("/pay-vat")
-  end
-
-  def and_i_add_a_path_which_does_not_match_a_content_item
-    all(".related-item-path")[1].set("/no-such-path")
-  end
-
-  def then_i_see_a_highlighted_error_for_the_missing_path
-    related_items = all(".related-item")
-
-    expect(related_items[0]["class"]).not_to include("has-error")
-    expect(related_items[1]["class"]).to include("has-error")
   end
 
   def example_topic


### PR DESCRIPTION
This extracts the test for related items from the main spec. It improves readability (at the cost of duplication). Also adds a specific test for the happy path.

https://trello.com/c/D6TywAem