### PR TITLE
Add ordered related items overrides

### DIFF
--- a/app/assets/javascripts/views/related-content-tagger.js
+++ b/app/assets/javascripts/views/related-content-tagger.js
@@ -2,16 +2,23 @@
   "use strict";
 
   Modules.RelatedContentTagger = function () {
-    this.start = function () {
+    this.start = function (fieldset) {
+      var $fieldset = $(fieldset);
+      var $basePathInput = $fieldset.find(".new-base-path");
+      var $lookupButton = $fieldset.find(".lookup-base-path-button");
+      var $tagList = $fieldset.find("ul");
+      var $templateTag = $fieldset.find(".related-item-template > li").first();
+      var $fieldErrors = $fieldset.find(".related-item-error-message");
 
-      $(".ordered-related-items").on("click", ".select2-search-choice-close", removeItem);
-      $("#related_item_new_base_path").on("keypress", lookUpBasePathOnEnterPress);
-      $("#lookup_base_path_button").on("click", lookUpBasePath);
 
-      $(".related-content-item-entry .title").show();
-      $(".related-content-item-entry .value").hide();
-      $(".add-sortable-input").show();
-      $(".sortable-inputs").sortable();
+      $fieldset.on("click", ".select2-search-choice-close", removeItem);
+      $basePathInput.on("keypress", lookUpBasePathOnEnterPress);
+      $lookupButton.on("click", lookUpBasePath);
+
+      $fieldset.find(".related-content-item-entry .title").show();
+      $fieldset.find(".related-content-item-entry .value").hide();
+      $fieldset.find(".add-sortable-input").show();
+      $fieldset.find(".sortable-inputs").sortable();
 
 
       function removeItem() {
@@ -33,7 +40,6 @@
       }
 
       function lookUpBasePath() {
-        var $basePathInput = $("#related_item_new_base_path");
         var basePath = $basePathInput.val();
 
         $.getJSON({
@@ -43,11 +49,9 @@
         });
 
         function onTagLookupSuccess(lookup) {
-          var $templateTag = $(".related-item-template > li").first();
-
           var $newTag = $templateTag
             .clone()
-            .appendTo(".ordered-related-items ul");
+            .appendTo($tagList);
 
           $newTag
             .find("input")
@@ -60,12 +64,12 @@
 
           $basePathInput.val("");
           $basePathInput.removeClass("has-error");
-          $(".related-item-error-message").hide();
+          $fieldErrors.hide();
         }
 
         function onTagLookupError(error) {
           $basePathInput.addClass("has-error");
-          $(".related-item-error-message").show();
+          $fieldErrors.show();
         }
       }
     };

--- a/app/controllers/taggings_controller.rb
+++ b/app/controllers/taggings_controller.rb
@@ -47,7 +47,8 @@ class TaggingsController < ApplicationController
       redirect_to :back, success: "Tags have been updated!"
     else
       tagging_update = Tagging::TaggingUpdateForm.from_content_item(content_item)
-      tagging_update.related_item_errors = publisher.errors
+      tagging_update.related_item_errors = publisher.related_item_errors
+      tagging_update.related_item_overrides_errors = publisher.related_item_overrides_errors
       tagging_update.update_attributes_from_form(params[:tagging_tagging_update_form])
 
       flash.now[:danger] = "This form contains errors. Please correct them and try again."

--- a/app/models/tagging/content_item_expanded_links.rb
+++ b/app/models/tagging/content_item_expanded_links.rb
@@ -6,6 +6,7 @@ module Tagging
     TAG_TYPES = %i(
       taxons
       ordered_related_items
+      ordered_related_items_overrides
       mainstream_browse_pages
       parent
       topics

--- a/app/services/tagging/tagging_update_publisher.rb
+++ b/app/services/tagging/tagging_update_publisher.rb
@@ -22,7 +22,25 @@ module Tagging
       )
     end
 
+    def generate_links_payload
+      content_item.allowed_tag_types.reduce({}) do |payload, tag_type|
+        content_ids = fetch_content_ids(tag_type)
+
+        payload.merge(tag_type => content_ids)
+      end
+    end
+
   private
+
+    def fetch_content_ids(tag_type)
+      if tag_type == :ordered_related_items
+        related_content_items.map(&:content_id)
+      elsif tag_type == :ordered_related_items_overrides
+        related_content_items_overrides.map(&:content_id)
+      else
+        clean_input_array(params[tag_type])
+      end
+    end
 
     def valid?
       related_content_items.each do |related_item|
@@ -36,20 +54,6 @@ module Tagging
       end
 
       @related_item_errors.none? && @related_item_overrides_errors.none?
-    end
-
-    def generate_links_payload
-      content_item.allowed_tag_types.reduce({}) do |payload, tag_type|
-        content_ids = if tag_type == :ordered_related_items
-                        related_content_items.map(&:content_id)
-                      elsif tag_type == :ordered_related_items_overrides
-                        related_content_items_overrides.map(&:content_id)
-                      else
-                        clean_input_array(params[tag_type])
-                      end
-
-        payload.merge(tag_type => content_ids)
-      end
     end
 
     def related_content_items

--- a/app/views/taggings/_form_for_ordered_related_items.html.erb
+++ b/app/views/taggings/_form_for_ordered_related_items.html.erb
@@ -23,9 +23,9 @@
 
     <div class="add-sortable-input">
       <div class="input-group">
-        <input id="related_item_new_base_path" type="text" class="form-control" placeholder="URL or path" />
+        <input type="text" class="form-control new-base-path" placeholder="URL or path" />
         <span class="input-group-btn">
-          <button id="lookup_base_path_button" class="btn btn-default" type="button">
+          <button class="btn btn-default lookup-base-path-button" type="button">
             Add related item
           </button>
         </span>

--- a/app/views/taggings/_form_for_ordered_related_items_overrides.html.erb
+++ b/app/views/taggings/_form_for_ordered_related_items_overrides.html.erb
@@ -1,0 +1,45 @@
+<h3>Related content items (new navigation)</h3>
+
+<div class="form-group">
+  <fieldset class="ordered-related-items select2-container select2-container-multi"
+            data-module="related-content-tagger">
+    <ul class="sortable-list select2-choices ui-sortable sortable-inputs">
+      <% tagging_update.ordered_related_items_overrides.each do |base_path| %>
+        <%= render 'related_item_override_tagging_entry',
+          base_path: base_path,
+          is_template: false,
+          tagging_update: tagging_update %>
+      <% end %>
+    </ul>
+
+    <% # Hidden, empty tag used by JS to asynchronously render the related item template %>
+    <div class="related-item-template hide">
+      <%= render 'related_item_override_tagging_entry',
+        base_path: '',
+        is_template: true,
+        tagging_update: tagging_update
+      %>
+    </div>
+
+    <div class="add-sortable-input">
+      <div class="input-group">
+        <input type="text" class="form-control new-base-path" placeholder="URL or path" />
+        <span class="input-group-btn">
+          <button class="btn btn-default lookup-base-path-button" type="button">
+            Add related item
+          </button>
+        </span>
+      </div>
+    </div>
+
+    <div class="error-message related-item-error-message">
+      Not a known URL or path on GOV.UK
+    </div>
+  </fieldset>
+</div>
+
+<p class="explain">
+  Related items override the automatically-generated items in the sidebar for users
+  viewing the beta navigation. Enter the URL or path of a GOV.UK page, such as
+  /national-curriculum or /free-school-transport
+</p>

--- a/app/views/taggings/_related_item_override_tagging_entry.html.erb
+++ b/app/views/taggings/_related_item_override_tagging_entry.html.erb
@@ -1,0 +1,25 @@
+<li class="related-content-item-entry">
+  <% # JavaScript-specific HTML, which should only be included in tags with populated, error-free base paths,
+     # or for the template used by JavaScript to create new tags %>
+  <% if is_template || (!base_path.blank? && !tagging_update.related_item_overrides_errors[base_path]) %>
+    <div class="title select2-search-choice ui-sortable-handle ">
+      <a href="https://www.gov.uk<%= base_path %>" class="js-artefact-name">
+        <%= tagging_update.title_for_related_link(base_path) %> (<%= base_path %>)
+      </a>
+
+      <a href="#" class="select2-search-choice-close" tabindex="-1"></a>
+
+      <span class="glyphicon glyphicon-resize-vertical" aria-hidden="true"></span>
+    </div>
+  <% end %>
+
+  <div class="related-item value <%= tagging_update.related_item_overrides_errors[base_path] ? 'has-error' : '' %>">
+    <%= text_field_tag "tagging_tagging_update_form[ordered_related_items_overrides][]",
+      base_path,
+      class: "form-control related-item-path" %>
+
+    <span class="help-block">
+      <%= tagging_update.related_item_overrides_errors[base_path] %>
+    </span>
+  </div>
+</li>

--- a/config/blacklisted-tag-types.yml
+++ b/config/blacklisted-tag-types.yml
@@ -52,4 +52,5 @@ test-app-that-can-be-tagged-to-topics-only:
   - organisations
   - parent
   - ordered_related_items
+  - ordered_related_items_overrides
   - meets_user_needs

--- a/spec/features/related_item_tagging_spec.rb
+++ b/spec/features/related_item_tagging_spec.rb
@@ -100,6 +100,7 @@ RSpec.describe "Tagging content", type: :feature do
     then_the_publishing_api_is_sent(
       taxons: [],
       ordered_related_items: ['a484eaea-eeb6-48fa-92a7-b67c6cd414f6'],
+      ordered_related_items_overrides: [],
       mainstream_browse_pages: [],
       parent: [],
       topics: [],

--- a/spec/features/tag_a_page_spec.rb
+++ b/spec/features/tag_a_page_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe "Tagging content", type: :feature do
     then_the_publishing_api_is_sent(
       taxons: [],
       ordered_related_items: [],
+      ordered_related_items_overrides: [],
       mainstream_browse_pages: [],
       parent: [],
       topics: ["e1d6b771-a692-4812-a4e7-7562214286ef", example_topic['content_id']],
@@ -42,6 +43,7 @@ RSpec.describe "Tagging content", type: :feature do
     then_the_publishing_api_is_sent(
       taxons: [],
       ordered_related_items: [],
+      ordered_related_items_overrides: [],
       mainstream_browse_pages: [],
       parent: [],
       topics: ["e1d6b771-a692-4812-a4e7-7562214286ef"],
@@ -88,6 +90,7 @@ RSpec.describe "Tagging content", type: :feature do
       then_the_publishing_api_is_sent(
         taxons: [],
         ordered_related_items: [example_topic["content_id"], "a484eaea-eeb6-48fa-92a7-b67c6cd414f6"],
+        ordered_related_items_overrides: [],
         mainstream_browse_pages: [],
         parent: [],
         topics: [],

--- a/spec/services/tagging/tagging_update_publisher_spec.rb
+++ b/spec/services/tagging/tagging_update_publisher_spec.rb
@@ -6,20 +6,38 @@ RSpec.describe Tagging::TaggingUpdatePublisher do
       stub_request(:patch, %r{https://publishing-api.test.gov.uk/v2/links/*}).to_return(status: 200)
     end
 
+    let(:content_id) { "2797b5f2-7154-411e-9282-7756b78b22d6" }
+
+    let(:stubbed_content_item) do
+      double(content_id: content_id, allowed_tag_types: [:ordered_related_items, :ordered_related_items_overrides])
+    end
+
     it "converts base paths of related items into content IDs" do
-      stub_content_id_lookup("/my-page" => "THE-CONTENT-ID-OF-THIS-PAGE")
+      stub_content_id_lookup("/my-page" => content_id)
 
-      update_taggings_with_params(ordered_related_items: ["/my-page"])
+      update_taggings_with_params(ordered_related_items: ["/my-page"], ordered_related_items_overrides: ["/my-page"])
 
-      expect_links_to_have_been_published(ordered_related_items: ['THE-CONTENT-ID-OF-THIS-PAGE'])
+      expect_links_to_have_been_published(ordered_related_items: [content_id], ordered_related_items_overrides: [content_id])
+    end
+
+    it "generates a valid links payload using ordered_related_items" do
+      stub_content_id_lookup("/my-page" => content_id)
+
+      publisher = Tagging::TaggingUpdatePublisher.new(
+        stubbed_content_item,
+        ordered_related_items: ["/my-page"],
+        ordered_related_items_overrides: ["/my-page"]
+      )
+
+      expect(links: publisher.generate_links_payload).to be_valid_against_links_schema('publication')
     end
 
     it "converts absolute paths of related items into content IDs" do
-      stub_content_id_lookup("/my-page" => "THE-CONTENT-ID-OF-THIS-PAGE")
+      stub_content_id_lookup("/my-page" => content_id)
 
       update_taggings_with_params(ordered_related_items: ["https://www.gov.uk/my-page"])
 
-      expect_links_to_have_been_published(ordered_related_items: ['THE-CONTENT-ID-OF-THIS-PAGE'])
+      expect_links_to_have_been_published(ordered_related_items: [content_id], ordered_related_items_overrides: [])
     end
 
     it "is not valid if the provided base path does not exist" do
@@ -46,10 +64,6 @@ RSpec.describe Tagging::TaggingUpdatePublisher do
       stub_request(:post, "https://publishing-api.test.gov.uk/lookup-by-base-path")
         .with(body: { "base_paths" => response.keys })
         .to_return(body: response.to_json)
-    end
-
-    def stubbed_content_item
-      double(content_id: 'some-id', allowed_tag_types: [:ordered_related_items])
     end
   end
 end

--- a/spec/services/tagging/tagging_update_publisher_spec.rb
+++ b/spec/services/tagging/tagging_update_publisher_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Tagging::TaggingUpdatePublisher do
       )
 
       expect(response.save_to_publishing_api).to eql(false)
-      expect(response.errors).to eql("/my-page" => "Not a known URL on GOV.UK")
+      expect(response.related_item_errors).to eql("/my-page" => "Not a known URL on GOV.UK")
     end
 
     def expect_links_to_have_been_published(links)


### PR DESCRIPTION
Add new field for related items overrides. Depends on https://github.com/alphagov/govuk-content-schemas/pull/560

This will be used for the beta navigation we are deploying tomorrow for education. It allows publishers to override the automatically generated related content.

`A` group users will see the existing `ordered_related_items`, for mainstream content only.  `B` group users will see `ordered_related_items_overrides` if set, otherwise automatically generated links. The ordered_related_items will be ignored.

We thought about combining the views for `ordered_related_items` and `ordered_related_items_overrides` but couldn't think of a clean way to do it so decided to leave them separate.

Trello https://trello.com/c/vM6Kaw9B/505-ias-and-content-designers-can-curate-related-links-for-any-content-type
Paired with @rubenarakelyan  and @klssmith 