### PR TITLE
Add tagging to user needs

### DIFF
--- a/app/models/linkables.rb
+++ b/app/models/linkables.rb
@@ -16,6 +16,10 @@ class Linkables
     @organisations ||= for_document_type('organisation')
   end
 
+  def needs
+    @needs ||= for_document_type('need', include_draft: false)
+  end
+
   def mainstream_browse_pages
     @mainstream_browse_pages ||= for_nested_document_type('mainstream_browse_page')
   end

--- a/app/models/linkables.rb
+++ b/app/models/linkables.rb
@@ -22,8 +22,11 @@ class Linkables
 
 private
 
-  def for_document_type(document_type)
+  def for_document_type(document_type, include_draft: true)
     items = get_tags_of_type(document_type)
+    unless include_draft
+      items = items.reject { |x| x['publication_state'] == 'draft' }
+    end
     present_items(items)
   end
 

--- a/app/models/tagging/content_item_expanded_links.rb
+++ b/app/models/tagging/content_item_expanded_links.rb
@@ -10,6 +10,7 @@ module Tagging
       parent
       topics
       organisations
+      meets_user_needs
     ).freeze
 
     attr_accessor(*TAG_TYPES)

--- a/app/views/taggings/_form_for_meets_user_needs.html.erb
+++ b/app/views/taggings/_form_for_meets_user_needs.html.erb
@@ -1,0 +1,12 @@
+<h3>User Needs</h3>
+
+<%= f.input :meets_user_needs,
+    collection: linkables.needs,
+    placeholder: "Choose user needs...",
+    input_html: { multiple: true, class: :select2 } %>
+
+<p class='explain'>
+  Needs are managed through Maslow, and the list of user needs which a
+  item of content meets is displayed on the info page for that
+  content.
+</p>

--- a/config/blacklisted-tag-types.yml
+++ b/config/blacklisted-tag-types.yml
@@ -52,3 +52,4 @@ test-app-that-can-be-tagged-to-topics-only:
   - organisations
   - parent
   - ordered_related_items
+  - meets_user_needs

--- a/spec/features/related_item_tagging_spec.rb
+++ b/spec/features/related_item_tagging_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe "Tagging content", type: :feature do
 
   def given_we_can_populate_the_dropdowns_with_content_from_publishing_api
     # In this test we don't care about empty dropdowns
-    %w(topic taxon organisation mainstream_browse_page).each do |document_type|
+    %w(topic taxon organisation mainstream_browse_page need).each do |document_type|
       publishing_api_has_linkables([], document_type: document_type)
     end
   end
@@ -104,6 +104,7 @@ RSpec.describe "Tagging content", type: :feature do
       parent: [],
       topics: [],
       organisations: [],
+      meets_user_needs: [],
     )
   end
 end

--- a/spec/features/tag_a_page_spec.rb
+++ b/spec/features/tag_a_page_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe "Tagging content", type: :feature do
       parent: [],
       topics: ["e1d6b771-a692-4812-a4e7-7562214286ef", example_topic['content_id']],
       organisations: [],
+      meets_user_needs: [],
     )
   end
 
@@ -45,6 +46,7 @@ RSpec.describe "Tagging content", type: :feature do
       parent: [],
       topics: ["e1d6b771-a692-4812-a4e7-7562214286ef"],
       organisations: [],
+      meets_user_needs: [],
     )
   end
 
@@ -90,6 +92,7 @@ RSpec.describe "Tagging content", type: :feature do
         parent: [],
         topics: [],
         organisations: [],
+        meets_user_needs: [],
       )
     end
 
@@ -262,6 +265,12 @@ RSpec.describe "Tagging content", type: :feature do
     publishing_api_has_organisation_linkables(
       [
         "/government/organisations/student-loans-company",
+      ]
+    )
+
+    publishing_api_has_need_linkables(
+      [
+        "/needs/apply-for-a-copy-of-a-marriage-certificate",
       ]
     )
 

--- a/spec/features/tagging_during_migration_spec.rb
+++ b/spec/features/tagging_during_migration_spec.rb
@@ -26,6 +26,11 @@ RSpec.describe "Tagging content during migration", type: :feature do
         "/topic/business-tax/pension-scheme-administration",
       ]
     )
+    publishing_api_has_need_linkables(
+      [
+        "/needs/apply-for-a-copy-of-a-marriage-certificate",
+      ]
+    )
   end
 
   def given_there_is_an_item_that_can_have_only_one_link_type

--- a/spec/support/publishing_api_helper.rb
+++ b/spec/support/publishing_api_helper.rb
@@ -47,6 +47,13 @@ module PublishingApiHelper
     )
   end
 
+  def publishing_api_has_need_linkables(base_paths)
+    publishing_api_has_linkables(
+      select_by_base_path(stubbed_needs, base_paths),
+      document_type: 'need'
+    )
+  end
+
   def publishing_api_has_mainstream_browse_page_linkables(base_paths)
     publishing_api_has_linkables(
       select_by_base_path(stubbed_mainstream_browse_pages, base_paths),
@@ -102,6 +109,18 @@ module PublishingApiHelper
         "base_path" => "/government/organisations/student-loans-company",
         "internal_name" => "Student Loans Company"
       },
+    ]
+  end
+
+  def stubbed_needs
+    [
+      {
+        "title" => "As a user, I need to apply for a copy of a marriage certificate, so that I can prove identity and have a record of the marriage, or research my family history (100569)",
+        "content_id" => "29e9fb40-69af-4c4c-bd56-02e3c825a63b",
+        "publication_state" => "published",
+        "base_path" => "/needs/apply-for-a-copy-of-a-marriage-certificate",
+        "internal_name" => "As a user, I need to apply for a copy of a marriage certificate, so that I can prove identity and have a record of the marriage, or research my family history (100569)"
+      }
     ]
   end
 


### PR DESCRIPTION
This is work that @binaryberry, @issyl0 and I are working on as part of the preparatory work for the migration of Publisher (mainstream publisher) to the Publishing API.

Currently needs are stored in the Need API, and managed in Maslow. We are working on making needs content, and moving them to the Publishing API, which enables associating content and the user needs it meets using the links stored by the Publishing API. These changes bring tagging user needs to content tagger. 

![content-tagger-user-needs](https://cloud.githubusercontent.com/assets/1130010/22427438/1ec4e6b6-e6fb-11e6-9098-e599c80eabaf.png)
