### PR TITLE
Fix broken rake tasks

### DIFF
--- a/lib/tasks/taxonomy/export_tagged_content.rake
+++ b/lib/tasks/taxonomy/export_tagged_content.rake
@@ -15,7 +15,7 @@ namespace :taxonomy do
     taxonomy.build
 
     taxons = taxonomy.child_expansion.map do |node|
-      { base_path: node.content_item.base_path, content_id: node.content_id }
+      { base_path: node.base_path, content_id: node.content_id }
     end
 
     taxons.each do |taxon|

--- a/lib/tasks/taxonomy/remove_orphans.rake
+++ b/lib/tasks/taxonomy/remove_orphans.rake
@@ -40,7 +40,7 @@ def connected_taxonomy
 end
 
 def taxonomy_includes?(content_id, taxonomy: connected_taxonomy)
-  return true if taxonomy.content_item.content_id == content_id
+  return true if taxonomy.content_id == content_id
 
   taxonomy.children.any? do |node|
     taxonomy_includes?(content_id, taxonomy: node)


### PR DESCRIPTION
`content_id` and `base_path` are directly accessible from taxons using the new taxonomy gem.