### PR TITLE
Remove the link type column in spreadsheet uploads

### DIFF
--- a/app/services/bulk_tagging/fetch_remote_data.rb
+++ b/app/services/bulk_tagging/fetch_remote_data.rb
@@ -40,7 +40,7 @@ module BulkTagging
         content_base_path:  cast_and_strip(row["content_base_path"]),
         link_title:         cast_and_strip(row["link_title"]),
         link_content_id:    cast_and_strip(row["link_content_id"]),
-        link_type:          cast_and_strip(row["link_type"]),
+        link_type:          'taxons',
         state:              'ready_to_tag',
       )
     end


### PR DESCRIPTION
It's no longer useful, because we only allow taxons now.

This caused some of the errors in https://trello.com/c/rC2btscW/448-content-tagger-show-appropriate-error-messages-when-uploading-untaggable-content

Paired with @klssmith @Davidslv 