### PR TITLE
Revert "Use edition level links for "parent_taxons""

### DIFF
--- a/app/services/taxonomy/build_taxon_payload.rb
+++ b/app/services/taxonomy/build_taxon_payload.rb
@@ -23,9 +23,6 @@ module Taxonomy
           internal_name: internal_name,
           notes_for_editors: notes_for_editors,
         },
-        links: {
-          parent_taxons: taxon.parent_taxons.select(&:present?)
-        },
         routes: [
           { path: base_path, type: "exact" },
         ]

--- a/app/services/taxonomy/update_taxon.rb
+++ b/app/services/taxonomy/update_taxon.rb
@@ -19,6 +19,10 @@ module Taxonomy
       end
 
       Services.publishing_api.put_content(content_id, payload)
+      Services.publishing_api.patch_links(
+        content_id,
+        links: { parent_taxons: parent_taxons.select(&:present?) }
+      )
     rescue GdsApi::HTTPUnprocessableEntity => e
       # Since we cannot easily differentiate the reasons for getting a 422
       # error code, we do a lookup to see if a content item with the slug

--- a/spec/features/delete_taxon_spec.rb
+++ b/spec/features/delete_taxon_spec.rb
@@ -108,6 +108,7 @@ RSpec.feature "Delete Taxon", type: :feature do
 
   def when_i_click_restore_taxon
     @put_content_request = stub_publishing_api_put_content(@taxon_content_id, {})
+    @patch_links_request = stub_publishing_api_patch_links(@taxon_content_id, {})
     click_link "Restore"
   end
 
@@ -130,6 +131,7 @@ RSpec.feature "Delete Taxon", type: :feature do
 
   def then_the_taxon_is_restored
     expect(@put_content_request).to have_been_made
+    expect(@patch_links_request).to have_been_made
 
     # This is the taxons index page and not the trash page
     expect(page).to have_content @taxon.fetch(:title)

--- a/spec/features/taxonomy_editing_spec.rb
+++ b/spec/features/taxonomy_editing_spec.rb
@@ -40,6 +40,9 @@ RSpec.feature "Taxonomy editing" do
 
     @create_item = stub_request(:put, %r{https://publishing-api.test.gov.uk/v2/content*})
       .to_return(status: 200, body: {}.to_json)
+
+    @create_links = stub_request(:patch, %r{https://publishing-api.test.gov.uk/v2/links*})
+      .to_return(status: 200, body: {}.to_json)
   end
 
   scenario "User creates a taxon with multiple parents" do
@@ -254,11 +257,13 @@ RSpec.feature "Taxonomy editing" do
 
   def then_a_taxon_is_created
     expect(@create_item).to have_been_requested
+    expect(@create_links).to have_been_requested
     expect(page).to have_content I18n.t('controllers.taxons.create_success')
   end
 
   def then_my_taxon_is_updated
     expect(@update_item).to have_been_requested
+    expect(@create_links).to have_been_requested
   end
 
   def and_my_taxon_is_automatically_published

--- a/spec/services/taxonomy/build_taxon_payload_spec.rb
+++ b/spec/services/taxonomy/build_taxon_payload_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe Taxonomy::BuildTaxonPayload do
       base_path: "/taxons/my-taxon",
       description: "This is a taxon.",
       internal_name: "Internal title",
-      parent_taxons: [],
       notes_for_editors: "Use this taxon wisely."
     )
   end

--- a/spec/services/taxonomy/update_taxon_spec.rb
+++ b/spec/services/taxonomy/update_taxon_spec.rb
@@ -15,6 +15,8 @@ RSpec.describe Taxonomy::UpdateTaxon do
     context 'with a valid taxon form' do
       it 'publishes the document via the publishing API' do
         expect(Services.publishing_api).to receive(:put_content)
+        expect(Services.publishing_api).to receive(:patch_links)
+
         expect { publish }.to_not raise_error
       end
     end


### PR DESCRIPTION
This reverts https://github.com/alphagov/content-tagger/pull/329.

We can't use edition level links yet, because the link expansion doesn't work yet for those links. We need that to show the taxon hierarchy.

cc @kevindew 

https://trello.com/c/8YH5l9kF
