### PR TITLE
Show list of draft taxons

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -49,3 +49,9 @@ $red: #b10e1e;
 .left-space {
   margin-left: 5px;
 }
+
+// taxons page
+
+.nav.nav-tabs {
+  margin-bottom: 20px;
+}

--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -1,4 +1,5 @@
 class TaxonsController < ApplicationController
+  # TODO: deduplicate code between index, drafts, trash
   def index
     search_results = remote_taxons.search(
       page: params[:page],
@@ -16,6 +17,25 @@ class TaxonsController < ApplicationController
     render :index, locals: locals
   end
 
+  # TODO: deduplicate code between index, drafts, trash
+  def drafts
+    search_results = remote_taxons.search(
+      page: params[:page],
+      per_page: params[:per_page],
+      query: query,
+      states: ['draft']
+    )
+
+    locals = {
+      taxons: search_results.taxons,
+      search_results: search_results,
+      query: query,
+    }
+
+    render :drafts, locals: locals
+  end
+
+  # TODO: deduplicate code between index, drafts, trash
   def trash
     search_results = remote_taxons.search(
       page: params[:page],

--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -24,6 +24,10 @@ class Taxon
     @parent_taxons ||= []
   end
 
+  def draft?
+    publication_state == "draft"
+  end
+
   def content_id
     @content_id ||= SecureRandom.uuid
   end

--- a/app/views/taxons/drafts.html.erb
+++ b/app/views/taxons/drafts.html.erb
@@ -1,0 +1,38 @@
+<%= display_header title: "Draft taxons", breadcrumbs: [t('navigation.taxons')] %>
+
+<ul class="nav nav-tabs">
+  <li role="presentation"><%= link_to "Published", taxons_path %></li>
+  <li role="presentation" class="active"><%= link_to "Draft", drafts_taxons_path %></li>
+  <li role="presentation"><%= link_to "Deleted", trash_taxons_path %></li>
+</ul>
+
+<%= simple_form_for :taxon_search, url: drafts_taxons_path, method: :get do |f| %>
+  <div class="form-group">
+    <%= f.input :query,
+      input_html: { type: :text, class: 'form-control', value: query },
+      label: false %>
+    <%= f.submit "Search deleted taxons", class: "btn btn-md btn-success" %>
+  </div>
+<% end %>
+
+<table class="table queries-list table-bordered table-striped">
+  <thead>
+    <tr class="table-header">
+      <th>Taxon</th>
+      <th></th>
+      <th></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% taxons.each do |taxon| %>
+      <tr>
+        <td><%= taxon.internal_name %></td>
+        <td><%= link_to I18n.t('views.taxons.view'), taxon_path(taxon.content_id) %></td>
+        <td><%= link_to I18n.t('views.taxons.edit'), edit_taxon_path(taxon.content_id) %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<%= paginate search_results, theme: 'twitter-bootstrap-3' %>

--- a/app/views/taxons/edit.html.erb
+++ b/app/views/taxons/edit.html.erb
@@ -12,5 +12,11 @@
        path_prefixes_for_select: path_prefixes_for_select,
      } %>
 
+  <% if taxon.draft? %>
+    <div class="alert alert-danger clearfix" role="warning">
+      WARNING: This is a draft taxon. Saving it will also publish it.
+    </div>
+  <% end %>
+
   <%= f.submit I18n.t('views.taxons.edit_button'), class: "btn btn-lg btn-success" %>
 <% end %>

--- a/app/views/taxons/index.html.erb
+++ b/app/views/taxons/index.html.erb
@@ -8,6 +8,7 @@
 
 <ul class="nav nav-tabs">
   <li role="presentation" class="active"><%= link_to "Published", taxons_path %></li>
+  <li role="presentation"><%= link_to "Draft", drafts_taxons_path %></li>
   <li role="presentation"><%= link_to "Deleted", trash_taxons_path %></li>
 </ul>
 

--- a/app/views/taxons/index.html.erb
+++ b/app/views/taxons/index.html.erb
@@ -4,10 +4,12 @@
       <%= I18n.t('views.taxons.add_taxon') %>
     </i>
   <% end %>
-  <%= link_to trash_taxons_path, class: 'btn btn-default' do %>
-    <%= I18n.t('views.taxons.view_deleted_taxons') %>
-  <% end %>
 <% end %>
+
+<ul class="nav nav-tabs">
+  <li role="presentation" class="active"><%= link_to "Published", taxons_path %></li>
+  <li role="presentation"><%= link_to "Deleted", trash_taxons_path %></li>
+</ul>
 
 <div class="lead">
   Search for a taxon to see its place in the taxonomy, edit the taxon or move its content.

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -12,9 +12,11 @@
     <%= I18n.t('views.taxons.download_csv') %>
   <% end %>
 
-  <%= link_to taxon_confirm_delete_path(taxon.content_id), class: 'btn btn-md btn-default' do %>
-    <i class="glyphicon glyphicon-trash"></i>
-    <%= I18n.t('views.taxons.delete_taxon') %>
+  <% unless taxon.draft? %>
+    <%= link_to taxon_confirm_delete_path(taxon.content_id), class: 'btn btn-md btn-default' do %>
+      <i class="glyphicon glyphicon-trash"></i>
+      <%= I18n.t('views.taxons.delete_taxon') %>
+    <% end %>
   <% end %>
 <% end %>
 

--- a/app/views/taxons/trash.html.erb
+++ b/app/views/taxons/trash.html.erb
@@ -1,8 +1,9 @@
-<%= display_header title: t('views.taxons.deleted_title'), breadcrumbs: [t('navigation.taxons')] do %>
-  <%= link_to taxons_path, class: 'btn btn-default' do %>
-    <%= I18n.t('views.taxons.view_live_taxons') %>
-  <% end %>
-<% end %>
+<%= display_header title: t('views.taxons.deleted_title'), breadcrumbs: [t('navigation.taxons')] %>
+
+<ul class="nav nav-tabs">
+  <li role="presentation"><%= link_to "Published", taxons_path %></li>
+  <li role="presentation" class="active"><%= link_to "Deleted", trash_taxons_path %></li>
+</ul>
 
 <div class="lead">
   Search for a deleted taxon to restore it.

--- a/app/views/taxons/trash.html.erb
+++ b/app/views/taxons/trash.html.erb
@@ -2,6 +2,7 @@
 
 <ul class="nav nav-tabs">
   <li role="presentation"><%= link_to "Published", taxons_path %></li>
+  <li role="presentation"><%= link_to "Draft", drafts_taxons_path %></li>
   <li role="presentation" class="active"><%= link_to "Deleted", trash_taxons_path %></li>
 </ul>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -66,8 +66,6 @@ en:
       deleted_title: Deleted taxons
       edit: Edit taxon
       view: View taxon
-      view_live_taxons: View live taxons
-      view_deleted_taxons: View deleted taxons
       add_taxon: Add a taxon
       copy_taxon: Export taxons with IDs for spreadsheet
       delete_taxon: Delete taxon

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
     get :confirm_delete
     get :restore
     get :trash, on: :collection
+    get :drafts, on: :collection
   end
 
   resources :copy_taxons, only: [:index], path: 'copy-taxons'

--- a/spec/features/draft_taxons_spec.rb
+++ b/spec/features/draft_taxons_spec.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+
+RSpec.feature "Draft taxonomy" do
+  include PublishingApiHelper
+  include ContentItemHelper
+
+  scenario "User can see draft taxons" do
+    given_there_are_draft_taxons
+    when_i_visit_the_draft_taxonomy_page
+    then_i_can_see_the_draft_taxons
+  end
+
+  def given_there_are_draft_taxons
+    @taxon_1 = content_item_with_details(
+      "I Am A Taxon 1",
+      other_fields: {
+        content_id: "ID-1",
+        base_path: "/foo",
+        publication_state: 'active'
+      }
+    )
+    @taxon_2 = content_item_with_details(
+      "I Am Another Taxon 2",
+      other_fields: {
+        content_id: "ID-2",
+        base_path: "/bar",
+        publication_state: 'active'
+      }
+    )
+    @taxon_3 = content_item_with_details(
+      "I Am Yet Another Taxon 3",
+      other_fields: {
+        content_id: "ID-3",
+        base_path: "/bar",
+        publication_state: 'active'
+      }
+    )
+
+    publishing_api_has_taxons(
+      [@taxon_1, @taxon_2, @taxon_3],
+      page: 1,
+      states: ["draft"]
+    )
+  end
+
+  def when_i_visit_the_draft_taxonomy_page
+    visit drafts_taxons_path
+  end
+
+  def then_i_can_see_the_draft_taxons
+    expect(page).to have_text(@taxon_1[:title])
+    expect(page).to have_text(@taxon_2[:title])
+    expect(page).to have_text(@taxon_3[:title])
+  end
+end


### PR DESCRIPTION
This shows the user a list of draft taxons. Also changes the interface to navigate between the lists of taxons in live/draft/deleted state.

Note that it's currently not possible for users to create draft taxons, they're instantly published on creation. Functionality to create drafts and publish them will be implemented in a separate PR.  

## Before

![screen shot 2017-03-21 at 11 22 24](https://cloud.githubusercontent.com/assets/233676/24145348/b27c9e2c-0e28-11e7-842e-4124fbfb4fdd.png)

## After

![screen shot 2017-03-21 at 11 22 15](https://cloud.githubusercontent.com/assets/233676/24145347/b27667e6-0e28-11e7-84d3-0077d2e987bf.png)

![screen shot 2017-03-21 at 11 24 15](https://cloud.githubusercontent.com/assets/233676/24145420/f0c6d4fe-0e28-11e7-8cdd-b789d2261f29.png)


https://trello.com/c/8YH5l9kF