### PR TITLE
Rename education base path to /education

### DIFF
--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -1,8 +1,11 @@
 class Theme
-  ALPHA_TAXONOMY = '/alpha-taxonomy'.freeze # TODO: remove once all base paths have been updated
-  EDUCATION_THEME_BASE_PATH = '/education-training-and-skills'.freeze
+  # TODO: remove these once no longer used in base paths
+  ALPHA_TAXONOMY = '/alpha-taxonomy'.freeze
+  OLD_EDUCATION_THEME_BASE_PATH = '/education-training-and-skills'.freeze
+
+  EDUCATION_THEME_BASE_PATH = '/education'.freeze
 
   def self.taxon_path_prefixes
-    [EDUCATION_THEME_BASE_PATH, ALPHA_TAXONOMY]
+    [EDUCATION_THEME_BASE_PATH, OLD_EDUCATION_THEME_BASE_PATH, ALPHA_TAXONOMY]
   end
 end

--- a/app/services/taxonomy/publish_taxon.rb
+++ b/app/services/taxonomy/publish_taxon.rb
@@ -9,12 +9,12 @@ module Taxonomy
       @taxon = taxon
     end
 
-    def self.call(taxon:)
-      new(taxon: taxon).publish
+    def self.call(taxon:, validate: true)
+      new(taxon: taxon).publish(validate: validate)
     end
 
-    def publish
-      raise "Invalid Taxon passed into PublishTaxon" unless taxon.valid?
+    def publish(validate: true)
+      raise "Invalid Taxon passed into PublishTaxon" if validate && !taxon.valid?
 
       Services.publishing_api.put_content(content_id, payload)
       Services.publishing_api.publish(content_id, "minor")

--- a/lib/education_taxon_namer.rb
+++ b/lib/education_taxon_namer.rb
@@ -1,0 +1,42 @@
+module EducationTaxonNamer
+  def self.rename_taxon(taxon)
+    slug = slug_from_title(taxon)
+    taxon.base_path = make_base_path(slug)
+  end
+
+  def self.make_base_path(slug)
+    if slug_is_theme_root?(slug)
+      Theme::EDUCATION_THEME_BASE_PATH
+    else
+      Theme::EDUCATION_THEME_BASE_PATH + slug
+    end
+  end
+
+  def self.slug_is_theme_root?(slug)
+    [
+      Theme::OLD_EDUCATION_THEME_BASE_PATH,
+      Theme::EDUCATION_THEME_BASE_PATH
+    ].include?(slug)
+  end
+
+  def self.slug_from_title(taxon)
+    parent = RemoteTaxons.new.parents_for_taxon(taxon).first
+
+    if title_ambiguous?(taxon.title)
+      "/#{parent.title.parameterize}-#{taxon.title.parameterize}"
+    else
+      "/#{taxon.title.parameterize}"
+    end
+  end
+
+  def self.title_ambiguous?(title)
+    [
+      "Assessments",
+      "Tests",
+      "Programmes of study",
+      "Science",
+      "Maths",
+      "English"
+    ].include?(title)
+  end
+end

--- a/lib/tasks/taxonomy/fixup_taxon_urls.rake
+++ b/lib/tasks/taxonomy/fixup_taxon_urls.rake
@@ -9,21 +9,14 @@ namespace :taxonomy do
     taxon_ids.each do |taxon_id|
       taxon = Taxonomy::BuildTaxon.call(content_id: taxon_id)
 
-      if !taxon.path_prefix.blank? && !taxon.path_slug.blank?
-        if taxon.path_prefix != '/alpha-taxonomy'
-          puts "Skipping #{taxon.title} with path #{taxon.path_prefix + taxon.path_slug}"
-          next
-        end
-      end
-
       puts "Updating #{taxon.title}'s base path"
 
-      slug = '/' + taxon.title.parameterize
-      # If the slug is the same as the path prefix, this is the top-level taxon
-      taxon.base_path = slug == Theme::EDUCATION_THEME_BASE_PATH ? slug : Theme::EDUCATION_THEME_BASE_PATH + slug
+      EducationTaxonNamer.rename_taxon(taxon)
+
+      puts "\t-> #{taxon.title}"
 
       begin
-        Taxonomy::PublishTaxon.call(taxon: taxon)
+        Taxonomy::PublishTaxon.call(taxon: taxon, validate: false)
       rescue => e
         puts "#{taxon.title} is invalid"
         puts e.cause

--- a/spec/education_taxon_namer_spec.rb
+++ b/spec/education_taxon_namer_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.describe EducationTaxonNamer do
+  describe 'rename_taxon' do
+    it "names the theme root" do
+      education = Taxon.new(
+        title: 'Education, training and skills',
+        description: 'Education things',
+        path_prefix: '/alpha-taxonomy',
+        path_slug: '/some-existing-slug',
+      )
+      described_class.rename_taxon(education)
+
+      expect(education.base_path).to eq("/education")
+    end
+
+    it "names a child taxon based on the title" do
+      pupil_participation = Taxon.new(
+        title: 'Pupil participation in school governance',
+        description: 'Pupil participation in school governance',
+        path_prefix: '/alpha-taxonomy',
+        path_slug: '/some-existing-slug',
+      )
+      described_class.rename_taxon(pupil_participation)
+
+      expect(pupil_participation.base_path).to eq("/education/pupil-participation-in-school-governance")
+    end
+
+    it "names key stage 1 and key stage 2 taxons with a prefix" do
+      key_stage_1 = Taxon.new(
+        title: 'Key stage 1',
+        description: 'Key Stage 1',
+        path_prefix: '/alpha-taxonomy',
+        path_slug: '/key-stage-1-slug',
+      )
+
+      maths = Taxon.new(
+        title: 'Maths',
+        description: 'Maths in Key Stage 1',
+        path_prefix: '/alpha-taxonomy',
+        path_slug: '/some-existing-slug',
+      )
+
+      expect_any_instance_of(RemoteTaxons).to receive(:parents_for_taxon).and_return([key_stage_1])
+
+      described_class.rename_taxon(maths)
+
+      expect(maths.base_path).to eq("/education/key-stage-1-maths")
+    end
+  end
+end


### PR DESCRIPTION
Top level themes are the root taxon of a tree. Every other taxon in the tree
has that initial URL as a prefix.

Because of https://github.com/alphagov/content-tagger/pull/268, the taxon
"Primary curriculum, key stage 2" would have a URL like this:
https://www.gov.uk/education-training-and-skills/primary-curriculum-key-stage-2

In https://github.com/alphagov/content-tagger/pull/275, we removed everything that is not under the education theme.

This commit renames the prefix to /education.

Some taxons are not valid at the moment (due to missing descriptions) but the rake task ignores this so we can update the base paths independently.

For now if anything fails to be updated, skip it.

We can remove /alpha-taxonomy, and /education-training-and-skills in future commits, so that the validation still works if we can't migrate all taxons at once.

Trello: https://trello.com/c/CbJ3kzQC/439-rename-the-base-path-of-education-training-and-skills

I need to test this some more - On dev I have some content items that conflict with each other but I'm not sure how they got that way.