### PR TITLE
Change Copy Taxons page to show taxon internal name

### DIFF
--- a/app/views/copy_taxons/index.html.erb
+++ b/app/views/copy_taxons/index.html.erb
@@ -7,7 +7,7 @@
 <table class="table queries-list table-bordered" data-module="filterable-table">
   <thead>
     <tr class="table-header">
-      <th>Title</th>
+      <th>Taxon</th>
       <th>Content ID</th>
       <th>Link Type</th>
     </tr>
@@ -16,7 +16,7 @@
   <tbody>
     <% taxons.each do |taxon| %>
       <tr>
-        <td><%= taxon['title'] %></td>
+        <td><%= taxon['internal_name'] %></td>
         <td><%= taxon['content_id'] %></td>
         <td>taxons</td>
       </tr>

--- a/spec/features/copy_taxons_spec.rb
+++ b/spec/features/copy_taxons_spec.rb
@@ -16,7 +16,8 @@ RSpec.describe "Copying taxons for use in a spreadsheet" do
       other_fields: {
         content_id: "ID-1",
         base_path: "/foo",
-        publication_state: 'active'
+        publication_state: 'active',
+        internal_name: "I am an internal name",
       }
     )
     @taxon_2 = basic_content_item(
@@ -24,7 +25,8 @@ RSpec.describe "Copying taxons for use in a spreadsheet" do
       other_fields: {
         content_id: "ID-2",
         base_path: "/bar",
-        publication_state: 'active'
+        publication_state: 'active',
+        internal_name: "I am another internal name",
       }
     )
 
@@ -55,15 +57,15 @@ RSpec.describe "Copying taxons for use in a spreadsheet" do
     table_head = table.all('thead th').map(&:text)
     table_body = table.find('tbody').text
 
-    expect(table_head).to include(/title/i)
+    expect(table_head).to include(/taxon/i)
     expect(table_head).to include(/content id/i)
     expect(table_head).to include(/link type/i)
 
     expect(table_body).to include(@taxon_1[:content_id])
-    expect(table_body).to include(@taxon_1[:title])
+    expect(table_body).to include(@taxon_1[:internal_name])
 
     expect(table_body).to include(@taxon_2[:content_id])
-    expect(table_body).to include(@taxon_2[:title])
+    expect(table_body).to include(@taxon_2[:internal_name])
     expect(table_body).to include('taxons')
   end
 end


### PR DESCRIPTION
The table on the Copy Taxons page previously displayed the taxon titles
(which are the external taxon names). The table has been changed to
be consistent with other pages by displaying the internal taxon names
and using the heading of 'Taxon'.

[Trello card](https://trello.com/c/KNcqI98W/442-content-tagger-copy-taxons-page-in-should-show-internal-rather-than-external-taxon-names)