### PR TITLE
Copying related links to related item overrides

### DIFF
--- a/lib/tasks/taxonomy/ordered_related_items_overrides.rake
+++ b/lib/tasks/taxonomy/ordered_related_items_overrides.rake
@@ -1,0 +1,55 @@
+namespace :taxonomy do
+  namespace :ordered_related_items_overrides do
+    desc "Copies all ordered related items to ordered related item overrides for selected mainstream pages"
+    task populate: :environment do
+      mainstream_content_with_curated_sidebar = [
+        "/nhs-bursaries",
+        "/student-finance-register-login",
+        "/dance-drama-awards",
+        "/teacher-training-funding",
+        "/student-finance-for-existing-students",
+        "/funding-for-postgraduate-study",
+        "/apply-online-for-student-finance",
+        "/extra-money-pay-university",
+        "/career-development-loans",
+        "/travel-grants-students-england",
+        "/parents-learning-allowance",
+        "/social-work-bursaries",
+        "/adult-dependants-grant",
+        "/disabled-students-allowances-dsas",
+        "/apply-for-student-finance",
+        "/childcare-grant",
+        "/postgraduate-loan",
+        "/contact-student-finance-england",
+        "/repaying-your-student-loan",
+        "/student-finance",
+        "/care-to-learn",
+        "/advanced-learner-loan",
+        "/student-finance-calculator",
+        "/student-finance-forms",
+      ]
+
+      mainstream_content_with_curated_sidebar.each do |base_path|
+        puts "Copying related items to related item overrides for #{base_path}"
+
+        content_id =
+          Services.publishing_api.lookup_content_id(base_path: base_path)
+        content_item = ContentItem.find!(content_id)
+
+        ordered_related_items = content_item.link_set.ordered_related_items
+        link_content_ids =
+          ordered_related_items.map { |item| item['content_id'] }
+
+        updated_links = {
+          ordered_related_items_overrides: link_content_ids
+        }
+
+        Services.publishing_api.patch_links(
+          content_id,
+          links: updated_links,
+          previous_version: content_item.link_set.previous_version
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
We have an exception to the rule when it comes to displaying the new
taxonomy sidebar. Some content items (all mainstream) have very
important curated related items and those need to be displayed. The
taxonomy sidebar didn't support this before, so we are still showing the
old related links for those content items.

Now that there is a way to both add curated related items for the new
taxonomy and display it in the frontend, we need to migrate the previous
links so they show up.

This commit adds a rake task that copies over everything in
`ordered_related_items` to `ordered_related_items_overrides` for the
content items that had been the exception to the rule.

The list of mainstream pages is a combination of:
- this list in [frontend](https://github.com/alphagov/frontend/blob/master/config/mainstream_content_with_curated_sidebar.json)
- this list in [smart-answers](https://github.com/alphagov/smart-answers/blob/master/config/mainstream_content_with_curated_sidebar.json)

Trello: https://trello.com/c/vM6Kaw9B/546-ias-and-content-designers-can-curate-related-links-for-any-content-type