### PR TITLE
Track which user performed an action

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,7 @@ class ApplicationController < ActionController::Base
 
   include GDS::SSO::ControllerMethods
   before_filter :require_signin_permission!
+  before_filter :set_authenticated_user_header
 
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
@@ -31,5 +32,9 @@ private
 
   def active_navigation_item
     controller_name
+  end
+
+  def set_authenticated_user_header
+    GdsApi::GovukHeaders.set_header(:x_govuk_authenticated_user, current_user.uid)
   end
 end


### PR DESCRIPTION
This commit adds the current user as a header to gds-api-adapters. The header will be passed down to publishing-api, which will save it in it's history (events & actions).

I tested this in development:

<img width="1552" alt="screen shot 2017-03-22 at 17 50 42" src="https://cloud.githubusercontent.com/assets/233676/24212728/33cde544-0f28-11e7-9fae-039387000dbb.png">

https://trello.com/c/HQ28fhrF