### PR TITLE
Rescue more exceptions to handle invalid taxons

### DIFF
--- a/lib/tasks/taxonomy/fixup_taxon_urls.rake
+++ b/lib/tasks/taxonomy/fixup_taxon_urls.rake
@@ -24,7 +24,7 @@ namespace :taxonomy do
 
       begin
         Taxonomy::PublishTaxon.call(taxon: taxon)
-      rescue Taxonomy::PublishTaxon::InvalidTaxonError => e
+      rescue => e
         puts "#{taxon.title} is invalid"
         puts e.cause
         errors.push(taxon_base_path: taxon.base_path, taxon_id: taxon.content_id, e: e)


### PR DESCRIPTION
There are now validations in place for taxons like checking they have
descriptions. A number of taxons are now invalid, but we still want this
rake task to go through for the valid taxons (part of the taxonomy we
have been testing).