### PR TITLE
Show the theme of the taxon on index page

### DIFF
--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -24,6 +24,10 @@ class Taxon
     @parent_taxons ||= []
   end
 
+  def theme
+    Theme::THEMES[path_prefix] || "Other"
+  end
+
   def draft?
     publication_state == "draft"
   end

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -1,8 +1,10 @@
 class Theme
+  THEMES = {
+    '/childcare-parenting' => 'Childcare and Parenting',
+    '/education' => 'Education',
+  }.freeze
+
   def self.taxon_path_prefixes
-    [
-      '/childcare-parenting',
-      '/education',
-    ]
+    THEMES.keys
   end
 end

--- a/app/views/taxons/index.html.erb
+++ b/app/views/taxons/index.html.erb
@@ -28,6 +28,7 @@
 <table class="table queries-list table-bordered table-striped">
   <thead>
     <tr class="table-header">
+      <th>Theme</th>
       <th>Taxon</th>
       <th></th>
       <th></th>
@@ -38,6 +39,7 @@
   <tbody>
     <% taxons.each do |taxon| %>
       <tr>
+        <td><%= taxon.theme %></td>
         <td><%= taxon.internal_name %></td>
         <td><%= link_to I18n.t('views.taxons.view'), taxon_path(taxon.content_id) %></td>
         <td><%= link_to I18n.t('views.taxons.edit'), edit_taxon_path(taxon.content_id) %></td>

--- a/spec/models/taxon_spec.rb
+++ b/spec/models/taxon_spec.rb
@@ -86,4 +86,12 @@ RSpec.describe Taxon do
     expect(invalid_taxon).to_not be_valid
     expect(invalid_taxon.errors.keys).to include(:path_slug)
   end
+
+  describe '#theme' do
+    it "returns the theme" do
+      taxon = Taxon.new(base_path: "/education/foo")
+
+      expect(taxon.theme).to eql("Education")
+    end
+  end
 end


### PR DESCRIPTION
This adds the "theme" of the taxon to the index page. This makes it easier to differentiate them while we're building new taxonomies.

cc @samdub

## Before

![screen shot 2017-03-21 at 18 47 03](https://cloud.githubusercontent.com/assets/233676/24164861/ce3a939c-0e66-11e7-9772-9c740bd63c44.png)

## After

![screen shot 2017-03-21 at 18 46 56](https://cloud.githubusercontent.com/assets/233676/24164859/cd08b972-0e66-11e7-93d1-7b949b4962aa.png)


https://trello.com/c/8YH5l9kF