### PR TITLE
Show state of an expanded link if draft

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,8 +12,12 @@ private
 
   helper_method :active_navigation_item, :website_url
 
-  def website_url(base_path)
-    Plek.new.website_root + base_path
+  def website_url(base_path, draft: false)
+    if draft
+      Plek.new.find('draft-origin') + base_path
+    else
+      Plek.new.website_root + base_path
+    end
   end
 
   def active_navigation_item

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -7,6 +7,15 @@ module ApplicationHelper
     end
   end
 
+  def expanded_link_label(expanded_link)
+    label_type = expanded_link.state == 'draft' ? 'warning' : 'success'
+
+    state_label_for(
+      label_type: "label-#{label_type}",
+      title: expanded_link.state
+    )
+  end
+
   def time_tag_for(date)
     data_attributes = {
       'toggle': 'tooltip',

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -1,5 +1,13 @@
 class ContentItem
-  attr_reader :content_id, :title, :base_path, :publishing_app, :rendering_app, :document_type
+  attr_reader(
+    :content_id,
+    :title,
+    :base_path,
+    :publishing_app,
+    :rendering_app,
+    :document_type,
+    :state,
+  )
 
   def initialize(data)
     @content_id = data.fetch('content_id')
@@ -8,6 +16,7 @@ class ContentItem
     @publishing_app = data.fetch('publishing_app', nil)
     @rendering_app = data.fetch('rendering_app', nil)
     @document_type = data.fetch('document_type')
+    @state = data.fetch('state', nil)
   end
 
   def self.find!(content_id)
@@ -16,6 +25,10 @@ class ContentItem
     new(content_item.to_h)
   rescue GdsApi::HTTPNotFound
     raise ItemNotFoundError
+  end
+
+  def draft?
+    state == 'draft'
   end
 
   def link_set

--- a/app/services/bulk_tagging/fetch_tagged_content.rb
+++ b/app/services/bulk_tagging/fetch_tagged_content.rb
@@ -29,7 +29,7 @@ module BulkTagging
       results = Services.publishing_api.get_linked_items(
         content_id,
         link_type: "taxons",
-        fields: %w(title content_id base_path document_type)
+        fields: %w(title content_id base_path document_type state)
       )
 
       results.map { |result| ContentItem.new(result) }

--- a/app/views/tag_migrations/_items_tagged_to_item.html.erb
+++ b/app/views/tag_migrations/_items_tagged_to_item.html.erb
@@ -16,8 +16,11 @@
           <%= check_box_tag 'content_base_paths[]',
             expanded_link.base_path, false, class: 'select-content-item' %>
         </td>
-        <td><%= expanded_link.title %></td>
-        <td><%= link_to 'View on site', website_url(expanded_link.base_path) %></td>
+        <td>
+          <%= expanded_link.title %>
+          <%- if expanded_link.draft? %><%= expanded_link_label(expanded_link) %><%- end %>
+        </td>
+        <td><%= link_to 'View on site', website_url(expanded_link.base_path, draft: expanded_link.draft?) %></td>
       </tr>
     <% end %>
   </tbody>

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe ContentItem do
       'base_path'      => '/a-content-item',
       'publishing_app' => 'publisher',
       'rendering_app'  => 'frontend',
+      'state'          => 'draft',
     }
   end
 


### PR DESCRIPTION
This commit displays a "draft" tag on the taxon move content page when the content item is in a draft state, to differentiate it from published items. In addition, the link to the item points to `draft-origin`.

Original code by @Davidslv 

Trello: https://trello.com/c/E4nd1FVH/412-content-tagger-add-a-label-to-tables-of-content-to-highlight-pages-in-draft-state

Published content item:

![screen shot 2017-02-09 at 11 39 17](https://cloud.githubusercontent.com/assets/444232/22782087/661a5748-eebd-11e6-9ba7-a3fb440241d3.png)

Draft content item:

![screen shot 2017-02-09 at 11 39 57](https://cloud.githubusercontent.com/assets/444232/22782090/6a7d09c0-eebd-11e6-86a0-a6c127c35649.png)
