### PR TITLE
Temporarily increase publishing api timeout, and cache responses

### DIFF
--- a/lib/services.rb
+++ b/lib/services.rb
@@ -5,6 +5,10 @@ module Services
     @publishing_api ||= GdsApi::PublishingApiV2.new(
       Plek.new.find('publishing-api'),
       disable_cache: true,
+
+      # TODO: revisit this when get_linkables reliably responds in under 4 seconds
+      timeout: 15.seconds,
+
       bearer_token: ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example',
     )
   end


### PR DESCRIPTION
Publishing api response time is currently very variable for the linkables
request and is regularly timing out. Since content tagger makes a lot of
linkables requests in succession when tagging a page (to populate the
autocomplete widgets), content tagger has become unusable for actually tagging
content.

This happens on all environments, but I'm not able to reliably reproduce it in
dev at the moment.  Until we get to the bottom of it, it might mitigate the
problem if content tagger waited for the publishing api calls to complete. The
nginx read_proxy_timeout is set to 15 so we should be able to wait longer than
the default 4 seconds.

This is still unbearably slow, but the app is barely working at all at the
moment.  I've also switched on caching. Publishing API uses memcached to cache
the result sets, but getting that data onto the page is still really
inefficient because we make a separate request for each of the 7 tag types.