### PR TITLE
Change workflow to publish published taxons immediately

### DIFF
--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -71,7 +71,12 @@ class TaxonsController < ApplicationController
 
     if taxon.valid?
       Taxonomy::UpdateTaxon.call(taxon: taxon)
-      redirect_to(taxons_path)
+
+      if params[:publish_taxon_on_save] == "true"
+        Services.publishing_api.publish(taxon.content_id, "major")
+      end
+
+      redirect_to taxon_path(taxon.content_id)
     else
       error_messages = taxon.errors.full_messages.join('; ')
       flash[:danger] = error_messages

--- a/app/views/taxons/edit.html.erb
+++ b/app/views/taxons/edit.html.erb
@@ -12,5 +12,10 @@
        path_prefixes_for_select: path_prefixes_for_select,
      } %>
 
-  <%= f.submit I18n.t('views.taxons.edit_button'), class: "btn btn-lg btn-success" %>
+  <% if taxon.published? %>
+    <input type="hidden" name="publish_taxon_on_save" value="true" />
+    <%= f.submit "Save & publish", class: "btn btn-lg btn-success submit-button" %>
+  <% else %>
+    <%= f.submit "Save draft", class: "btn btn-lg btn-success submit-button" %>
+  <% end %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -82,7 +82,6 @@ en:
       new_title: New taxon
       new_breadcrumb: New taxon
       new_button: Create taxon
-      edit_button: Update taxon
       download_csv: Download taxonomy as CSV
       confirm_deletion_title: You are about to delete
       confirm_deletion_restore: Deleted taxons can be restored.


### PR DESCRIPTION
When taxons were updated previously they were not immediately published.
This meant that if a user edited a published taxon it would appear
both in the published list and the draft list. Published taxons are now
published immediately when changes are made to them so that they only
appear in the published list.

[Trello card](https://trello.com/c/8YH5l9kF/517-epic-implement-the-draft-workflow-for-taxonomy)

Paired with @tijmenb 