### PR TITLE
Add rake task for exporting taxon base paths

### DIFF
--- a/lib/tasks/taxonomy/export_tagged_content.rake
+++ b/lib/tasks/taxonomy/export_tagged_content.rake
@@ -6,7 +6,7 @@ namespace :taxonomy do
     taxon as a starting point. The script will print to STDOUT base paths for
     all content tagged to the chosen taxon and all of its children.
   DESC
-  task :export_base_paths, [:taxon_id] => :environment do |_, args|
+  task :export_tagged_content, [:taxon_id] => :environment do |_, args|
     taxon_id = args.fetch(:taxon_id)
     output = {}
 

--- a/lib/tasks/taxonomy/export_taxonomy.rake
+++ b/lib/tasks/taxonomy/export_taxonomy.rake
@@ -1,0 +1,12 @@
+namespace :taxonomy do
+  desc <<-DESC
+    Prints the base paths of all taxons to STDOUT
+  DESC
+  task export: :environment do
+    taxons = RemoteTaxons.new.search(per_page: 10_000).taxons
+
+    taxons.each do |taxon|
+      puts taxon.base_path
+    end
+  end
+end


### PR DESCRIPTION
This adds a Rake task to export the base paths of all taxons. This should make it easier to update the [navigation prototype](https://github.com/alphagov/govuk-content-navigation), for example.

Trello: https://trello.com/c/bv9RRshW/401-update-the-prototype-with-the-latest-tagged-data 