### PR TITLE
Add grey banner for taxon state changes

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -9,6 +9,7 @@ $red: #b10e1e;
 @import 'forms';
 @import 'taxonomy-tree';
 @import 'related-item-tagging';
+@import 'views/taxon';
 
 .error-message {
   color: $red;

--- a/app/assets/stylesheets/views/taxon.scss
+++ b/app/assets/stylesheets/views/taxon.scss
@@ -1,0 +1,11 @@
+.state-box {
+  .state {
+    font-weight: bold;
+    margin-right: 40px;
+    display: inline-block;
+  }
+
+  .delete-link {
+    float: right;
+  }
+}

--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -40,6 +40,14 @@ class Taxon
     publication_state == "unpublished"
   end
 
+  def publication_state_name
+    {
+      "draft" => "Draft",
+      "published" => "Published",
+      "unpublished" => "Deleted",
+    }.fetch(publication_state)
+  end
+
   def content_id
     @content_id ||= SecureRandom.uuid
   end

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -14,7 +14,7 @@
 <% end %>
 
 <div class="well state-box">
-  <div class="state">State: <%= taxon.publication_state %></div>
+  <div class="state">State: <%= taxon.publication_state_name %></div>
   <% if taxon.published? %>
     <%= link_to "Delete", taxon_confirm_delete_path(taxon.content_id), class: 'delete-link' %>
   <% elsif taxon.draft? %>

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -11,22 +11,22 @@
     <i class="glyphicon glyphicon-download-alt"></i>
     <%= I18n.t('views.taxons.download_csv') %>
   <% end %>
+<% end %>
 
-  <% if taxon.draft? %>
+<div class="well state-box">
+  <div class="state">State: <%= taxon.publication_state %></div>
+  <% if taxon.published? %>
+    <%= link_to "Delete", taxon_confirm_delete_path(taxon.content_id), class: 'delete-link' %>
+  <% elsif taxon.draft? %>
     <%= link_to taxon_confirm_publish_path(taxon.content_id), class: 'btn btn-md btn-default' do %>
-      Publish taxon
+      Publish
     <% end %>
   <% elsif taxon.unpublished? %>
     <%= link_to taxon_restore_path(taxon.content_id), class: 'btn btn-md btn-default' do %>
-      <%= I18n.t('views.taxons.restore_taxon') %>
-    <% end %>
-  <% elsif taxon.published? %>
-    <%= link_to taxon_confirm_delete_path(taxon.content_id), class: 'btn btn-md btn-default' do %>
-      <i class="glyphicon glyphicon-trash"></i>
-      <%= I18n.t('views.taxons.delete_taxon') %>
+      Restore
     <% end %>
   <% end %>
-<% end %>
+</div>
 
 <h3><%= t('views.taxons.tree') %></h3>
 

--- a/spec/features/delete_taxon_spec.rb
+++ b/spec/features/delete_taxon_spec.rb
@@ -103,12 +103,12 @@ RSpec.feature "Delete Taxon", type: :feature do
   end
 
   def when_i_click_delete_taxon
-    click_on "Delete taxon"
+    click_on "Delete"
   end
 
   def when_i_click_restore_taxon
     @put_content_request = stub_publishing_api_put_content(@taxon_content_id, {})
-    click_link "Restore taxon"
+    click_link "Restore"
   end
 
   def then_i_see_a_basic_prompt_to_delete

--- a/spec/features/draft_taxons_spec.rb
+++ b/spec/features/draft_taxons_spec.rb
@@ -90,7 +90,7 @@ RSpec.feature "Draft taxonomy" do
   end
 
   def and_i_click_the_publish_button
-    click_link "Publish taxon"
+    click_link "Publish"
   end
 
   def and_i_confirm_that_i_want_to_publish

--- a/spec/features/taxonomy_editing_spec.rb
+++ b/spec/features/taxonomy_editing_spec.rb
@@ -146,7 +146,7 @@ RSpec.feature "Taxonomy editing" do
     # After the taxon is created we'll be redirected to the taxon's "view" page
     # which needs a bunch of API calls stubbed.
     stub_request(:get, %r{https://publishing-api.test.gov.uk/v2/content/*})
-      .to_return(body: { content_id: "", title: "Hey", base_path: "/foo", details: { internal_name: "Foo" } }.to_json)
+      .to_return(body: { content_id: "", title: "Hey", base_path: "/foo", publication_state: "published", details: { internal_name: "Foo" } }.to_json)
     stub_request(:get, %r{https://publishing-api.test.gov.uk/v2/links/*})
       .to_return(body: {}.to_json)
     stub_request(:get, %r{https://publishing-api.test.gov.uk/v2/expanded-links/*})


### PR DESCRIPTION
- Added a banner to show the taxon state to the taxon show pages.

Paired with @tijmenb 

https://trello.com/c/8YH5l9kF/517-epic-implement-the-draft-workflow-for-taxonomy

![screen shot 2017-03-22 at 14 10 40](https://cloud.githubusercontent.com/assets/12881990/24201893/5cc53bf6-0f09-11e7-93f9-712f09c1e563.png)
