### PR TITLE
Add taxon undelete functionality

### DIFF
--- a/app/models/remote_taxons.rb
+++ b/app/models/remote_taxons.rb
@@ -1,8 +1,8 @@
 # TODO: Split this up and move it into the BulkTagging & Taxonomy namespaces.
 class RemoteTaxons
-  def search(page: 1, per_page: 50, query: '')
+  def search(page: 1, per_page: 50, query: '', states: ['published'])
     BulkTagging::TaxonSearchResults.new(
-      taxon_content_items(page: page, per_page: per_page, query: query)
+      taxon_content_items(page: page, per_page: per_page, query: query, states: states)
     )
   end
 
@@ -16,7 +16,7 @@ private
 
   # Return a list of taxons from the publishing API with links included.
   # Does not include the details hash of each taxon.
-  def taxon_content_items(page:, per_page:, query:)
+  def taxon_content_items(page:, per_page:, query:, states:)
     Services
       .publishing_api
       .get_content_items(
@@ -25,7 +25,7 @@ private
         q: query || '',
         page: page || 1,
         per_page: per_page || 50,
-        states: ["published"],
+        states: states || [],
       )
   end
 end

--- a/app/views/taxons/_search_deleted.html.erb
+++ b/app/views/taxons/_search_deleted.html.erb
@@ -1,0 +1,8 @@
+<%= simple_form_for :taxon_search, url: trash_taxons_path, method: :get do |f| %>
+  <div class="form-group">
+    <%= f.input :query,
+      input_html: { type: :text, class: 'form-control', value: query },
+      label: false %>
+    <%= f.submit "Search deleted taxons", class: "btn btn-md btn-success" %>
+  </div>
+<% end %>

--- a/app/views/taxons/confirm_delete.html.erb
+++ b/app/views/taxons/confirm_delete.html.erb
@@ -1,4 +1,6 @@
-<h1>You are about to delete "<%= taxon.internal_name %>"</h1>
+<h1><%= I18n.t('views.taxons.confirm_deletion_title') %> "<%= taxon.internal_name %>"</h1>
+
+<div class="lead"><%= I18n.t('views.taxons.confirm_deletion_restore') %></div>
 
 <%= render partial: 'deletion_warning',
   locals: { taxon: taxon, children: children, tagged: tagged } %>

--- a/app/views/taxons/index.html.erb
+++ b/app/views/taxons/index.html.erb
@@ -4,6 +4,9 @@
       <%= I18n.t('views.taxons.add_taxon') %>
     </i>
   <% end %>
+  <%= link_to trash_taxons_path, class: 'btn btn-default' do %>
+    <%= I18n.t('views.taxons.view_deleted_taxons') %>
+  <% end %>
 <% end %>
 
 <div class="lead">

--- a/app/views/taxons/trash.html.erb
+++ b/app/views/taxons/trash.html.erb
@@ -1,0 +1,31 @@
+<%= display_header title: t('views.taxons.deleted_title'), breadcrumbs: [t('navigation.taxons')] do %>
+  <%= link_to taxons_path, class: 'btn btn-default' do %>
+    <%= I18n.t('views.taxons.view_live_taxons') %>
+  <% end %>
+<% end %>
+
+<div class="lead">
+  Search for a deleted taxon to restore it.
+</div>
+
+<%= render 'taxons/search_deleted', query: query %>
+
+<table class="table queries-list table-bordered table-striped">
+  <thead>
+    <tr class="table-header">
+      <th>Taxon</th>
+      <th></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% taxons.each do |taxon| %>
+      <tr>
+        <td><%= taxon.internal_name %></td>
+        <td><%= link_to I18n.t('views.taxons.restore_taxon'), taxon_restore_path(taxon.content_id) %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<%= paginate search_results, theme: 'twitter-bootstrap-3' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,7 +7,8 @@ en:
     tag_migration: 'Bulk tag history'
     tag_importer: 'Bulk tag by upload'
   errors:
-    invalid_taxon: There was a problem with your request. The chosen slug may already be in use. We have been notified of the issue and will fix it as soon as possible.
+    invalid_taxon: There was a problem with your request. We have been notified of the issue and will fix it as soon as possible.
+    invalid_taxon_base_path: A taxon with this slug already exists. If the taxon has been deleted, you can restore it.
     invalid_hostname: Is not a Google Docs URL
     invalid_path: Does not have the expected public path /spreadsheets/d/<id>/pub
     missing_gid: Is missing a Google Spreadsheet ID parameter (gid)
@@ -62,17 +63,23 @@ en:
       edit_tagging: Edit tagging
       move_content: Move content
       title: Taxons
+      deleted_title: Deleted taxons
       edit: Edit taxon
       view: View taxon
+      view_live_taxons: View live taxons
+      view_deleted_taxons: View deleted taxons
       add_taxon: Add a taxon
       copy_taxon: Export taxons with IDs for spreadsheet
       delete_taxon: Delete taxon
+      restore_taxon: Restore taxon
       new_title: New taxon
       new_breadcrumb: New taxon
       new_button: Create taxon
       edit_button: Update taxon
       download_csv: Download taxonomy as CSV
-      confirm_deletion: I understand and I want to delete it!
+      confirm_deletion_title: You are about to delete
+      confirm_deletion_restore: Deleted taxons can be restored.
+      confirm_deletion: Delete
       cancel_button: Cancel
       delete_warning_1: "Before you delete this taxon, make sure you've:"
       delete_warning_2: given its child taxons a new parent
@@ -91,8 +98,10 @@ en:
     tag_migrations:
       import_removed: Tag migration import has been removed.
     taxons:
-      success: You have sucessfully deleted the taxon
-      alert: It was not possible to delete the taxon
+      destroy_success: You have sucessfully deleted the taxon
+      destroy_alert: It was not possible to delete the taxon
+      restore_success: You have sucessfully restored the taxon
+      restore_alert: It was not possible to restore the taxon
   messages:
     views:
       confirm: Are you sure?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,10 @@ Rails.application.routes.draw do
 
   resources :taxons do
     get :confirm_delete
+    get :restore
+    get :trash, on: :collection
   end
+
   resources :copy_taxons, only: [:index], path: 'copy-taxons'
 
   resources :taggings, only: %i(show update), param: :content_id do

--- a/spec/controllers/taxons_controller_spec.rb
+++ b/spec/controllers/taxons_controller_spec.rb
@@ -15,6 +15,18 @@ RSpec.describe TaxonsController, type: :controller do
     end
   end
 
+  describe "#trash" do
+    it "renders trash" do
+      taxon = { title: "foo", base_path: "/foo", content_id: SecureRandom.uuid }
+
+      publishing_api_has_deleted_taxons([taxon])
+
+      get :trash
+
+      expect(response.code).to eql "200"
+    end
+  end
+
   describe "#show" do
     it "renders 404 for unknown taxons" do
       stub_request(:get, "https://publishing-api.test.gov.uk/v2/content/does-not-exist")

--- a/spec/models/remote_taxons_spec.rb
+++ b/spec/models/remote_taxons_spec.rb
@@ -41,6 +41,41 @@ RSpec.describe RemoteTaxons do
 
       expect(result.taxons.length).to eq(1)
     end
+
+    it 'fetches deleted taxons from the publishing api with pagination' do
+      taxon_1 = { title: "foo" }
+      taxon_2 = { title: "bar" }
+      taxon_3 = { title: "aha" }
+      publishing_api_has_deleted_taxons(
+        [taxon_1, taxon_2, taxon_3],
+        page: 2,
+        per_page: 2
+      )
+
+      result = described_class.new.search(page: 2, per_page: 2, states: ['unpublished'])
+
+      expect(result).to be_a(BulkTagging::TaxonSearchResults)
+      expect(result.taxons.length).to eq(1)
+      taxon = result.taxons.first
+      expect(taxon.title).to eq('aha')
+    end
+
+    it 'is possible to search with a query string' do
+      taxon_1 = { title: "foo" }
+      publishing_api_has_taxons(
+        [taxon_1],
+        page: 1,
+        per_page: 1,
+        q: 'foo'
+      )
+      result = described_class.new.search(
+        page: 1,
+        per_page: 1,
+        query: 'foo'
+      )
+
+      expect(result.taxons.length).to eq(1)
+    end
   end
 
   describe '#parents_for_taxon' do

--- a/spec/services/taxonomy/publish_taxon_spec.rb
+++ b/spec/services/taxonomy/publish_taxon_spec.rb
@@ -35,11 +35,20 @@ RSpec.describe Taxonomy::PublishTaxon do
         allow(Services.publishing_api).to receive(:put_content).and_raise(error)
       end
 
-      it 'raises an error with a generic message and notifies Airbrake' do
+      it 'raises an error with a generic message and notifies Airbrake if it is not a base path conflict' do
+        allow(Services.publishing_api).to receive(:lookup_content_id).and_return(nil)
         expect(Airbrake).to receive(:notify).with(error)
         expect { publish }.to raise_error(
           Taxonomy::PublishTaxon::InvalidTaxonError,
           /there was a problem with your request/i
+        )
+      end
+
+      it 'raises an error with a specific message if it is a base path conflict' do
+        allow(Services.publishing_api).to receive(:lookup_content_id).and_return(SecureRandom.uuid)
+        expect { publish }.to raise_error(
+          Taxonomy::PublishTaxon::InvalidTaxonError,
+          /a taxon with this slug already exists/i
         )
       end
     end

--- a/spec/support/content_item_helper.rb
+++ b/spec/support/content_item_helper.rb
@@ -1,5 +1,5 @@
 module ContentItemHelper
-  def content_item_with_details(title, other_fields: {})
+  def content_item_with_details(title, other_fields: {}, unpublished: false)
     other_fields_with_details = other_fields.merge(
       details: {
         internal_name: "internal name for #{title}",
@@ -7,17 +7,30 @@ module ContentItemHelper
       },
       links: {}
     )
-    basic_content_item(title, other_fields: other_fields_with_details)
+    basic_content_item(
+      title,
+      other_fields: other_fields_with_details,
+      unpublished: unpublished
+    )
   end
 
-  def basic_content_item(title, other_fields: {})
-    ActiveSupport::HashWithIndifferentAccess.new(
+  def basic_content_item(title, other_fields: {}, unpublished: false)
+    content_item = ActiveSupport::HashWithIndifferentAccess.new(
       content_id: title.parameterize,
       title: title,
       base_path: title.parameterize.prepend('/path/'),
       document_type: "guidance",
       links: {}
     ).merge(other_fields)
+
+    if unpublished
+      content_item[:publication_state] = 'unpublished'
+      content_item[:unpublishing] = {
+        type: 'gone'
+      }
+    end
+
+    content_item
   end
 
   def build_linkable(hash)

--- a/spec/support/publishing_api_helper.rb
+++ b/spec/support/publishing_api_helper.rb
@@ -27,6 +27,19 @@ module PublishingApiHelper
     publishing_api_has_content(taxons, default_options.merge(options))
   end
 
+  def publishing_api_has_deleted_taxons(taxons, options = {})
+    default_options = {
+      document_type: "taxon",
+      order: '-public_updated_at',
+      page: 1,
+      per_page: 50,
+      q: '',
+      states: ["unpublished"],
+    }
+
+    publishing_api_has_content(taxons, default_options.merge(options))
+  end
+
   def publishing_api_has_taxon_linkables(base_paths)
     publishing_api_has_linkables(
       select_by_base_path(stubbed_taxons, base_paths),


### PR DESCRIPTION
This commit adds the ability to undelete previously deleted taxons. Deleted taxons are listed on a separate “trash” page, from where they can be restored.

The taxon deletion process is also changed as follows:

* The delete confirmation page now makes it clear that deleted taxons can be restored
* The wording of the “delete” button is now less scary, since deletions can be reversed

Users attempting to create a new taxon with the same slug as an existing one (live or deleted) now reveive a more specific error message to this effect.

As a bonus, error messages when creating/editing taxons are now displayed correctly, and the values of form fields are not lost if there is an error when attempting to publish the taxon.

Trello: https://trello.com/c/qC6zPIO2/516-bug-taxons-cannot-be-created-in-content-tagger-that-use-the-same-slug-as-a-previously-deleted-taxon

The taxons index page has a button linking to the trash page:

![screen shot 2017-03-02 at 11 26 26](https://cloud.githubusercontent.com/assets/444232/23512729/7b68355a-ff59-11e6-966e-676ea178b614.png)

This message is displayed when a deleted taxon is restored:

![screen shot 2017-03-02 at 11 26 19](https://cloud.githubusercontent.com/assets/444232/23512747/8fd81c3a-ff59-11e6-929e-9a9c209050d9.png)

This message is displayed if a user attempts to create a new taxon with a slug that is already in use:

![screen shot 2017-03-02 at 11 57 23](https://cloud.githubusercontent.com/assets/444232/23512759/9bb18b9a-ff59-11e6-8337-522032109b64.png)

This message is displayed for all other errors received from the publishing-api:

![screen shot 2017-03-02 at 11 57 36](https://cloud.githubusercontent.com/assets/444232/23512774/a8d3919c-ff59-11e6-9044-fe613c4cd37b.png)

The trash page, with a button back to the taxons index page. Deleted taxons are displayed with a link to restore them:

![screencapture-content-tagger-dev-gov-uk-taxons-trash-1488454009880](https://cloud.githubusercontent.com/assets/444232/23512780/b90b2b74-ff59-11e6-9640-c0405eb1d98a.png)
