### PR TITLE
Fix bug with specifying parents

### DIFF
--- a/app/services/taxonomy/build_taxon.rb
+++ b/app/services/taxonomy/build_taxon.rb
@@ -21,24 +21,16 @@ module Taxonomy
         publication_state: content_item['publication_state'],
         internal_name: content_item['details']['internal_name'],
         notes_for_editors: content_item['details']['notes_for_editors'],
-        parent_taxons: parent_taxons,
+        parent_taxons: content_item.dig("links", "parent_taxons") || [],
       )
     end
 
   private
 
-    def parent_taxons
-      links["parent_taxons"] || []
-    end
-
     def content_item
       @content_item ||= Services.publishing_api.get_content!(content_id)
     rescue GdsApi::HTTPNotFound => e
       raise(TaxonNotFoundError, e.message)
-    end
-
-    def links
-      @links ||= Services.publishing_api.get_links(content_id)['links'].to_h
     end
   end
 end

--- a/spec/features/copy_taxons_spec.rb
+++ b/spec/features/copy_taxons_spec.rb
@@ -32,9 +32,6 @@ RSpec.describe "Copying taxons for use in a spreadsheet" do
 
     publishing_api_has_linkables([@taxon_1, @taxon_2], document_type: 'taxon')
 
-    stub_request(:get, "https://publishing-api.test.gov.uk/v2/links/ID-1")
-      .to_return(body: { links: { parent_taxons: [] } }.to_json)
-
     empty_details = { "details" => {} }
 
     stub_request(:get, "https://publishing-api.test.gov.uk/v2/content/ID-1")

--- a/spec/features/taxonomy_editing_spec.rb
+++ b/spec/features/taxonomy_editing_spec.rb
@@ -101,9 +101,6 @@ RSpec.feature "Taxonomy editing" do
     )
     publishing_api_has_taxons([@taxon_1, @taxon_2])
 
-    stub_request(:get, "https://publishing-api.test.gov.uk/v2/links/ID-1")
-      .to_return(body: { links: { parent_taxons: [] } }.to_json)
-
     stub_request(:get, "https://publishing-api.test.gov.uk/v2/content/ID-1")
       .to_return(body: @taxon_1.to_json)
 
@@ -160,9 +157,6 @@ RSpec.feature "Taxonomy editing" do
     # dropdown of parent taxons
     stub_request(:get, "https://publishing-api.test.gov.uk/v2/linkables?document_type=taxon")
       .to_return(status: 200, body: "[]", headers: {})
-
-    stub_request(:get, "https://publishing-api.test.gov.uk/v2/links/ID-1")
-      .to_return(status: 200, body: "{}", headers: {})
   end
 
   def and_i_visit_the_taxon_edit_page
@@ -176,9 +170,6 @@ RSpec.feature "Taxonomy editing" do
     # dropdown of parent taxons
     stub_request(:get, "https://publishing-api.test.gov.uk/v2/linkables?document_type=taxon")
       .to_return(status: 200, body: "[]", headers: {})
-
-    stub_request(:get, "https://publishing-api.test.gov.uk/v2/links/ID-1")
-      .to_return(status: 200, body: "{}", headers: {})
   end
 
   def when_i_submit_the_taxon_with_a_title_and_parents
@@ -186,8 +177,6 @@ RSpec.feature "Taxonomy editing" do
     # which needs a bunch of API calls stubbed.
     stub_request(:get, %r{https://publishing-api.test.gov.uk/v2/content/*})
       .to_return(body: { content_id: "", title: "Hey", base_path: "/foo", publication_state: "published", details: { internal_name: "Foo" } }.to_json)
-    stub_request(:get, %r{https://publishing-api.test.gov.uk/v2/links/*})
-      .to_return(body: {}.to_json)
     stub_request(:get, %r{https://publishing-api.test.gov.uk/v2/expanded-links/*})
       .to_return(body: { expanded_links: {} }.to_json)
     stub_request(:get, %r{https://publishing-api.test.gov.uk/v2/linked/*})

--- a/spec/features/viewing_taxons_spec.rb
+++ b/spec/features/viewing_taxons_spec.rb
@@ -79,9 +79,6 @@ RSpec.describe "Viewing taxons" do
   end
 
   def when_i_view_the_root_taxon
-    stub_request(:get, %r{https://publishing-api.test.gov.uk/v2/links/apples})
-      .to_return(status: 200, body: {}.to_json)
-
     visit taxon_path(apples["content_id"])
   end
 
@@ -103,9 +100,6 @@ RSpec.describe "Viewing taxons" do
   end
 
   def when_i_view_one_of_the_parents
-    stub_request(:get, %r{https://publishing-api.test.gov.uk/v2/links/fruits})
-      .to_return(status: 200, body: {}.to_json)
-
     click_link fruits["title"]
   end
 

--- a/spec/services/taxonomy/build_taxon_spec.rb
+++ b/spec/services/taxonomy/build_taxon_spec.rb
@@ -13,6 +13,12 @@ RSpec.describe Taxonomy::BuildTaxon do
         details: {
           internal_name: 'Internal name',
           notes_for_editors: 'Notes for editors',
+        },
+        links: {
+          parent_taxons: %w(
+            0f27606a-4012-4106-8f50-70ad3c898a0b
+            cb000e46-4c16-42fe-bb9c-595a5f9eb677
+          ),
         }
       }
     end
@@ -20,13 +26,6 @@ RSpec.describe Taxonomy::BuildTaxon do
 
     before do
       publishing_api_has_item(content)
-      publishing_api_has_links(
-        content_id: content_id,
-        links: {
-          topics: [],
-          parent_taxons: []
-        }
-      )
     end
 
     it 'builds a taxon object' do
@@ -34,7 +33,10 @@ RSpec.describe Taxonomy::BuildTaxon do
     end
 
     it 'assigns the parents to the taxon' do
-      expect(taxon.parent_taxons).to be_empty
+      expect(taxon.parent_taxons).to eql(%w(
+                                           0f27606a-4012-4106-8f50-70ad3c898a0b
+                                           cb000e46-4c16-42fe-bb9c-595a5f9eb677
+                                         ))
     end
 
     it 'assigns the content id correctly' do
@@ -63,38 +65,6 @@ RSpec.describe Taxonomy::BuildTaxon do
 
     it 'assigns the notes_for_editors correctly' do
       expect(taxon.notes_for_editors).to eq("Notes for editors")
-    end
-
-    context 'without taxon parents' do
-      before do
-        publishing_api_has_links(
-          content_id: content_id,
-          links: {
-            topics: []
-          }
-        )
-      end
-
-      it 'has no taxon parents' do
-        expect(taxon.parent_taxons).to be_empty
-      end
-    end
-
-    context 'with existing links' do
-      let(:parent_taxons) { ["CONTENT-ID-RTI", "CONTENT-ID-VAT"] }
-      before do
-        publishing_api_has_links(
-          content_id: content_id,
-          links: {
-            topics: [],
-            parent_taxons: parent_taxons
-          }
-        )
-      end
-
-      it 'assigns the parents to the taxon' do
-        expect(taxon.parent_taxons).to eq(parent_taxons)
-      end
     end
 
     context 'with an invalid taxon' do

--- a/spec/support/publishing_api_helper.rb
+++ b/spec/support/publishing_api_helper.rb
@@ -2,8 +2,6 @@ module PublishingApiHelper
   def stub_taxon_show_page(content_id)
     stub_request(:get, "https://publishing-api.test.gov.uk/v2/content/#{content_id}")
       .to_return(status: 200, body: { content_id: content_id, title: "Hey", base_path: "/foo", details: { internal_name: "Foo" } }.to_json)
-    stub_request(:get, "https://publishing-api.test.gov.uk/v2/links/#{content_id}")
-      .to_return(status: 200, body: {}.to_json)
   end
 
   def publishing_api_has_content_items(items, options = {})


### PR DESCRIPTION
In https://github.com/alphagov/content-tagger/pull/319 we switched the taxon system to use "edition" level links. But we forgot to port over the reading of the links. Turns out that if you ask the publishing-api for links, the edition level links won't be returned.

By fixing this bug we can also remove a lot of stubbing!

https://trello.com/c/8YH5l9kF