### PR TITLE
Add Appsignal configuration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'simple_form', '~> 3.2', '>= 3.2.1'
 gem 'gds-api-adapters', '~> 37.2'
 
 gem 'airbrake', '~> 4.3.1'
+gem 'appsignal', '~> 2.0'
 
 gem 'sass-rails', '~> 5.0'
 gem 'uglifier', '>= 1.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,6 +41,9 @@ GEM
     airbrake (4.3.8)
       builder
       multi_json
+    appsignal (2.0.5)
+      rack
+      thread_safe
     arel (6.0.3)
     ast (2.3.0)
     autoprefixer-rails (6.4.1.1)
@@ -350,6 +353,7 @@ PLATFORMS
 
 DEPENDENCIES
   airbrake (~> 4.3.1)
+  appsignal (~> 2.0)
   awesome_print
   better_errors
   bootstrap-kaminari-views (~> 0.0.5)

--- a/config/appsignal.yml
+++ b/config/appsignal.yml
@@ -1,0 +1,10 @@
+default: &defaults
+  push_api_key: "<%= ENV['APPSIGNAL_API_KEY'] %>"
+  name: "Content Tagger"
+  active: <%= ENV['APPSIGNAL_API_KEY'] ? true : false %>
+
+development:
+  <<: *defaults
+
+production:
+  <<: *defaults


### PR DESCRIPTION
This adds Appsignal to the app. We're evaluating to see if it is a good replacement for Errbit, while also adding performance tracking.

It's only activated if `APPSIGNAL_API_KEY` is set, which is currently only in integration (https://github.com/alphagov/govuk-puppet/pull/5376 https://github.gds/gds/deployment/pull/1215).

cc @carvil 

https://trello.com/c/J3kDeZD7