### PR TITLE
Update taxon show & view pages

### DIFF
--- a/app/views/taxons/index.html.erb
+++ b/app/views/taxons/index.html.erb
@@ -31,8 +31,6 @@
       <th>Theme</th>
       <th>Taxon</th>
       <th></th>
-      <th></th>
-      <th></th>
     </tr>
   </thead>
 
@@ -42,8 +40,6 @@
         <td><%= taxon.theme %></td>
         <td><%= taxon.internal_name %></td>
         <td><%= link_to I18n.t('views.taxons.view'), taxon_path(taxon.content_id) %></td>
-        <td><%= link_to I18n.t('views.taxons.edit'), edit_taxon_path(taxon.content_id) %></td>
-        <td><%= link_to I18n.t('views.taxons.move_content'), new_taxon_migration_path(source_content_id: taxon.content_id) %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -1,15 +1,17 @@
 <%= display_header title: page.title, breadcrumbs: [:taxons, page.taxon] do %>
-  <%= link_to I18n.t('views.taxons.edit'), edit_taxon_path(page.taxon_content_id), class: "btn btn-default"%>
+  <% unless page.unpublished? %>
+    <%= link_to I18n.t('views.taxons.edit'), edit_taxon_path(page.taxon_content_id), class: "btn btn-default"%>
 
-  <%= link_to new_taxon_migration_path(source_content_id: page.taxon_content_id),
-    class: 'btn btn-md btn-default' do %>
-    <i class="glyphicon glyphicon-move"></i>
-    <%= I18n.t('views.taxons.move_content') %>
-  <% end %>
+    <%= link_to new_taxon_migration_path(source_content_id: page.taxon_content_id),
+      class: 'btn btn-md btn-default' do %>
+      <i class="glyphicon glyphicon-move"></i>
+      <%= I18n.t('views.taxons.move_content') %>
+    <% end %>
 
-  <%= link_to taxonomy_path(page.taxon_content_id, format: :csv), class: "btn btn-default" do %>
-    <i class="glyphicon glyphicon-download-alt"></i>
-    <%= I18n.t('views.taxons.download_csv') %>
+    <%= link_to taxonomy_path(page.taxon_content_id, format: :csv), class: "btn btn-default" do %>
+      <i class="glyphicon glyphicon-download-alt"></i>
+      <%= I18n.t('views.taxons.download_csv') %>
+    <% end %>
   <% end %>
 <% end %>
 

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -30,14 +30,16 @@
   <% end %>
 </div>
 
-<h3><%= t('views.taxons.tree') %></h3>
+<% unless page.unpublished? %>
+  <h3><%= t('views.taxons.tree') %></h3>
 
-<%= render 'taxonomy_tree', taxonomy_tree: page.taxonomy_tree %>
+  <%= render 'taxonomy_tree', taxonomy_tree: page.taxonomy_tree %>
 
-<h3><%= t('views.taxons.tagged_content') %></h3>
+  <h3><%= t('views.taxons.tagged_content') %></h3>
 
-<% if page.tagged.any? %>
-  <%= render 'tagged_content', tagged: page.tagged %>
-<% else %>
-  <p class="no-content no-content-bordered">No content tagged to this taxon</p>
+  <% if page.tagged.any? %>
+    <%= render 'tagged_content', tagged: page.tagged %>
+  <% else %>
+    <p class="no-content no-content-bordered">No content tagged to this taxon</p>
+  <% end %>
 <% end %>

--- a/spec/features/taxonomy_editing_spec.rb
+++ b/spec/features/taxonomy_editing_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "Taxonomy editing" do
       other_fields: {
         content_id: "ID-1",
         base_path: "/education/1",
-        publication_state: 'active'
+        publication_state: 'published'
       }
     )
     @taxon_2 = content_item_with_details(
@@ -18,7 +18,7 @@ RSpec.feature "Taxonomy editing" do
       other_fields: {
         content_id: "ID-2",
         base_path: "/education/2",
-        publication_state: 'active'
+        publication_state: 'published'
       }
     )
     @linkable_taxon_1 = {
@@ -26,14 +26,14 @@ RSpec.feature "Taxonomy editing" do
       content_id: "ID-1",
       base_path: "/education/1",
       internal_name: "I Am A Taxon",
-      publication_state: 'active'
+      publication_state: 'published'
     }
     @linkable_taxon_2 = {
       title: "I Am Another Taxon",
       content_id: "ID-2",
       base_path: "/education/2",
       internal_name: "I Am Another Taxon",
-      publication_state: 'active'
+      publication_state: 'published'
     }
 
     @dummy_editor_notes = "Some usage notes for this taxon."
@@ -84,14 +84,9 @@ RSpec.feature "Taxonomy editing" do
 
   scenario "Taxon base path preview", js: true do
     given_there_are_taxons
-    when_i_visit_the_taxonomy_page
-    and_i_click_on_the_edit_taxon_link
+    and_i_visit_the_taxon_edit_page
     when_i_change_the_path_slug
     then_the_base_path_preview_is_updated
-  end
-
-  def and_i_click_on_the_edit_taxon_link
-    click_link(I18n.t('views.taxons.edit'), match: :prefer_exact)
   end
 
   def given_there_are_taxons


### PR DESCRIPTION
Things:

- Don't show buttons on deleted taxon pages
- Don't show tagged content on deleted taxon pages
- Remove "edit" & "move content" buttons entirely

## Before

<img width="1154" alt="screen shot 2017-03-23 at 16 00 02" src="https://cloud.githubusercontent.com/assets/233676/24257170/fde30d32-0fe1-11e7-900b-01f770f26a74.png">

## After

<img width="1154" alt="screen shot 2017-03-23 at 15 59 52" src="https://cloud.githubusercontent.com/assets/233676/24257169/fde28f24-0fe1-11e7-93b1-3feb6332d8ec.png">

https://trello.com/c/8YH5l9kF