### PR TITLE
Make taxon descriptions mandatory

### DIFF
--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -13,7 +13,7 @@ class Taxon
 
   include ActiveModel::Model
 
-  validates_presence_of :title, :internal_name
+  validates_presence_of :title, :description, :internal_name
   validates_with CircularDependencyValidator
 
   def parent_taxons

--- a/spec/features/taxonomy_editing_spec.rb
+++ b/spec/features/taxonomy_editing_spec.rb
@@ -114,6 +114,7 @@ RSpec.feature "Taxonomy editing" do
 
   def when_i_update_the_taxon
     fill_in :taxon_internal_name, with: "My updated taxon"
+    fill_in :taxon_description, with: "Description of my updated taxon."
     fill_in :taxon_notes_for_editors, with: @dummy_editor_notes
 
     @update_item = stub_request(:put, %r{https://publishing-api.test.gov.uk/v2/content*})
@@ -133,6 +134,7 @@ RSpec.feature "Taxonomy editing" do
 
   def when_i_submit_the_taxon_with_a_title_and_parents
     fill_in :taxon_title, with: "My Lovely Taxon"
+    fill_in :taxon_description, with: "A description of my lovely taxon."
     fill_in :taxon_internal_name, with: "My Lovely Taxon"
     fill_in :taxon_notes_for_editors, with: @dummy_editor_notes
 
@@ -146,6 +148,7 @@ RSpec.feature "Taxonomy editing" do
 
   def when_i_submit_the_taxon_with_a_taxon_with_semantic_issues
     fill_in :taxon_title, with: 'My Taxon'
+    fill_in :taxon_description, with: 'Description of my taxon.'
     fill_in :taxon_internal_name, with: 'My Taxon'
 
     stub_request(:put, %r{https://publishing-api.test.gov.uk/v2/content*})

--- a/spec/models/taxon_spec.rb
+++ b/spec/models/taxon_spec.rb
@@ -7,6 +7,12 @@ RSpec.describe Taxon do
       expect(taxon).to_not be_valid
       expect(taxon.errors.keys).to include(:title)
     end
+
+    it 'is not valid without a description' do
+      taxon = described_class.new
+      expect(taxon).to_not be_valid
+      expect(taxon.errors.keys).to include(:description)
+    end
   end
 
   it 'generates unique base paths for the same title' do


### PR DESCRIPTION
This commit makes the taxon description field mandatory when adding or editing taxons.

Trello: https://trello.com/c/wixuzb4G/429-content-tagger-make-adding-descriptions-mandatory-when-creating-a-new-taxon