### PR TITLE
Add discarding of drafts

### DIFF
--- a/app/assets/stylesheets/views/taxon.scss
+++ b/app/assets/stylesheets/views/taxon.scss
@@ -9,3 +9,16 @@
     float: right;
   }
 }
+
+.confirmation-box {
+  padding-top: 2em;
+  padding-bottom: 2em;
+
+  form {
+    display: inline-block;
+  }
+
+  .cancel-link {
+    margin-left: 40px;
+  }
+}

--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -87,6 +87,11 @@ class TaxonsController < ApplicationController
     redirect_to taxon_path(taxon.content_id), success: "You have successfully published the taxon"
   end
 
+  def discard_draft
+    Services.publishing_api.discard_draft(taxon.content_id)
+    redirect_to taxons_path, success: t("controllers.taxons.discard_draft_success")
+  end
+
 private
 
   def taxon

--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -87,6 +87,10 @@ class TaxonsController < ApplicationController
     redirect_to taxon_path(taxon.content_id), success: "You have successfully published the taxon"
   end
 
+  def confirm_discard
+    render :confirm_discard, locals: { taxon: taxon }
+  end
+
   def discard_draft
     Services.publishing_api.discard_draft(taxon.content_id)
     redirect_to taxons_path, success: t("controllers.taxons.discard_draft_success")

--- a/app/views/taxons/confirm_discard.html.erb
+++ b/app/views/taxons/confirm_discard.html.erb
@@ -1,0 +1,15 @@
+<h1><%= taxon.internal_name %></h1>
+
+<div class="lead">
+  You are about to <strong>delete</strong> this topic - this will remove the
+  topic from the system, and cannot be undone.
+ </div>
+
+<div class="confirmation-box">
+  <%= button_to "Confirm delete",
+  taxon_discard_draft_path(taxon.content_id),
+  method: :delete,
+  class: 'btn btn-lg btn-success confirm-button' %>
+
+  <%= link_to "Cancel", taxon_path(taxon.content_id), class: "cancel-link" %>
+</div>

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -31,7 +31,7 @@
     <%= link_to taxon_confirm_publish_path(page.taxon_content_id), class: 'btn btn-md btn-default' do %>
       Publish
     <% end %>
-    <%= link_to "Delete", taxon_discard_draft_path(page.taxon_content_id), method: :delete, class: 'delete-link' %>
+    <%= link_to "Delete", taxon_confirm_discard_path(page.taxon_content_id), class: 'delete-link' %>
   <% elsif page.unpublished? %>
     <%= link_to taxon_restore_path(page.taxon_content_id), class: 'btn btn-md btn-default' do %>
       Restore

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -31,6 +31,7 @@
     <%= link_to taxon_confirm_publish_path(page.taxon_content_id), class: 'btn btn-md btn-default' do %>
       Publish
     <% end %>
+    <%= link_to "Delete", taxon_discard_draft_path(page.taxon_content_id), method: :delete, class: 'delete-link' %>
   <% elsif page.unpublished? %>
     <%= link_to taxon_restore_path(page.taxon_content_id), class: 'btn btn-md btn-default' do %>
       Restore

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -109,6 +109,7 @@ en:
       destroy_alert: It was not possible to delete the taxon
       restore_success: You have sucessfully restored the taxon
       restore_alert: It was not possible to restore the taxon
+      discard_draft_success: You have successfully discarded the draft taxon
   messages:
     views:
       confirm: Are you sure?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -109,7 +109,7 @@ en:
       destroy_alert: It was not possible to delete the taxon
       restore_success: You have sucessfully restored the taxon
       restore_alert: It was not possible to restore the taxon
-      discard_draft_success: You have successfully discarded the draft taxon
+      discard_draft_success: You have successfully deleted the draft taxon
   messages:
     views:
       confirm: Are you sure?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
 
   resources :taxons do
     get :confirm_delete
+    get :confirm_discard
     get :confirm_publish
     post :publish
     get :restore

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
     get :restore
     get :trash, on: :collection
     get :drafts, on: :collection
+    delete :discard_draft
   end
 
   resources :copy_taxons, only: [:index], path: 'copy-taxons'

--- a/spec/controllers/taxons_controller_spec.rb
+++ b/spec/controllers/taxons_controller_spec.rb
@@ -56,4 +56,23 @@ RSpec.describe TaxonsController, type: :controller do
       expect(WebMock).to have_requested(:post, "https://publishing-api.test.gov.uk/v2/content/#{foo_content_id}/unpublish")
     end
   end
+
+  describe "#discard_draft" do
+    it "sends a request to Publishing API to delete the draft taxon" do
+      taxon = build(:taxon, publication_state: "draft")
+      publishing_api_has_taxons([taxon])
+
+      stub_request(:post, "https://publishing-api.test.gov.uk/v2/content/#{taxon.content_id}/discard-draft")
+        .to_return(status: 200, body: "", headers: {})
+
+      stub_request(:get, "https://publishing-api.test.gov.uk/v2/content/#{taxon.content_id}")
+        .to_return(status: 200, body: { content_id: "ID-1", base_path: "/foo", title: "Foo", publication_state: "draft", details: { internal_name: "foo" } }.to_json, headers: {})
+
+      stub_request(:get, "https://publishing-api.test.gov.uk/v2/links/#{taxon.content_id}")
+        .to_return(status: 200, body: {}.to_json, headers: {})
+
+      delete :discard_draft, taxon_id: taxon.content_id
+      expect(WebMock).to have_requested(:post, "https://publishing-api.test.gov.uk/v2/content/#{taxon.content_id}/discard-draft")
+    end
+  end
 end

--- a/spec/features/draft_taxons_spec.rb
+++ b/spec/features/draft_taxons_spec.rb
@@ -18,6 +18,13 @@ RSpec.feature "Draft taxonomy" do
     then_the_taxon_should_be_published
   end
 
+  scenario "User can discard draft taxons" do
+    given_there_is_a_draft_taxon
+    when_i_visit_the_taxon_page
+    and_i_click_the_delete_link
+    then_the_taxon_should_be_discarded
+  end
+
   def given_there_are_draft_taxons
     @taxon_1 = content_item_with_details(
       "I Am A Taxon 1",
@@ -93,6 +100,16 @@ RSpec.feature "Draft taxonomy" do
     click_link "Publish"
   end
 
+  def and_i_click_the_delete_link
+    taxon = build(:taxon, publication_state: "draft")
+    publishing_api_has_taxons([taxon])
+
+    @discard_request = stub_request(:post, "https://publishing-api.test.gov.uk/v2/content/#{@taxon_content_id}/discard-draft")
+      .to_return(status: 200, body: "{}")
+
+    click_on "Delete"
+  end
+
   def and_i_confirm_that_i_want_to_publish
     @publish_request = stub_request(:post, "https://publishing-api.test.gov.uk/v2/content/#{@taxon_content_id}/publish")
       .to_return(status: 200, body: "{}")
@@ -102,5 +119,9 @@ RSpec.feature "Draft taxonomy" do
 
   def then_the_taxon_should_be_published
     expect(@publish_request).to have_been_requested
+  end
+
+  def then_the_taxon_should_be_discarded
+    expect(@discard_request).to have_been_requested
   end
 end

--- a/spec/features/draft_taxons_spec.rb
+++ b/spec/features/draft_taxons_spec.rb
@@ -22,6 +22,7 @@ RSpec.feature "Draft taxonomy" do
     given_there_is_a_draft_taxon
     when_i_visit_the_taxon_page
     and_i_click_the_delete_link
+    and_i_confirm_that_i_want_to_discard
     then_the_taxon_should_be_discarded
   end
 
@@ -101,12 +102,6 @@ RSpec.feature "Draft taxonomy" do
   end
 
   def and_i_click_the_delete_link
-    taxon = build(:taxon, publication_state: "draft")
-    publishing_api_has_taxons([taxon])
-
-    @discard_request = stub_request(:post, "https://publishing-api.test.gov.uk/v2/content/#{@taxon_content_id}/discard-draft")
-      .to_return(status: 200, body: "{}")
-
     click_on "Delete"
   end
 
@@ -119,6 +114,16 @@ RSpec.feature "Draft taxonomy" do
 
   def then_the_taxon_should_be_published
     expect(@publish_request).to have_been_requested
+  end
+
+  def and_i_confirm_that_i_want_to_discard
+    taxon = build(:taxon, publication_state: "draft")
+    publishing_api_has_taxons([taxon])
+
+    @discard_request = stub_request(:post, "https://publishing-api.test.gov.uk/v2/content/#{@taxon_content_id}/discard-draft")
+      .to_return(status: 200, body: "{}")
+
+    click_on "Confirm delete"
   end
 
   def then_the_taxon_should_be_discarded


### PR DESCRIPTION
This adds functionality so users can discard drafts.

Code by @klssmith.

## Screens

<img width="1162" alt="screen shot 2017-03-24 at 10 44 20" src="https://cloud.githubusercontent.com/assets/233676/24290955/e8ca5098-107e-11e7-8c2a-5f6c75eba116.png">

---

<img width="1162" alt="screen shot 2017-03-24 at 10 44 26" src="https://cloud.githubusercontent.com/assets/233676/24290956/e8cadce8-107e-11e7-8126-389686990f19.png">

---

<img width="1158" alt="screen shot 2017-03-24 at 10 44 32" src="https://cloud.githubusercontent.com/assets/233676/24290954/e8ca0c3c-107e-11e7-9192-1b385cfa2047.png">


https://trello.com/c/8YH5l9kF