### PR TITLE
Use separate link to link to site

### DIFF
--- a/app/assets/stylesheets/tag-update-preview.scss
+++ b/app/assets/stylesheets/tag-update-preview.scss
@@ -6,4 +6,8 @@
   .tag-mapping-status {
     font-size: 1.8rem;
   }
+
+  .link-to-site {
+    white-space: nowrap;
+  }
 }

--- a/app/views/application/_aggregated_tag_mappings.html.erb
+++ b/app/views/application/_aggregated_tag_mappings.html.erb
@@ -1,7 +1,7 @@
 <% aggregated_tag_mappings.each do |aggregated_tagging| %>
   <tr>
     <td>
-      <%= link_to aggregated_tagging.content_base_path, website_url(aggregated_tagging.content_base_path) %>
+      <%= aggregated_tagging.content_base_path %>
     </td>
     <td>
       <% aggregated_tagging.links.each do |tag_link| %>
@@ -26,6 +26,10 @@
         <%= state_label_for(label_type: tag_mapping.label_type, title: tag_mapping.state_title) %>
         <br>
       <% end %>
+    </td>
+
+    <td class="link-to-site">
+      <%= link_to "View on site", website_url(aggregated_tagging.content_base_path) %>
     </td>
   </tr>
 <% end %>

--- a/app/views/application/_tag_update_preview.html.erb
+++ b/app/views/application/_tag_update_preview.html.erb
@@ -18,6 +18,7 @@
         <th>Page</th>
         <th>Will be tagged to</th>
         <th>Status</th>
+        <th></th>
       </tr>
 
       <%= render partial: 'shared/table_filter' %>

--- a/app/views/tag_migrations/show.html.erb
+++ b/app/views/tag_migrations/show.html.erb
@@ -1,5 +1,3 @@
-
-
 <%= display_header title: t('views.tag_migrations.show.title', taxon: source_content_item.title, type: source_content_item.document_type.humanize.downcase),
     breadcrumbs: [
     link_to(t('navigation.bulk_tag'), new_bulk_tag_path),


### PR DESCRIPTION
When we link the base path, it's not entirely clear where we are sending the user. This removes any ambiguity.

https://trello.com/c/CW3lMGRf

## Before

<img width="1203" alt="screen shot 2017-01-11 at 17 42 26" src="https://cloud.githubusercontent.com/assets/233676/21859653/684566ba-d825-11e6-97f8-90da2388f8fa.png">

## After


<img width="1197" alt="screen shot 2017-01-11 at 17 41 11" src="https://cloud.githubusercontent.com/assets/233676/21859652/682cb002-d825-11e6-947c-26fc122c2b36.png">
