### PR TITLE
Rake task for removing unused taxons

### DIFF
--- a/lib/tasks/taxonomy/remove_orphans.rake
+++ b/lib/tasks/taxonomy/remove_orphans.rake
@@ -1,0 +1,48 @@
+namespace :taxonomy do
+  task show_orphans: :environment do
+    orphaned_taxons.each do |taxon|
+      puts "#{taxon.base_path} (#{taxon.content_id})"
+    end
+  end
+
+  task remove_orphans: :environment do
+    content_ids_to_remove = orphaned_taxons.map(&:content_id)
+
+    content_ids_to_remove.each do |content_id|
+      puts "Removing #{content_id}"
+      Services.publishing_api.unpublish(content_id, type: 'gone')
+    end
+  end
+end
+
+def orphaned_taxons
+  Enumerator.new do |yielder|
+    1.step do |page|
+      results = RemoteTaxons.new.search(page: page).taxons
+
+      break if results.empty?
+
+      results.each do |result|
+        yielder << result unless taxonomy_includes?(result.content_id)
+      end
+    end
+  end
+end
+
+def connected_taxonomy
+  @taxonomy ||= begin
+    root_taxon = ENV['ROOT_TAXON_CONTENT_ID']
+
+    throw "Missing ROOT_TAXON_CONTENT_ID environment variable" if root_taxon.nil?
+
+    Taxonomy::ExpandedTaxonomy.new(root_taxon).build_child_expansion.child_expansion
+  end
+end
+
+def taxonomy_includes?(content_id, taxonomy: connected_taxonomy)
+  return true if taxonomy.content_item.content_id == content_id
+
+  taxonomy.children.any? do |node|
+    taxonomy_includes?(content_id, taxonomy: node)
+  end
+end


### PR DESCRIPTION
Unpublish old taxon content items that are not linked to the current
education taxonomy.

Anything that is not reachable from the top level of the education
taxonomy is no longer needed and clutters up content tagger.

None of these have been visible to users so don't bother with redirects.

This should be run with ROOT_TAXON_CONTENT_ID=c58fdadd-7743-46d6-9629-90bb3ccc4ef0 (education, training and skills).

Part of https://trello.com/c/4AJLWbUW/427-content-tagger-clear-out-all-the-test-data

There is a separate task for just printing the orphaned taxons so we
can see what will be removed.