### PR TITLE
Content tagger bug not able to tag some documents

### DIFF
--- a/app/presenters/bulk_tagging/tag_migration_presenter.rb
+++ b/app/presenters/bulk_tagging/tag_migration_presenter.rb
@@ -2,7 +2,8 @@ module BulkTagging
   class TagMigrationPresenter < SimpleDelegator
     def label_type
       {
-        imported: 'label-success'
+        imported: 'label-success',
+        errored: 'label-danger',
       }.fetch(state.to_sym, 'label-warning')
     end
 

--- a/app/validators/link_type_validator.rb
+++ b/app/validators/link_type_validator.rb
@@ -1,7 +1,7 @@
 class LinkTypeValidator < ActiveModel::Validator
   def validate(record)
-    if record.link_types != ['taxons']
-      record.errors[:link_types] << I18n.t('tag_import.errors.invalid_link_types')
+    if record.link_type != 'taxons'
+      record.errors[:link_type] << I18n.t('tag_import.errors.invalid_link_types')
     end
   end
 end

--- a/app/views/tagging_spreadsheets/show.html.erb
+++ b/app/views/tagging_spreadsheets/show.html.erb
@@ -11,15 +11,14 @@
     An error occured when attempting to read the spreadsheet:
     <%= tagging_spreadsheet.error_message %>
   </p>
-<% else %>
-  <div class='view-on-site'>
-    <%= link_to "View on Google Docs", tagging_spreadsheet.url, target: "_blank" %>
-  </div>
-
-  <%= render "tag_update_preview",
-        completed_tag_mappings: completed_tag_mappings,
-        total_tag_mappings: total_tag_mappings,
-        error_count: tagging_spreadsheet.error_count,
-        aggregated_tag_mappings: aggregated_tag_mappings,
-        progress_path: progress_path %>
 <% end %>
+<div class='view-on-site'>
+  <%= link_to "View on Google Docs", tagging_spreadsheet.url, target: "_blank" %>
+</div>
+
+<%= render "tag_update_preview",
+      completed_tag_mappings: completed_tag_mappings,
+      total_tag_mappings: total_tag_mappings,
+      error_count: tagging_spreadsheet.error_count,
+      aggregated_tag_mappings: aggregated_tag_mappings,
+      progress_path: progress_path %>

--- a/app/workers/publish_links_worker.rb
+++ b/app/workers/publish_links_worker.rb
@@ -10,7 +10,7 @@ class PublishLinksWorker
     # time the job runs.
     return if tag_mapping.blank?
 
-    if tag_mapping.valid?(context: :update_links)
+    if tag_mapping.valid?(:update_links)
       BulkTagging::PublishLinks.call(tag_mapping: tag_mapping)
       tag_mapping.mark_as_tagged
     else

--- a/spec/support/google_sheet_helper.rb
+++ b/spec/support/google_sheet_helper.rb
@@ -32,4 +32,10 @@ module GoogleSheetHelper
       hash[base_path] = fake_content_id
     end
   end
+
+  def google_sheet_content_items_with_draft
+    items = google_sheet_content_items
+    items["/content-2/"] = nil
+    items
+  end
 end

--- a/spec/validators/link_type_validator_spec.rb
+++ b/spec/validators/link_type_validator_spec.rb
@@ -2,14 +2,14 @@ require 'rails_helper'
 
 RSpec.describe LinkTypeValidator do
   it 'validates incorrect link types' do
-    record = double(link_types: ['organisations'], errors: { link_types: [] })
+    record = double(link_type: 'organisations', errors: { link_type: [] })
     described_class.new.validate(record)
 
-    expect(record.errors[:link_types]).to include(/invalid link types found/i)
+    expect(record.errors[:link_type]).to include(/invalid link types found/i)
   end
 
   it 'does not add validation errors when we have expected link types' do
-    record = double(link_types: ['taxons'], errors: {})
+    record = double(link_type: 'taxons', errors: {})
     described_class.new.validate(record)
 
     expect(record.errors).to be_empty


### PR DESCRIPTION
When going to Bulk Tag by upload and using the example spreadsheet, there are two content items that are not tagged because publishing-api cannot look up these base paths. This bug is fixed by showing an error if lookup_by_base_path fails (for example if content is draft or has been moved).

[Trello card](https://trello.com/c/CW3lMGRf/399-content-tagger-bug-not-able-to-tag-some-documents)

Paired with @MatMoore 

#### Errored status label before
![screen shot 2017-01-19 at 12 20 18](https://cloud.githubusercontent.com/assets/12881990/22106731/15fdfd22-de42-11e6-9e4e-b1d789914f29.png)
#### Errored status label after
![screen shot 2017-01-19 at 12 20 33](https://cloud.githubusercontent.com/assets/12881990/22106735/19d77d6a-de42-11e6-91fc-a9a815321a1e.png)
#### The view after a spreadsheet with errors has been imported - before
![screen shot 2017-01-19 at 12 24 57](https://cloud.githubusercontent.com/assets/12881990/22106853/ae8250d4-de42-11e6-9f5e-5b6b9009cf43.png)
#### The view after a spreadsheet with errors has been imported - after
![screen shot 2017-01-19 at 12 25 27](https://cloud.githubusercontent.com/assets/12881990/22106856/b3605c2c-de42-11e6-9a38-a50511deb9f5.png)
