### PR TITLE
Use `get_content_items` to populate linkables

### DIFF
--- a/app/controllers/copy_taxons_controller.rb
+++ b/app/controllers/copy_taxons_controller.rb
@@ -6,6 +6,6 @@ class CopyTaxonsController < ApplicationController
 private
 
   def taxons
-    Services.publishing_api.get_linkables(format: 'taxon')
+    Linkables.new.get_tags_of_type(:taxon)
   end
 end

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -7,6 +7,7 @@ class ContentItem
     :rendering_app,
     :document_type,
     :state,
+    :details,
   )
 
   def initialize(data)
@@ -17,6 +18,7 @@ class ContentItem
     @rendering_app = data.fetch('rendering_app', nil)
     @document_type = data.fetch('document_type')
     @state = data.fetch('state', nil)
+    @details = data.fetch('details', {})
   end
 
   def self.find!(content_id)

--- a/app/models/linkable.rb
+++ b/app/models/linkable.rb
@@ -1,0 +1,21 @@
+class Linkable < ContentItem
+  MISSING_INTERNAL_NAME_DOCUMENT_TYPES = %w(need organisation).freeze
+
+  def valid_internal_name?
+    internal_name.present?
+  end
+
+  def internal_name
+    @internal_name ||= begin
+      return title if missing_internal_name?
+
+      details['internal_name']
+    end
+  end
+
+private
+
+  def missing_internal_name?
+    MISSING_INTERNAL_NAME_DOCUMENT_TYPES.include?(document_type)
+  end
+end

--- a/app/views/copy_taxons/index.html.erb
+++ b/app/views/copy_taxons/index.html.erb
@@ -16,8 +16,8 @@
   <tbody>
     <% taxons.each do |taxon| %>
       <tr>
-        <td><%= taxon['internal_name'] %></td>
-        <td><%= taxon['content_id'] %></td>
+        <td><%= taxon.internal_name %></td>
+        <td><%= taxon.content_id %></td>
         <td>taxons</td>
       </tr>
     <% end %>

--- a/spec/features/bulk_tagging_spec.rb
+++ b/spec/features/bulk_tagging_spec.rb
@@ -48,7 +48,8 @@ RSpec.feature "Bulk tagging", type: :feature do
 
     publishing_api_has_content_items(
       [document_collection],
-      q: "Tax"
+      q: "Tax",
+      search_in: [:title, :base_path, :'details.internal_name']
     )
 
     publishing_api_has_item(document_collection)
@@ -60,7 +61,8 @@ RSpec.feature "Bulk tagging", type: :feature do
         base_path: "/a-topic",
         document_type: "topic",
       }],
-      q: "topic"
+      q: "topic",
+      search_in: [:title, :base_path, :'details.internal_name']
     )
 
     publishing_api_has_content_items(
@@ -70,7 +72,8 @@ RSpec.feature "Bulk tagging", type: :feature do
         base_path: "/a-maintstream-browse-page",
         document_type: "mainstream_browse_page",
       }],
-      q: "browse"
+      q: "browse",
+      search_in: [:title, :base_path, :'details.internal_name']
     )
 
     publishing_api_has_expanded_links(
@@ -89,11 +92,20 @@ RSpec.feature "Bulk tagging", type: :feature do
     publishing_api_has_item(basic_content_item("Taxon 2"))
 
     # Used in the dropdown
-    publishing_api_has_linkables(
+    publishing_api_has_content_items_for_linkables(
       [
-        build_linkable(internal_name: "Taxon 1", content_id: 'taxon-1'),
-        build_linkable(internal_name: "Taxon 2", content_id: 'taxon-2'),
-        build_linkable(internal_name: "Taxon 3", content_id: 'taxon-3'),
+        content_item_with_details(
+          'Taxon 1',
+          other_fields: { content_id: 'taxon-1' }
+        ),
+        content_item_with_details(
+          'Taxon 2',
+          other_fields: { content_id: 'taxon-2' }
+        ),
+        content_item_with_details(
+          'Taxon 3',
+          other_fields: { content_id: 'taxon-3' }
+        ),
       ],
       document_type: "taxon",
     )

--- a/spec/features/copy_taxons_spec.rb
+++ b/spec/features/copy_taxons_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.describe "Copying taxons for use in a spreadsheet" do
   include ContentItemHelper
+  include PublishingApiHelper
 
   scenario "Copy taxons" do
     given_there_are_taxons
@@ -17,7 +18,9 @@ RSpec.describe "Copying taxons for use in a spreadsheet" do
         content_id: "ID-1",
         base_path: "/foo",
         publication_state: 'active',
-        internal_name: "I am an internal name",
+        details: {
+          internal_name: "I am an internal name",
+        }
       }
     )
     @taxon_2 = basic_content_item(
@@ -26,11 +29,16 @@ RSpec.describe "Copying taxons for use in a spreadsheet" do
         content_id: "ID-2",
         base_path: "/bar",
         publication_state: 'active',
-        internal_name: "I am another internal name",
+        details: {
+          internal_name: "I am another internal name",
+        }
       }
     )
 
-    publishing_api_has_linkables([@taxon_1, @taxon_2], document_type: 'taxon')
+    publishing_api_has_content_items_for_linkables(
+      [@taxon_1, @taxon_2],
+      document_type: 'taxon'
+    )
 
     stub_request(:get, "https://publishing-api.test.gov.uk/v2/links/ID-1")
       .to_return(body: { links: { parent_taxons: [] } }.to_json)
@@ -62,10 +70,10 @@ RSpec.describe "Copying taxons for use in a spreadsheet" do
     expect(table_head).to include(/link type/i)
 
     expect(table_body).to include(@taxon_1[:content_id])
-    expect(table_body).to include(@taxon_1[:internal_name])
+    expect(table_body).to include(@taxon_1[:details][:internal_name])
 
     expect(table_body).to include(@taxon_2[:content_id])
-    expect(table_body).to include(@taxon_2[:internal_name])
+    expect(table_body).to include(@taxon_2[:details][:internal_name])
     expect(table_body).to include('taxons')
   end
 end

--- a/spec/features/move_content_between_taxons_spec.rb
+++ b/spec/features/move_content_between_taxons_spec.rb
@@ -41,22 +41,12 @@ RSpec.feature "Move content between Taxons", type: :feature do
         document_type: 'taxon'
       }
     )
-    @source_taxon_for_select = {
-      'internal_name' => @source_taxon['details']['internal_name'],
-      'content_id' => @source_taxon['content_id'],
-      'publication_state' => 'live'
-    }
     @dest_taxon = content_item_with_details(
       "Destination taxon",
       other_fields: {
         document_type: 'taxon'
       }
     )
-    @dest_taxon_for_select = {
-      'internal_name' => @dest_taxon['details']['internal_name'],
-      'content_id' => @dest_taxon['content_id'],
-      'publication_state' => 'live'
-    }
 
     @document_1 = basic_content_item("Tagged content 1")
     @document_2 = basic_content_item("Tagged content 2")
@@ -82,8 +72,8 @@ RSpec.feature "Move content between Taxons", type: :feature do
     publishing_api_has_item(@source_taxon)
     publishing_api_has_item(@dest_taxon)
 
-    publishing_api_has_linkables(
-      [@source_taxon_for_select, @dest_taxon_for_select],
+    publishing_api_has_content_items_for_linkables(
+      [@source_taxon, @dest_taxon],
       document_type: 'taxon'
     )
   end
@@ -104,7 +94,7 @@ RSpec.feature "Move content between Taxons", type: :feature do
   end
 
   def and_select_a_taxon_to_move_content_to
-    select @dest_taxon_for_select['internal_name']
+    select @dest_taxon['details']['internal_name']
   end
 
   def and_select_all_content

--- a/spec/features/related_item_tagging_spec.rb
+++ b/spec/features/related_item_tagging_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe "Tagging content", type: :feature do
   def given_we_can_populate_the_dropdowns_with_content_from_publishing_api
     # In this test we don't care about empty dropdowns
     %w(topic taxon organisation mainstream_browse_page need).each do |document_type|
-      publishing_api_has_linkables([], document_type: document_type)
+      publishing_api_has_content_items_for_linkables([], document_type: document_type)
     end
   end
 

--- a/spec/features/taxonomy_editing_spec.rb
+++ b/spec/features/taxonomy_editing_spec.rb
@@ -21,20 +21,6 @@ RSpec.feature "Taxonomy editing" do
         publication_state: 'active'
       }
     )
-    @linkable_taxon_1 = {
-      title: "I Am A Taxon",
-      content_id: "ID-1",
-      base_path: "#{Theme::EDUCATION_THEME_BASE_PATH}/1",
-      internal_name: "I Am A Taxon",
-      publication_state: 'active'
-    }
-    @linkable_taxon_2 = {
-      title: "I Am Another Taxon",
-      content_id: "ID-2",
-      base_path: "#{Theme::EDUCATION_THEME_BASE_PATH}/2",
-      internal_name: "I Am Another Taxon",
-      publication_state: 'active'
-    }
 
     @dummy_editor_notes = "Some usage notes for this taxon."
 
@@ -85,8 +71,8 @@ RSpec.feature "Taxonomy editing" do
   end
 
   def given_there_are_taxons
-    publishing_api_has_linkables(
-      [@linkable_taxon_1, @linkable_taxon_2],
+    publishing_api_has_content_items_for_linkables(
+      [@taxon_1, @taxon_2],
       document_type: 'taxon'
     )
     publishing_api_has_taxons([@taxon_1, @taxon_2])

--- a/spec/services/linkables_spec.rb
+++ b/spec/services/linkables_spec.rb
@@ -2,35 +2,56 @@ require "rails_helper"
 
 RSpec.describe Linkables do
   include ContentItemHelper
+  include PublishingApiHelper
 
   let(:linkables) { Linkables.new }
 
   describe '.taxons' do
     before do
-      publishing_api_has_linkables(
+      publishing_api_has_content_items_for_linkables(
         [
-          build_linkable(
-            content_id: 'invalid-1',
-            publication_state: 'live',
-            internal_name: nil,
+          basic_content_item(
+            'invalid 1',
+            other_fields: {
+              content_id: 'invalid-1',
+              publication_state: 'live',
+              details: {
+                internal_name: nil,
+              }
+            }
           ),
-          build_linkable(
-            content_id: 'invalid-2',
-            publication_state: 'live',
-            internal_name: '',
+          basic_content_item(
+            'invalid 2',
+            other_fields: {
+              content_id: 'invalid-2',
+              publication_state: 'live',
+              details: {
+                internal_name: '',
+              }
+            }
           ),
-          build_linkable(
-            content_id: 'valid-1',
-            publication_state: 'live',
-            internal_name: 'Valid-1!',
+          basic_content_item(
+            'valid 1',
+            other_fields: {
+              content_id: 'valid-1',
+              publication_state: 'live',
+              details: {
+                internal_name: 'Valid-1!',
+              }
+            }
           ),
-          build_linkable(
-            content_id: 'valid-2',
-            publication_state: 'live',
-            internal_name: 'Valid-2!',
+          basic_content_item(
+            'valid 2',
+            other_fields: {
+              content_id: 'valid-2',
+              publication_state: 'live',
+              details: {
+                internal_name: 'Valid-2!',
+              }
+            }
           ),
         ],
-        document_type: 'taxon'
+        document_type: 'taxon',
       )
     end
 
@@ -49,26 +70,32 @@ RSpec.describe Linkables do
 
   describe ".topics" do
     it 'returns an array of hashes with title and content id pairs' do
-      publishing_api_has_linkables(
+      publishing_api_has_content_items_for_linkables(
         [
-          {
-            "public_updated_at" => "2016-04-07 10:34:05",
-            "title" => "Pension scheme administration",
-            "content_id" => "e1d6b771-a692-4812-a4e7-7562214286ef",
-            "publication_state" => "live",
-            "base_path" => "/topic/business-tax/pension-scheme-administration",
-            "internal_name" => "Business tax / Pension scheme administration"
-          },
-          {
-            "public_updated_at" => "2016-04-07 10:34:05",
-            "title" => nil,
-            "content_id" => "3535b8ad-7209-4c97-9dac-e25c25d9c27c",
-            "publication_state" => "live",
-            "base_path" => "/topic/redirect",
-            "internal_name" => nil
-          },
+          basic_content_item(
+            "Pension scheme administration",
+            other_fields: {
+              content_id: "e1d6b771-a692-4812-a4e7-7562214286ef",
+              publication_state: 'live',
+              base_path: "/topic/business-tax/pension-scheme-administration",
+              details: {
+                internal_name: "Business tax / Pension scheme administration",
+              }
+            }
+          ),
+          basic_content_item(
+            '',
+            other_fields: {
+              content_id: "3535b8ad-7209-4c97-9dac-e25c25d9c27c",
+              publication_state: 'live',
+              base_path: "/topic/redirect",
+              details: {
+                internal_name: nil,
+              }
+            }
+          )
         ],
-        document_type: "topic",
+        document_type: 'topic'
       )
 
       expected = {
@@ -83,21 +110,26 @@ RSpec.describe Linkables do
 
   describe ".organisations" do
     it "returns an array of arrays with title and content id pairs" do
-      publishing_api_has_linkables(
+      publishing_api_has_content_items_for_linkables(
         [
-          {
-            "public_updated_at" => "2014-10-15 14:35:22",
-            "title" => "Student Loans Company",
-            "content_id" => "9a9111aa-1db8-4025-8dd2-e08ec3175e72",
-            "publication_state" => "live",
-            "base_path" => "/government/organisations/student-loans-company",
-            "internal_name" => "Student Loans Company"
-          },
+          basic_content_item(
+            "Student Loans Company",
+            other_fields: {
+              content_id: "9a9111aa-1db8-4025-8dd2-e08ec3175e72",
+              publication_state: 'live',
+              base_path: "/government/organisations/student-loans-company",
+              details: {
+                internal_name: "Student Loans Company",
+              }
+            }
+          )
         ],
-        document_type: "organisation",
+        document_type: 'organisation'
       )
 
-      expect(linkables.organisations).to eq [["Student Loans Company", "9a9111aa-1db8-4025-8dd2-e08ec3175e72"]]
+      expect(linkables.organisations).to eq [
+        ["Student Loans Company", "9a9111aa-1db8-4025-8dd2-e08ec3175e72"]
+      ]
     end
   end
 end

--- a/spec/support/content_item_helper.rb
+++ b/spec/support/content_item_helper.rb
@@ -15,19 +15,7 @@ module ContentItemHelper
       title: title,
       base_path: title.parameterize.prepend('/path/'),
       document_type: "guidance",
+      publication_state: 'live',
     ).merge(other_fields)
-  end
-
-  def build_linkable(hash)
-    default = {
-      content_id: SecureRandom.uuid,
-      title: SecureRandom.hex,
-      internal_name: SecureRandom.hex,
-      base_path: "/#{SecureRandom.hex}",
-      document_type: SecureRandom.hex,
-      publication_state: %w(live draft).sample,
-    }
-
-    default.stringify_keys.merge(hash.stringify_keys)
   end
 end

--- a/spec/support/publishing_api_helper.rb
+++ b/spec/support/publishing_api_helper.rb
@@ -1,11 +1,27 @@
 module PublishingApiHelper
+  include ContentItemHelper
+
+  def publishing_api_has_content_items_for_linkables(items, options = {})
+    default_options = {
+      q: '',
+      page: 1,
+      per_page: 10_000,
+      states: %w(live published draft),
+      fields: [:content_id, :publication_state, :title, :base_path, :details]
+    }
+
+    publishing_api_has_content(
+      items,
+      default_options.merge(options)
+    )
+  end
+
   def publishing_api_has_content_items(items, options = {})
     default_options = {
       document_type: BulkTagging::Search.default_document_types,
       page: 1,
       q: '',
-      fields: [:content_id, :document_type, :title, :base_path],
-      search_in: [:title, :base_path, :'details.internal_name']
+      fields: [:content_id, :document_type, :title, :base_path]
     }
 
     publishing_api_has_content(
@@ -28,35 +44,35 @@ module PublishingApiHelper
   end
 
   def publishing_api_has_taxon_linkables(base_paths)
-    publishing_api_has_linkables(
+    publishing_api_has_content_items_for_linkables(
       select_by_base_path(stubbed_taxons, base_paths),
       document_type: 'taxon'
     )
   end
 
   def publishing_api_has_topic_linkables(base_paths)
-    publishing_api_has_linkables(
+    publishing_api_has_content_items_for_linkables(
       select_by_base_path(stubbed_topics, base_paths),
       document_type: 'topic'
     )
   end
 
   def publishing_api_has_organisation_linkables(base_paths)
-    publishing_api_has_linkables(
+    publishing_api_has_content_items_for_linkables(
       select_by_base_path(stubbed_organisations, base_paths),
       document_type: 'organisation'
     )
   end
 
   def publishing_api_has_need_linkables(base_paths)
-    publishing_api_has_linkables(
+    publishing_api_has_content_items_for_linkables(
       select_by_base_path(stubbed_needs, base_paths),
       document_type: 'need'
     )
   end
 
   def publishing_api_has_mainstream_browse_page_linkables(base_paths)
-    publishing_api_has_linkables(
+    publishing_api_has_content_items_for_linkables(
       select_by_base_path(stubbed_mainstream_browse_pages, base_paths),
       document_type: 'mainstream_browse_page'
     )
@@ -68,73 +84,98 @@ module PublishingApiHelper
 
   def stubbed_taxons
     [
-      {
-        "public_updated_at" => "2016-04-06 16:25:37.238",
-        "title" => "Vehicle plating",
-        "content_id" => "17f91fdf-a36f-48f0-989c-a056d56876ee",
-        "publication_state" => "live",
-        "base_path" => "/alpha-taxonomy/vehicle-plating",
-        "internal_name" => "Vehicle plating"
-      },
+      basic_content_item(
+        "Vehicle plating",
+        other_fields: {
+          document_type: 'taxon',
+          content_id: "17f91fdf-a36f-48f0-989c-a056d56876ee",
+          publication_state: 'live',
+          base_path: "/alpha-taxonomy/vehicle-plating",
+          details: {
+            internal_name: "Vehicle plating",
+          }
+        }
+      )
     ]
   end
 
   def stubbed_topics
     [
-      {
-        "public_updated_at" => "2016-04-06 16:25:37.238",
-        "title" => "ID OF ALREADY TAGGED",
-        "content_id" => "ID-OF-ALREADY-TAGGED",
-        "publication_state" => "live",
-        "base_path" => "/topic/id-of-already-tagged",
-        "internal_name" => "Test / Id of already tagged"
-      },
-      {
-        "public_updated_at" => "2016-04-07 10:34:05",
-        "title" => "Pension scheme administration",
-        "content_id" => "e1d6b771-a692-4812-a4e7-7562214286ef",
-        "publication_state" => "live",
-        "base_path" => "/topic/business-tax/pension-scheme-administration",
-        "internal_name" => "Business tax / Pension scheme administration"
-      },
+      basic_content_item(
+        "ID OF ALREADY TAGGED",
+        other_fields: {
+          document_type: 'topic',
+          content_id: "ID-OF-ALREADY-TAGGED",
+          publication_state: 'live',
+          base_path: "/topic/id-of-already-tagged",
+          details: {
+            internal_name: "Test / Id of already tagged",
+          }
+        }
+      ),
+      basic_content_item(
+        "Pension scheme administration",
+        other_fields: {
+          document_type: 'topic',
+          content_id: "e1d6b771-a692-4812-a4e7-7562214286ef",
+          publication_state: 'live',
+          base_path: "/topic/business-tax/pension-scheme-administration",
+          details: {
+            internal_name: "Business tax / Pension scheme administration",
+          }
+        }
+      )
     ]
   end
 
   def stubbed_organisations
     [
-      {
-        "public_updated_at" => "2014-10-15 14:35:22",
-        "title" => "Student Loans Company",
-        "content_id" => "9a9111aa-1db8-4025-8dd2-e08ec3175e72",
-        "publication_state" => "live",
-        "base_path" => "/government/organisations/student-loans-company",
-        "internal_name" => "Student Loans Company"
-      },
+      basic_content_item(
+        "Student Loans Company",
+        other_fields: {
+          document_type: 'organisation',
+          content_id: "9a9111aa-1db8-4025-8dd2-e08ec3175e72",
+          publication_state: 'live',
+          base_path: "/government/organisations/student-loans-company",
+          details: {
+            internal_name: "Student Loans Company",
+          }
+        }
+      )
     ]
   end
 
   def stubbed_needs
     [
-      {
-        "title" => "As a user, I need to apply for a copy of a marriage certificate, so that I can prove identity and have a record of the marriage, or research my family history (100569)",
-        "content_id" => "29e9fb40-69af-4c4c-bd56-02e3c825a63b",
-        "publication_state" => "published",
-        "base_path" => "/needs/apply-for-a-copy-of-a-marriage-certificate",
-        "internal_name" => "As a user, I need to apply for a copy of a marriage certificate, so that I can prove identity and have a record of the marriage, or research my family history (100569)"
-      }
+      basic_content_item(
+        "As a user, I need to apply for a copy of a marriage certificate, so that I can prove identity and have a record of the marriage, or research my family history (100569)",
+        other_fields: {
+          document_type: 'need',
+          content_id: "29e9fb40-69af-4c4c-bd56-02e3c825a63b",
+          publication_state: 'live',
+          base_path: "/needs/apply-for-a-copy-of-a-marriage-certificate",
+          details: {
+            internal_name: "As a user, I need to apply for a copy of a marriage certificate, so that I can prove identity and have a record of the marriage, or research my family history (100569)",
+          }
+        }
+      )
     ]
   end
 
   def stubbed_mainstream_browse_pages
     [
-      {
-        "public_updated_at" => "2016-03-27 10:32:40",
-        "title" => "Vehicle tax and SORN",
-        "content_id" => "d93d0cff-a035-4c49-8bc2-eaf6e040c42d",
-        "publication_state" => "live",
-        "base_path" => "/browse/driving/car-tax-discs",
-        "internal_name" => "Driving and transport / Vehicle tax and SORN"
-      },
+      basic_content_item(
+        "Vehicle tax and SORN",
+        other_fields: {
+          document_type: 'mainstream_browse_page',
+          content_id: "d93d0cff-a035-4c49-8bc2-eaf6e040c42d",
+          publication_state: 'live',
+          base_path: "/browse/driving/car-tax-discs",
+          details: {
+            internal_name: "Driving and transport / Vehicle tax and SORN",
+          }
+        }
+      )
     ]
   end
 end


### PR DESCRIPTION
Previously we were using `get_linkables` to fetch all types of links from the Publishing API to populate dropdowns and allow tagging of pages.

These links include:
- taxons
- organisations
- topics
- mainstream browse pages
- needs

These API calls have become increasingly slow which means that in most environments the requests to this particular page timeout.

This commit replaces calls to `get_linkables` to `get_content_items` in the hope to speed the load page of that tagging page and prevent timeouts in all environments.

It also makes the linkable items instances of `ContentItem` rather than hashes, which hopefully makes things more consistent.

What do people think?

cc/ @MatMoore @tijmenb 