### PR TITLE
Change design of 'confirm publish' page

### DIFF
--- a/app/views/taxons/confirm_discard.html.erb
+++ b/app/views/taxons/confirm_discard.html.erb
@@ -1,15 +1,17 @@
-<h1><%= taxon.internal_name %></h1>
+<header class="heading-with-actions">
+  <h1><%= taxon.internal_name %></h1>
+</header>
 
 <div class="lead">
   You are about to <strong>delete</strong> this topic - this will remove the
   topic from the system, and cannot be undone.
- </div>
+</div>
 
 <div class="confirmation-box">
   <%= button_to "Confirm delete",
   taxon_discard_draft_path(taxon.content_id),
   method: :delete,
-  class: 'btn btn-lg btn-success confirm-button' %>
+  class: 'btn btn-lg btn-success' %>
 
   <%= link_to "Cancel", taxon_path(taxon.content_id), class: "cancel-link" %>
 </div>

--- a/app/views/taxons/confirm_publish.html.erb
+++ b/app/views/taxons/confirm_publish.html.erb
@@ -1,10 +1,16 @@
-<h1>Publish "<%= taxon.internal_name %>"</h1>
+<header class="heading-with-actions">
+  <h1><%= taxon.internal_name %></h1>
+</header>
 
 <div class="lead">
-  You are about to <strong>publish</strong> this taxon - this will make the
-  navigation page appear to everyone on GOV.UK.
+  You are about to <strong>publish</strong> this topic - this will make the
+  topic appear to everyone on GOV.UK.
 </div>
 
-<%= button_to "Confirm publish",
+<div class="confirmation-box">
+  <%= button_to "Confirm publish",
   taxon_publish_path(taxon.content_id),
-  class: 'btn btn-success' %>
+  class: 'btn btn-lg btn-success' %>
+
+  <%= link_to "Cancel", taxon_path(taxon.content_id), class: "cancel-link" %>
+</div>


### PR DESCRIPTION
- Updated the text of the confirm publish page and added a cancel link.
- Also changed the CSS classes of the confirm discard page to be consistent.

[Trello card](https://trello.com/c/8YH5l9kF/517-epic-implement-the-draft-workflow-for-taxonomy)

![screen shot 2017-03-27 at 10 46 14](https://cloud.githubusercontent.com/assets/12881990/24351029/3a24c11c-12dc-11e7-8d9b-0d350a271b86.png)
