### PR TITLE
Add rake task to register a taxonomy email signup page

### DIFF
--- a/app/presenters/taxonomy/email_signup_page.rb
+++ b/app/presenters/taxonomy/email_signup_page.rb
@@ -29,7 +29,7 @@ module Taxonomy
     end
 
     def base_path
-      '/taxonomy-email-signup'
+      '/email-signup'
     end
 
     def routes

--- a/app/presenters/taxonomy/email_signup_page.rb
+++ b/app/presenters/taxonomy/email_signup_page.rb
@@ -1,0 +1,42 @@
+module Taxonomy
+  class EmailSignupPage
+    def payload
+      # The base_path and routes specified here are the only important values -
+      # we want to ensure the specified path is reserved correctly via the
+      # publishing-api. All other fields are populated with nominal values,
+      # particularly the details hash which needs to satisfy the schema
+      # definition for an email_alert_signup.
+      {
+        base_path: base_path,
+        document_type: 'email_alert_signup',
+        schema_name: 'email_alert_signup',
+        title: 'Get email alerts',
+        description: '',
+        locale: 'en',
+        public_updated_at: DateTime.now.iso8601,
+        publishing_app: 'content-tagger',
+        rendering_app: 'email-alert-frontend',
+        routes: routes,
+        details: {
+          summary: '',
+          subscriber_list: { 'taxons' => [] },
+        },
+      }
+    end
+
+    def content_id
+      'e3bf851b-5df7-441b-8813-f0ec849da35f'
+    end
+
+    def base_path
+      '/taxonomy-email-signup'
+    end
+
+    def routes
+      [
+        { path: base_path, type: 'exact' },
+        { path: "#{base_path}/confirm", type: 'exact' },
+      ]
+    end
+  end
+end

--- a/lib/tasks/taxonomy/register_email_signup_page.rake
+++ b/lib/tasks/taxonomy/register_email_signup_page.rake
@@ -1,0 +1,46 @@
+namespace :taxonomy do
+  desc <<-DESC
+    Register a content item representing the email-alert-frontend endpoint that
+    handles taxonomy email alert subscriptions
+  DESC
+  task register_email_signup_page: :environment do
+    def base_path
+      '/taxonomy-email-signup'
+    end
+
+    def routes
+      [
+        { path: base_path, type: "exact" },
+        { path: "#{base_path}/confirm", type: "exact" },
+      ]
+    end
+
+    # The base_path and routes specified here are the only important values -
+    # we want to ensure the specified path is reserved correctly via the
+    # publishing-api. All other fields are populated with nominal values,
+    # particularly the details hash which needs to satisfy the schema
+    # definition for an email_alert_signup.
+    email_signup_page = {
+      base_path: base_path,
+      document_type: 'email_alert_signup',
+      schema_name: 'email_alert_signup',
+      title: 'Get email alerts',
+      description: '',
+      locale: 'en',
+      need_ids: [],
+      public_updated_at: DateTime.now.iso8601,
+      publishing_app: 'content-tagger',
+      rendering_app: 'email-alert-frontend',
+      routes: routes,
+      details: {
+        summary: '',
+        subscriber_list: { 'taxons' => [] },
+      },
+    }
+
+    content_id = 'e3bf851b-5df7-441b-8813-f0ec849da35f'
+
+    Services.publishing_api.put_content(content_id, email_signup_page)
+    Services.publishing_api.publish(content_id, 'major')
+  end
+end

--- a/lib/tasks/taxonomy/register_email_signup_page.rake
+++ b/lib/tasks/taxonomy/register_email_signup_page.rake
@@ -4,43 +4,9 @@ namespace :taxonomy do
     handles taxonomy email alert subscriptions
   DESC
   task register_email_signup_page: :environment do
-    def base_path
-      '/taxonomy-email-signup'
-    end
+    signup_page = Taxonomy::EmailSignupPage.new
 
-    def routes
-      [
-        { path: base_path, type: "exact" },
-        { path: "#{base_path}/confirm", type: "exact" },
-      ]
-    end
-
-    # The base_path and routes specified here are the only important values -
-    # we want to ensure the specified path is reserved correctly via the
-    # publishing-api. All other fields are populated with nominal values,
-    # particularly the details hash which needs to satisfy the schema
-    # definition for an email_alert_signup.
-    email_signup_page = {
-      base_path: base_path,
-      document_type: 'email_alert_signup',
-      schema_name: 'email_alert_signup',
-      title: 'Get email alerts',
-      description: '',
-      locale: 'en',
-      need_ids: [],
-      public_updated_at: DateTime.now.iso8601,
-      publishing_app: 'content-tagger',
-      rendering_app: 'email-alert-frontend',
-      routes: routes,
-      details: {
-        summary: '',
-        subscriber_list: { 'taxons' => [] },
-      },
-    }
-
-    content_id = 'e3bf851b-5df7-441b-8813-f0ec849da35f'
-
-    Services.publishing_api.put_content(content_id, email_signup_page)
-    Services.publishing_api.publish(content_id, 'major')
+    Services.publishing_api.put_content(signup_page.content_id, signup_page.payload)
+    Services.publishing_api.publish(signup_page.content_id, 'major')
   end
 end

--- a/spec/presenters/taxonomy/email_signup_page_spec.rb
+++ b/spec/presenters/taxonomy/email_signup_page_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe Taxonomy::EmailSignupPage do
+  describe '#payload' do
+    it 'conforms to the email_alert_signup schema' do
+      expect(Taxonomy::EmailSignupPage.new.payload)
+        .to be_valid_against_schema('email_alert_signup')
+    end
+  end
+end


### PR DESCRIPTION
Create a content item at the base path /taxonomy-email-signup. The
email-alert-frontend app will be updated to serve signup pages at this
endpoint, allowing users to subscribe to content changes in the
taxonomy.

https://trello.com/c/lPlSbZnX/166-3-build-3-types-of-sign-up-pages-backend