### PR TITLE
Rake task to upload the parenting and childcare taxonomy

### DIFF
--- a/app/services/parenting_childcare/build_taxon.rb
+++ b/app/services/parenting_childcare/build_taxon.rb
@@ -1,0 +1,20 @@
+module ParentingChildcare
+  class BuildTaxon
+    def self.build(title:, description:, prefix:)
+      taxon_params = {
+        path_prefix: prefix,
+        path_slug: "/" + title.strip.downcase.tr(" ", "-").gsub(/[^\w-]/, ''),
+        internal_name: title,
+        title: title,
+        description: description || 'TBC'
+      }
+
+      taxon = Taxon.new(taxon_params)
+      puts " => Creating '#{taxon.title}'"
+
+      Taxonomy::PublishTaxon.call(taxon: taxon)
+
+      taxon
+    end
+  end
+end

--- a/app/services/parenting_childcare/build_theme.rb
+++ b/app/services/parenting_childcare/build_theme.rb
@@ -1,0 +1,18 @@
+module ParentingChildcare
+  class BuildTheme
+    def self.build
+      theme_params = {
+        path_prefix: '/parenting-childcare',
+        path_slug: '',
+        internal_name: "Parenting, childcare and childrens services",
+        title: "Parenting, childcare and childrens services",
+        description: 'Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.'
+      }
+      theme = Taxon.new(theme_params)
+      puts "Creating theme '#{theme.title}'"
+      Taxonomy::PublishTaxon.call(taxon: theme)
+
+      theme
+    end
+  end
+end

--- a/lib/tasks/taxonomy/upload.rake
+++ b/lib/tasks/taxonomy/upload.rake
@@ -1,0 +1,46 @@
+require 'csv'
+
+namespace :taxonomy do
+  namespace :parenting_and_childcare do
+    desc "Create top level theme and upload taxons from a remote CSV file (title, description and parent)"
+    task :upload_taxons, [:path] => [:environment] do |_, args|
+      puts "Creating the top level theme..."
+      theme = ParentingChildcare::BuildTheme.build
+      taxons_by_title = {}
+      taxons_by_title[theme.title] = theme
+
+      puts "Read taxonomy data (taxon title, description and parent)..."
+      raw_data = open(args[:path])
+      rows = CSV.parse(raw_data, col_sep: "\t", headers: true)
+
+      puts "Creating all taxons..."
+      rows.each do |row|
+        taxon = ParentingChildcare::BuildTaxon.build(
+          title: row['taxon'],
+          description: row['description'],
+          prefix: theme.base_path
+        )
+
+        taxons_by_title[taxon.title] = taxon
+      end
+
+      puts "Updating taxons with parents..."
+      rows.each do |row|
+        parent_title = row['parent_taxon']
+        taxon = taxons_by_title[row['taxon']]
+
+        if parent_title.nil?
+          puts " => No parent found for '#{taxon.title}, skipping..."
+          next
+        end
+
+        puts " => Updating '#{taxon.title}' with '#{parent_title}'"
+        parent_base_path = taxons_by_title[parent_title].base_path
+        content_id = Services.publishing_api.lookup_content_id(base_path: parent_base_path)
+
+        taxon.parent_taxons << content_id
+        Taxonomy::PublishTaxon.call(taxon: taxon)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This rake task takes a CSV file containing taxon titles, descriptions
and parents, and creates them in content tagger.

The reason for this task is so we can upload the new taxonomy to staging
and perform a data dump for the prototype. It will also let us bulk tag
all pieces of content related to the parenting and childcare branch, so
they are available in search. This way, we can point the prototype to
staging and be able to show both scoped search results and related
links.

**NOTE**: this rake task is temporary and only needed until we can
create draft taxons live. Since the prototype will be tested before
that's available, we need it as a temporary step.

There is no need to merge this branch, as it can be deployed to integration and staging as it is.