### PR TITLE
Remove instance vars from controllers

### DIFF
--- a/app/controllers/taggings_controller.rb
+++ b/app/controllers/taggings_controller.rb
@@ -1,6 +1,6 @@
 class TaggingsController < ApplicationController
   def lookup
-    @lookup = ContentLookupForm.new
+    render :lookup, locals: { lookup: ContentLookupForm.new }
   end
 
   def find_by_slug
@@ -9,8 +9,7 @@ class TaggingsController < ApplicationController
     if content_lookup.valid?
       redirect_to tagging_path(content_lookup.content_id)
     else
-      @lookup = content_lookup
-      render 'lookup'
+      render :lookup, locals: { lookup: content_lookup }
     end
   end
 
@@ -32,7 +31,10 @@ class TaggingsController < ApplicationController
 
   def show
     content_item = ContentItem.find!(params[:content_id])
-    @tagging_update = Tagging::TaggingUpdateForm.from_content_item(content_item)
+
+    render :show, locals: {
+      tagging_update: Tagging::TaggingUpdateForm.from_content_item(content_item)
+    }
   rescue ContentItem::ItemNotFoundError
     render "item_not_found", status: 404
   end
@@ -44,12 +46,12 @@ class TaggingsController < ApplicationController
     if publisher.save_to_publishing_api
       redirect_to :back, success: "Tags have been updated!"
     else
-      @tagging_update = Tagging::TaggingUpdateForm.from_content_item(content_item)
-      @tagging_update.related_item_errors = publisher.errors
-      @tagging_update.update_attributes_from_form(params[:tagging_tagging_update_form])
+      tagging_update = Tagging::TaggingUpdateForm.from_content_item(content_item)
+      tagging_update.related_item_errors = publisher.errors
+      tagging_update.update_attributes_from_form(params[:tagging_tagging_update_form])
 
       flash.now[:danger] = "This form contains errors. Please correct them and try again."
-      render 'show'
+      render :show, locals: { tagging_update: tagging_update }
     end
   rescue GdsApi::HTTPConflict
     redirect_to :back, danger: "Somebody changed the tags before you could. Your changes have not been saved."

--- a/app/controllers/taxonomies_controller.rb
+++ b/app/controllers/taxonomies_controller.rb
@@ -1,13 +1,13 @@
 class TaxonomiesController < ApplicationController
   def show
     taxon_content_id = params[:content_id]
-    @taxonomy = Taxonomy::ExpandedTaxonomy.new(taxon_content_id).build
+    taxonomy = Taxonomy::ExpandedTaxonomy.new(taxon_content_id).build
 
     respond_to do |format|
       format.csv do
         send_data(
-          Taxonomy::CsvTreePresenter.new(@taxonomy.child_expansion).present,
-          filename: @taxonomy.root_node.content_item.title + ".csv"
+          Taxonomy::CsvTreePresenter.new(taxonomy.child_expansion).present,
+          filename: taxonomy.root_node.content_item.title + ".csv"
         )
       end
     end

--- a/app/views/taggings/_form_for_ordered_related_items.html.erb
+++ b/app/views/taggings/_form_for_ordered_related_items.html.erb
@@ -4,14 +4,21 @@
   <fieldset class="ordered-related-items select2-container select2-container-multi"
             data-module="related-content-tagger">
     <ul class="sortable-list select2-choices ui-sortable sortable-inputs">
-      <% @tagging_update.ordered_related_items.each do |base_path| %>
-        <%= render 'related_item_tagging_entry', base_path: base_path, is_template: false %>
+      <% tagging_update.ordered_related_items.each do |base_path| %>
+        <%= render 'related_item_tagging_entry',
+          base_path: base_path,
+          is_template: false,
+          tagging_update: tagging_update %>
       <% end %>
     </ul>
 
     <% # Hidden, empty tag used by JS to asynchronously render the related item template %>
     <div class="related-item-template hide">
-      <%= render 'related_item_tagging_entry', base_path: '', is_template: true %>
+      <%= render 'related_item_tagging_entry',
+        base_path: '',
+        is_template: true,
+        tagging_update: tagging_update
+      %>
     </div>
 
     <div class="add-sortable-input">

--- a/app/views/taggings/_related_item_tagging_entry.html.erb
+++ b/app/views/taggings/_related_item_tagging_entry.html.erb
@@ -1,10 +1,10 @@
 <li class="related-content-item-entry">
   <% # JavaScript-specific HTML, which should only be included in tags with populated, error-free base paths,
      # or for the template used by JavaScript to create new tags %>
-  <% if is_template || (!base_path.blank? && !@tagging_update.related_item_errors[base_path]) %>
+  <% if is_template || (!base_path.blank? && !tagging_update.related_item_errors[base_path]) %>
     <div class="title select2-search-choice ui-sortable-handle ">
       <a href="https://www.gov.uk<%= base_path %>" class="js-artefact-name">
-        <%= @tagging_update.title_for_related_link(base_path) %> (<%= base_path %>)
+        <%= tagging_update.title_for_related_link(base_path) %> (<%= base_path %>)
       </a>
 
       <a href="#" class="select2-search-choice-close" tabindex="-1"></a>
@@ -13,13 +13,13 @@
     </div>
   <% end %>
 
-  <div class="related-item value <%= @tagging_update.related_item_errors[base_path] ? 'has-error' : '' %>">
+  <div class="related-item value <%= tagging_update.related_item_errors[base_path] ? 'has-error' : '' %>">
     <%= text_field_tag "tagging_tagging_update_form[ordered_related_items][]",
       base_path,
       class: "form-control related-item-path" %>
 
     <span class="help-block">
-      <%= @tagging_update.related_item_errors[base_path] %>
+      <%= tagging_update.related_item_errors[base_path] %>
     </span>
   </div>
 </li>

--- a/app/views/taggings/_tagging_form.html.erb
+++ b/app/views/taggings/_tagging_form.html.erb
@@ -4,7 +4,11 @@
 
   <% tagging_update.allowed_tag_types.each do |tag_type| %>
     <div class='tag-section'>
-      <%= render "form_for_#{tag_type}", { f: f, linkables: tagging_update.linkables } %>
+      <%= render "form_for_#{tag_type}", {
+        f: f,
+        linkables: tagging_update.linkables,
+        tagging_update: tagging_update
+      } %>
     </div>
   <% end %>
 

--- a/app/views/taggings/lookup.html.erb
+++ b/app/views/taggings/lookup.html.erb
@@ -5,7 +5,7 @@
   Enter the URL or path of a GOV.UK page to edit its tagging or related links.
 </div>
 
-<%= simple_form_for @lookup, url: lookup_taggings_path do |f| %>
+<%= simple_form_for lookup, url: lookup_taggings_path do |f| %>
   <div class="form-group">
     <%= f.input :base_path,
       label: false,

--- a/app/views/taggings/show.html.erb
+++ b/app/views/taggings/show.html.erb
@@ -1,8 +1,8 @@
-<%= display_header title: "Add or remove tags from #{@tagging_update.content_item.title}",
-  breadcrumbs: [link_to(t('navigation.tagging_content'), lookup_taggings_path), @tagging_update.content_item] %>
+<%= display_header title: "Add or remove tags from #{tagging_update.content_item.title}",
+  breadcrumbs: [link_to(t('navigation.tagging_content'), lookup_taggings_path), tagging_update.content_item] %>
 
 <div class='view-on-site'>
-  View on site: <%= link_to @tagging_update.content_item.base_path, website_url(@tagging_update.content_item.base_path), target: "_blank" %>
+  View on site: <%= link_to tagging_update.content_item.base_path, website_url(tagging_update.content_item.base_path), target: "_blank" %>
 </div>
 
 <hr/>
@@ -10,7 +10,7 @@
 <%= render(
   partial: 'tagging_form',
   locals: {
-    tagging_update: @tagging_update,
+    tagging_update: tagging_update,
   }
 )
 %>


### PR DESCRIPTION
This PR replaces the instance variables in the taggings controller
with variables passed in inside the locals hash.

This was the last controller that was not using a locals hash and
explicit render calls.

It also removes instance variables from the taxonomies controller
that were not needed.

Please see https://github.com/alphagov/collections/pull/217#discussion_r96445998 for more context.