### PR TITLE
Include internal taxon names in bulk tagging search

### DIFF
--- a/app/services/bulk_tagging/search.rb
+++ b/app/services/bulk_tagging/search.rb
@@ -27,7 +27,8 @@ module BulkTagging
         document_type: document_type,
         page: page,
         q: query,
-        fields: [:content_id, :document_type, :title, :base_path]
+        fields: [:content_id, :document_type, :title, :base_path],
+        search_in: [:title, :base_path, :'details.internal_name']
       )
     end
   end

--- a/spec/services/bulk_tagging/search_spec.rb
+++ b/spec/services/bulk_tagging/search_spec.rb
@@ -10,7 +10,8 @@ module BulkTagging
         q: 'tax',
         page: 1,
         document_type: 'taxon',
-        fields: [:content_id, :document_type, :title, :base_path]
+        fields: [:content_id, :document_type, :title, :base_path],
+        search_in: [:title, :base_path, :'details.internal_name']
       )
     end
 

--- a/spec/support/publishing_api_helper.rb
+++ b/spec/support/publishing_api_helper.rb
@@ -4,7 +4,8 @@ module PublishingApiHelper
       document_type: BulkTagging::Search.default_document_types,
       page: 1,
       q: '',
-      fields: [:content_id, :document_type, :title, :base_path]
+      fields: [:content_id, :document_type, :title, :base_path],
+      search_in: [:title, :base_path, :'details.internal_name']
     }
 
     publishing_api_has_content(


### PR DESCRIPTION
This commit uses the new `search_in` parameter for `get_content_items` to extend the search to the internal taxon name when searching for taxons in the bulk tagging section.

Depends on https://github.com/alphagov/publishing-api/pull/771.

Trello: https://trello.com/c/B7Xj7NFu/370-content-tagger-allow-search-on-internal-taxon-names-including-brackets