### PR TITLE
Add rake task for finding taxon-tagged content by document type

### DIFF
--- a/lib/tasks/taxonomy/export_tagged_content.rake
+++ b/lib/tasks/taxonomy/export_tagged_content.rake
@@ -15,7 +15,7 @@ namespace :taxonomy do
     taxonomy.build
 
     taxons = taxonomy.child_expansion.map do |node|
-      { base_path: node.content_item.base_path, content_id: node.content_id }
+      { base_path: node.base_path, content_id: node.content_id }
     end
 
     taxons.each do |taxon|

--- a/lib/tasks/taxonomy/find_tagged_content.rake
+++ b/lib/tasks/taxonomy/find_tagged_content.rake
@@ -1,0 +1,22 @@
+namespace :taxonomy do
+  desc "Find content tagged with the given document type"
+  task :find_tagged_content_with_document_type, [:document_type] => :environment do |_t, args|
+    output = Set.new
+
+    taxons = RemoteTaxons.new.search(per_page: 10_000).taxons
+
+    taxons.each do |taxon|
+      linked_items = Services.publishing_api.get_linked_items(
+        taxon.content_id,
+        link_type: "taxons",
+        fields: %w(base_path document_type)
+      ).to_a.select { |item| item.fetch("document_type") == args[:document_type] }
+
+      taxon_content = linked_items.map { |item| item.fetch("base_path") }
+
+      output.merge(taxon_content)
+    end
+
+    puts output.to_a
+  end
+end


### PR DESCRIPTION
This will be used to check our assumptions about whether content with a given document type is really 'guidance' and should appear on taxon pages.

Trello: https://trello.com/c/m3sc4i5N/11-notices-appearing-as-guidance-content