### PR TITLE
Remove business-support-finder

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -73,7 +73,6 @@ private
       licencefinder
       frontend
       multipage-frontend
-      businesssupportfinder
       calculators
     ).include?(rendering_app)
   end


### PR DESCRIPTION
This commit removes business-support-finder, which has been replaced with finder-frontend.

Trello: https://trello.com/c/9O34PdXb/547-remove-business-support-finder-application