### PR TITLE
Update link to example spreadsheet

### DIFF
--- a/app/views/tagging_spreadsheets/_help.html.erb
+++ b/app/views/tagging_spreadsheets/_help.html.erb
@@ -15,7 +15,7 @@
     </ul>
     <p class='explain'>
       See the <%= link_to "example spreadsheet",
-        "https://docs.google.com/spreadsheets/d/1Qjs6oGL3MC-kuwBJSeDdM9dDqImtM-xTSxkSrGk3TlA/pub?gid=0&single=true&output=tsv" %>
+        "https://docs.google.com/spreadsheets/d/1qUajhROscOjcPzuDc9tpEnVsBZCJSfO6Ctkcwh9EgvY/pub?gid=0&single=true&output=tsv" %>
         for the correct format.
     </p>
   </div>


### PR DESCRIPTION
This commit updates the link to the example spreadsheet for bulk tagging to take into account changes made to the format of the imported file.

Trello: https://trello.com/c/rC2btscW/448-content-tagger-show-appropriate-error-messages-when-uploading-untaggable-content