### PR TITLE
Add link to see "more like this" in search admin

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,7 +10,11 @@ class ApplicationController < ActionController::Base
 
 private
 
-  helper_method :active_navigation_item, :website_url
+  helper_method(
+    :active_navigation_item,
+    :website_url,
+    :similar_search_results_url
+  )
 
   def website_url(base_path, draft: false)
     if draft
@@ -18,6 +22,11 @@ private
     else
       Plek.new.website_root + base_path
     end
+  end
+
+  def similar_search_results_url(base_path)
+    Plek.new.find('search-admin') +
+      "/similar-search-results/result?base_path=#{base_path}"
   end
 
   def active_navigation_item

--- a/app/views/taxons/_tagged_content.html.erb
+++ b/app/views/taxons/_tagged_content.html.erb
@@ -4,7 +4,8 @@
       <tr class="table-header">
         <th>Page</th>
         <th>Format</th>
-        <th>Actions</th>
+        <th></th>
+        <th></th>
       </tr>
 
       <%= render partial: 'shared/table_filter' %>
@@ -15,7 +16,23 @@
         <tr>
           <td><%= link_to content_item["title"], website_url(content_item["base_path"]) %></td>
           <td><%= content_item["document_type"].humanize %></td>
-          <td><%= link_to t('views.taxons.edit_tagging'), tagging_url(content_item["content_id"]) %></td>
+          <td>
+            <%=
+              link_to(
+                t('views.taxons.edit_tagging'),
+                tagging_url(content_item["content_id"])
+              )
+            %>
+          </td>
+          <td>
+            <%=
+              link_to(
+                t('views.taxons.view_similar'),
+                similar_search_results_url(content_item['base_path']),
+                target: 'blank'
+              )
+            %>
+          </td>
         </tr>
       <% end %>
     </tbody>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -84,6 +84,7 @@ en:
       path_slug: 'Slug'
       preview: 'The URL of the navigation page will be:'
       displayed_on_govuk: 'Displayed on GOV.UK'
+      view_similar: 'More like this'
   controllers:
     bulk_taggings:
       failure: We could not perform search, please try again.


### PR DESCRIPTION
This commit adds a link to the tagged content in the taxons show page to
view "more like this" links in search admin.

This is convenient when going through content and understanding what
related content there is without having to manually copy the base paths
into search admin.

Trello: https://trello.com/c/0GcWhX1t/402-list-current-top-more-like-this-links-for-all-education-content