### PR TITLE
Add link to navigation page on live/draft site

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -17,6 +17,7 @@ $red: #b10e1e;
 
 .view-on-site {
   font-size: 20px;
+  margin-bottom: 10px;
 
   a:after {
     content: "\A0\A0\A0";

--- a/app/services/taxonomy/show_page.rb
+++ b/app/services/taxonomy/show_page.rb
@@ -1,6 +1,6 @@
 module Taxonomy
   class ShowPage
-    delegate :content_id, :draft?, :published?, :unpublished?, to: :taxon
+    delegate :content_id, :draft?, :published?, :unpublished?, :base_path, to: :taxon
 
     attr_reader :taxon
 

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -13,6 +13,14 @@
   <% end %>
 <% end %>
 
+<div class='view-on-site'>
+  <% if page.published? %>
+    View on site: <%= link_to page.base_path, website_url(page.base_path) %>
+  <% elsif page.draft? %>
+    <%= link_to "View draft page", website_url(page.base_path, draft: true) %>
+  <% end %>
+</div>
+
 <div class="well state-box">
   <div class="state">State: <%= page.publication_state_name %></div>
   <% if page.published? %>


### PR DESCRIPTION
This adds links to the gov.uk live or draft site for taxons.

The pattern is the same as on the tag content page.

## Screenshots

<img width="1157" alt="screen shot 2017-03-23 at 16 41 55" src="https://cloud.githubusercontent.com/assets/233676/24259122/d9c00968-0fe7-11e7-8aae-b5ab6dd9c63c.png">
<img width="1156" alt="screen shot 2017-03-23 at 16 42 00" src="https://cloud.githubusercontent.com/assets/233676/24259120/d9baecee-0fe7-11e7-906c-df11b727e510.png">


https://trello.com/c/8YH5l9kF