### PR TITLE
Measure patch links, lookups and linkables

### DIFF
--- a/app/forms/content_lookup_form.rb
+++ b/app/forms/content_lookup_form.rb
@@ -6,7 +6,11 @@ class ContentLookupForm
   validate :base_path_should_be_a_content_item
 
   def content_id
-    @content_id ||= Services.publishing_api.lookup_content_id(base_path: base_path)
+    @content_id ||= begin
+      Services.statsd.time "base_path_lookup" do
+        Services.publishing_api.lookup_content_id(base_path: base_path)
+      end
+    end
   end
 
 private

--- a/app/models/linkables.rb
+++ b/app/models/linkables.rb
@@ -64,7 +64,10 @@ private
   end
 
   def get_tags_of_type(document_type)
-    items = Services.publishing_api.get_linkables(format: document_type)
+    items = Services.statsd.time "linkables.#{document_type}" do
+      Services.publishing_api.get_linkables(format: document_type)
+    end
+
     # We only are interested in linkables that have an internal name and not
     # redirects or similar
     items.select { |item| item['internal_name'].present? }

--- a/app/services/tagging/tagging_update_publisher.rb
+++ b/app/services/tagging/tagging_update_publisher.rb
@@ -14,11 +14,13 @@ module Tagging
     def save_to_publishing_api
       return false unless valid?
 
-      Services.publishing_api.patch_links(
-        content_item.content_id,
-        links: generate_links_payload,
-        previous_version: params[:previous_version].to_i,
-      )
+      Services.statsd.time "patch_links" do
+        Services.publishing_api.patch_links(
+          content_item.content_id,
+          links: generate_links_payload,
+          previous_version: params[:previous_version].to_i,
+        )
+      end
     end
 
   private

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -8,4 +8,12 @@ module Services
       bearer_token: ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example',
     )
   end
+
+  def self.statsd
+    @statsd_client ||= begin
+      statsd_client = Statsd.new
+      statsd_client.namespace = "govuk.app.content-tagger"
+      statsd_client
+    end
+  end
 end


### PR DESCRIPTION
This adds statsd timers for patch links, lookups and linkables. This will allow us to make a dashboard that shows how the app is performing.