### PR TITLE
Redirect the user to the created taxon page after create

### DIFF
--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -30,7 +30,7 @@ class TaxonsController < ApplicationController
 
     if taxon.valid?
       Taxonomy::PublishTaxon.call(taxon: taxon)
-      redirect_to(taxons_path)
+      redirect_to taxon_path(taxon.content_id), success: t('controllers.taxons.create_success')
     else
       error_messages = taxon.errors.full_messages.join('; ')
       flash[:danger] = error_messages

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -105,6 +105,7 @@ en:
     tag_migrations:
       import_removed: Tag migration import has been removed.
     taxons:
+      create_success: You have sucessfully created a taxon
       destroy_success: You have sucessfully deleted the taxon
       destroy_alert: It was not possible to delete the taxon
       restore_success: You have sucessfully restored the taxon

--- a/spec/features/taxonomy_editing_spec.rb
+++ b/spec/features/taxonomy_editing_spec.rb
@@ -149,6 +149,17 @@ RSpec.feature "Taxonomy editing" do
   end
 
   def when_i_submit_the_taxon_with_a_title_and_parents
+    # After the taxon is created we'll be redirected to the taxon's "view" page
+    # which needs a bunch of API calls stubbed.
+    stub_request(:get, %r{https://publishing-api.test.gov.uk/v2/content/*})
+      .to_return(body: { content_id: "", title: "Hey", base_path: "/foo", details: { internal_name: "Foo" } }.to_json)
+    stub_request(:get, %r{https://publishing-api.test.gov.uk/v2/links/*})
+      .to_return(body: {}.to_json)
+    stub_request(:get, %r{https://publishing-api.test.gov.uk/v2/expanded-links/*})
+      .to_return(body: { expanded_links: {} }.to_json)
+    stub_request(:get, %r{https://publishing-api.test.gov.uk/v2/linked/*})
+      .to_return(body: {}.to_json)
+
     fill_in :taxon_title, with: "My Lovely Taxon"
     fill_in :taxon_description, with: "A description of my lovely taxon."
     fill_in :taxon_internal_name, with: "My Lovely Taxon"
@@ -212,6 +223,7 @@ RSpec.feature "Taxonomy editing" do
     expect(@create_item).to have_been_requested
     expect(@publish_item).to have_been_requested
     expect(@create_links).to have_been_requested
+    expect(page).to have_content I18n.t('controllers.taxons.create_success')
   end
 
   def then_my_taxon_is_updated


### PR DESCRIPTION
Currently if you create a taxon, you'll be redirected to the taxons index page.

This commit makes it so that the user redirects to the newly created taxon page. This will allow the user to perform additional actions. It also makes it clear that the taxon has been created.

https://trello.com/c/8YH5l9kF