### PR TITLE
Only show related item overrides on education pages

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -9,6 +9,8 @@ class ContentItem
     :state,
   )
 
+  attr_writer :link_set
+
   def initialize(data)
     @content_id = data.fetch('content_id')
     @title = data.fetch('title')
@@ -35,6 +37,10 @@ class ContentItem
     @link_set ||= Tagging::ContentItemExpandedLinks.find(content_id)
   end
 
+  def taxons?
+    link_set.taxons.present?
+  end
+
   def blacklisted_tag_types
     blacklist = YAML.load_file("#{Rails.root}/config/blacklisted-tag-types.yml")
     document_blacklist = Array(blacklist[publishing_app]).map(&:to_sym)
@@ -42,6 +48,10 @@ class ContentItem
 
     unless related_links_are_renderable
       document_blacklist += [:ordered_related_items]
+    end
+
+    unless taxons?
+      document_blacklist += [:ordered_related_items_overrides]
     end
 
     document_blacklist

--- a/spec/features/related_item_tagging_spec.rb
+++ b/spec/features/related_item_tagging_spec.rb
@@ -100,7 +100,6 @@ RSpec.describe "Tagging content", type: :feature do
     then_the_publishing_api_is_sent(
       taxons: [],
       ordered_related_items: ['a484eaea-eeb6-48fa-92a7-b67c6cd414f6'],
-      ordered_related_items_overrides: [],
       mainstream_browse_pages: [],
       parent: [],
       topics: [],

--- a/spec/features/tag_a_page_spec.rb
+++ b/spec/features/tag_a_page_spec.rb
@@ -24,7 +24,6 @@ RSpec.describe "Tagging content", type: :feature do
     then_the_publishing_api_is_sent(
       taxons: [],
       ordered_related_items: [],
-      ordered_related_items_overrides: [],
       mainstream_browse_pages: [],
       parent: [],
       topics: ["e1d6b771-a692-4812-a4e7-7562214286ef", example_topic['content_id']],
@@ -43,7 +42,6 @@ RSpec.describe "Tagging content", type: :feature do
     then_the_publishing_api_is_sent(
       taxons: [],
       ordered_related_items: [],
-      ordered_related_items_overrides: [],
       mainstream_browse_pages: [],
       parent: [],
       topics: ["e1d6b771-a692-4812-a4e7-7562214286ef"],
@@ -90,7 +88,6 @@ RSpec.describe "Tagging content", type: :feature do
       then_the_publishing_api_is_sent(
         taxons: [],
         ordered_related_items: [example_topic["content_id"], "a484eaea-eeb6-48fa-92a7-b67c6cd414f6"],
-        ordered_related_items_overrides: [],
         mainstream_browse_pages: [],
         parent: [],
         topics: [],

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -1,6 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe ContentItem do
+  let(:content_item) do
+    ContentItem.new(
+      content_item_params
+    ).tap do |content_item|
+      content_item.link_set = Tagging::ContentItemExpandedLinks.new(link_set_params)
+    end
+  end
+
   let(:content_item_params) do
     {
       'content_id'     => 'uuid-88',
@@ -13,81 +21,92 @@ RSpec.describe ContentItem do
     }
   end
 
+  let(:link_set_params) do
+    {
+      'content_id'     => 'uuid-88',
+      'previous_version' => 0,
+    }
+  end
+
   describe "#blacklisted_tag_types" do
-    context "for apps in the blacklist" do
-      let(:content_item) do
-        ContentItem.new(
-          content_item_params.merge('publishing_app' => 'travel-advice-publisher')
-        )
+    context "without taxons" do
+      let(:content_item_params) do
+        super().merge('publishing_app' => 'not-in-the-blacklist')
       end
 
-      it "returns the blacklisted fields" do
-        expect(content_item.blacklisted_tag_types).to eq [:parent]
+      it "blacklists related item overrides for content not tagged to taxons" do
+        expect(content_item.blacklisted_tag_types).to eq [:ordered_related_items_overrides]
       end
     end
 
-    context "for apps not in the blacklist" do
-      let(:content_item) do
-        ContentItem.new(
-          content_item_params.merge('publishing_app' => 'not-in-the-blacklist')
-        )
+    context "with taxons" do
+      let(:link_set_params) do
+        super().merge('taxons' => ["6fde156c-98f3-4045-ac21-c64fcf1677e5"])
       end
 
-      it "returns an empty list" do
-        expect(content_item.blacklisted_tag_types).to eq []
-      end
-    end
+      context "for apps in the blacklist" do
+        let(:content_item_params) do
+          super().merge('publishing_app' => 'travel-advice-publisher')
+        end
 
-    context "for rendering apps with a sidebar" do
-      let(:content_item) do
-        ContentItem.new(
-          content_item_params.merge('publishing_app' => 'not-in-the-blacklist', 'rendering_app' => 'frontend')
-        )
+        it "returns the blacklisted fields" do
+          expect(content_item.blacklisted_tag_types).to eq [:parent]
+        end
       end
 
-      it "returns an empty list" do
-        expect(content_item.blacklisted_tag_types).to eq []
-      end
-    end
+      context "for apps not in the blacklist" do
+        let(:content_item_params) do
+          super().merge('publishing_app' => 'not-in-the-blacklist')
+        end
 
-    context "for rendering apps without a sidebar" do
-      let(:content_item) do
-        ContentItem.new(
-          content_item_params.merge('publishing_app' => 'not-in-the-blacklist', 'rendering_app' => 'whitehall-frontend')
-        )
+        it "returns an empty list" do
+          expect(content_item.blacklisted_tag_types).to eq []
+        end
       end
 
-      it "blacklists related items" do
-        expect(content_item.blacklisted_tag_types).to eq [:ordered_related_items]
-      end
-    end
+      context "for rendering apps with a sidebar" do
+        let(:content_item_params) do
+          super().merge('publishing_app' => 'not-in-the-blacklist', 'rendering_app' => 'frontend')
+        end
 
-    context "for finder blacklisting during specialist-publisher migration" do
-      let(:content_item) do
-        ContentItem.new(
-          content_item_params.merge(
+        it "returns an empty list" do
+          expect(content_item.blacklisted_tag_types).to eq []
+        end
+      end
+
+      context "for rendering apps without a sidebar" do
+        let(:content_item_params) do
+          super().merge('publishing_app' => 'not-in-the-blacklist', 'rendering_app' => 'whitehall-frontend')
+        end
+
+        it "blacklists related items" do
+          expect(content_item.blacklisted_tag_types).to eq [:ordered_related_items]
+        end
+      end
+
+      context "for finder blacklisting during specialist-publisher migration" do
+        let(:content_item_params) do
+          super().merge(
             'publishing_app' => 'specialist-publisher',
             'document_type' => 'finder',
           )
-        )
+        end
+
+        it "blacklists topics as well as other tag types" do
+          expect(content_item.blacklisted_tag_types).to include :topics
+        end
       end
 
-      it "blacklists topics as well as other tag types" do
-        expect(content_item.blacklisted_tag_types).to include :topics
-      end
-    end
-
-    context 'for the publisher app' do
-      let(:content_item) do
-        ContentItem.new(
-          content_item_params.merge(
+      context 'for the publisher app' do
+        let(:content_item_params) do
+          super().merge(
             'publishing_app' => 'publisher',
           )
-        )
-      end
+        end
 
-      it 'does not blacklist any tag types' do
-        expect(content_item.blacklisted_tag_types).to be_empty
+        it 'does not blacklist any tag types' do
+          expect(content_item.blacklisted_tag_types).to be_empty
+        end
       end
     end
   end

--- a/spec/services/tagging/tagging_update_publisher_spec.rb
+++ b/spec/services/tagging/tagging_update_publisher_spec.rb
@@ -20,11 +20,12 @@ RSpec.describe Tagging::TaggingUpdatePublisher do
       expect_links_to_have_been_published(ordered_related_items: [content_id], ordered_related_items_overrides: [content_id])
     end
 
-    it "generates a valid links payload using ordered_related_items" do
+    it "generates a valid links payload using ordered_related_items and overrides" do
       stub_content_id_lookup("/my-page" => content_id)
 
       publisher = Tagging::TaggingUpdatePublisher.new(
         stubbed_content_item,
+        taxons: ["0ffd5e18-af20-4413-a215-8511cf7628b5"],
         ordered_related_items: ["/my-page"],
         ordered_related_items_overrides: ["/my-page"]
       )


### PR DESCRIPTION
This tag type is only used when content is already tagged to a taxon. With the
new navigation, we automagically generate related links by default. The
overrides are used after previewing those, if they're no good.

For content not tagged to the taxonomy, the overrides have no effect.

Trello: https://trello.com/c/vM6Kaw9B/505-ias-and-content-designers-can-curate-related-links-for-any-content-type