### PR TITLE
Add mandatory redirection for deleted taxons

### DIFF
--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -63,8 +63,14 @@ class TaxonsController < ApplicationController
   end
 
   def destroy
-    Services.publishing_api.unpublish(params[:id], type: "gone").code
-    redirect_to taxon_path(taxon.content_id), success: t("controllers.taxons.destroy_success")
+    if params[:taxon][:redirect_to].empty?
+      flash[:danger] = t("controllers.taxons.destroy_no_redirect")
+      render :confirm_delete, locals: { page: Taxonomy::ShowPage.new(taxon) }
+    else
+      base_path = Services.publishing_api.get_content(params[:taxon][:redirect_to])['base_path']
+      Services.publishing_api.unpublish(params[:id], type: "redirect", alternative_path: base_path).code
+      redirect_to taxon_path(taxon.content_id), success: t("controllers.taxons.destroy_success")
+    end
   end
 
   def confirm_delete

--- a/app/models/bulk_tagging/taxon_search_results.rb
+++ b/app/models/bulk_tagging/taxon_search_results.rb
@@ -19,7 +19,8 @@ module BulkTagging
               base_path: taxon_hash["base_path"],
               publication_state: taxon_hash['publication_state'],
               internal_name: details['internal_name'],
-              notes_for_editors: details['notes_for_editors']
+              notes_for_editors: details['notes_for_editors'],
+              redirect_to: taxon_hash.dig('unpublishing', 'alternative_path')
             )
           end
 

--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -10,7 +10,8 @@ class Taxon
     :publication_state,
     :internal_name,
     :notes_for_editors,
-    :document_type
+    :document_type,
+    :redirect_to
   )
 
   include ActiveModel::Model
@@ -38,6 +39,10 @@ class Taxon
 
   def unpublished?
     publication_state == "unpublished"
+  end
+
+  def redirected?
+    publication_state == "unpublished" && !redirect_to.nil?
   end
 
   def content_id

--- a/app/services/taxonomy/build_taxon.rb
+++ b/app/services/taxonomy/build_taxon.rb
@@ -22,6 +22,7 @@ module Taxonomy
         internal_name: content_item['details']['internal_name'],
         notes_for_editors: content_item['details']['notes_for_editors'],
         parent_taxons: parent_taxons,
+        redirect_to: content_item.dig('unpublishing', 'alternative_path'),
       )
     end
 

--- a/app/services/taxonomy/show_page.rb
+++ b/app/services/taxonomy/show_page.rb
@@ -1,6 +1,7 @@
 module Taxonomy
   class ShowPage
-    delegate :content_id, :draft?, :published?, :unpublished?, :base_path, to: :taxon
+    delegate :content_id, :draft?, :published?, :unpublished?, :redirected?,
+             :redirect_to, :base_path, to: :taxon
 
     attr_reader :taxon
 
@@ -42,6 +43,10 @@ module Taxonomy
           fields: %w(title content_id base_path document_type)
         )
       end
+    end
+
+    def taxons_for_select
+      Linkables.new.taxons(exclude_ids: taxon_content_id)
     end
   end
 end

--- a/app/views/taxons/confirm_delete.html.erb
+++ b/app/views/taxons/confirm_delete.html.erb
@@ -11,28 +11,22 @@
       <li><%= t('views.taxons.delete_warning_3') %></li>
     </ul>
   </p>
+</div>
+<% end %>
 
-  <%= link_to taxon_path(page.taxon_content_id), method: :delete, class: 'btn btn-md btn-danger pull-right left-space' do %>
+<%= simple_form_for page.taxon, url: taxon_path(page.taxon_content_id), method: :delete do |f| %>
+  <%= f.input :redirect_to, collection: page.taxons_for_select,
+    input_html: { class: :select2, multiple: false, include_blank: true } %>
+
+  <%= f.button :button, class: 'btn btn-md btn-danger' do %>
     <span class="glyphicon glyphicon-trash"></span>
     <span><%= t('views.taxons.confirm_deletion') %></span>
   <% end %>
 
-  <%= link_to taxon_path(page.taxon_content_id), class: 'btn btn-md btn-default pull-right' do %>
-    <span>
-      <%= t('views.taxons.cancel_button') %>
-    </span>
-  <% end %>
-</div>
-<% else %>
   <%= link_to taxon_path(page.taxon_content_id), class: 'btn btn-md btn-default' do %>
     <span>
       <%= t('views.taxons.cancel_button') %>
     </span>
-  <% end %>
-
-  <%= link_to taxon_path(page.taxon_content_id), method: :delete, class: 'btn btn-md btn-danger left-space' do %>
-    <span class="glyphicon glyphicon-trash"></span>
-    <span><%= t('views.taxons.confirm_deletion') %></span>
   <% end %>
 <% end %>
 

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -24,7 +24,12 @@
 </div>
 
 <div class="well state-box">
-  <div class="state">State: <%= page.publication_state_name %></div>
+  <div class="state">
+    State: <%= page.publication_state_name %>
+    <% if page.redirected? %>
+      (redirects to <%= page.redirect_to %>)
+    <% end %>
+  </div>
   <% if page.published? %>
     <%= link_to "Delete", taxon_confirm_delete_path(page.taxon_content_id), class: 'delete-link' %>
   <% elsif page.draft? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -85,7 +85,7 @@ en:
       download_csv: Download taxonomy as CSV
       confirm_deletion_title: You are about to delete
       confirm_deletion_restore: Deleted taxons can be restored.
-      confirm_deletion: Delete
+      confirm_deletion: Delete and redirect
       cancel_button: Cancel
       delete_warning_1: "Before you delete this taxon, make sure you've:"
       delete_warning_2: given its child taxons a new parent
@@ -107,6 +107,7 @@ en:
       create_success: You have sucessfully created a taxon
       destroy_success: You have sucessfully deleted the taxon
       destroy_alert: It was not possible to delete the taxon
+      destroy_no_redirect: Please select a taxon to redirect to
       restore_success: You have sucessfully restored the taxon
       restore_alert: It was not possible to restore the taxon
       discard_draft_success: You have successfully deleted the draft taxon

--- a/spec/features/delete_taxon_spec.rb
+++ b/spec/features/delete_taxon_spec.rb
@@ -9,6 +9,7 @@ RSpec.feature "Delete Taxon", type: :feature do
     when_i_visit_the_taxon_page
     when_i_click_delete_taxon
     then_i_see_a_basic_prompt_to_delete
+    when_i_choose_a_taxon_to_redirect_to("Vehicle plating")
     when_i_confirm_deletion
     then_the_taxon_is_deleted
   end
@@ -19,6 +20,7 @@ RSpec.feature "Delete Taxon", type: :feature do
     then_i_expect_to_see_the_child_taxon
     when_i_click_delete_taxon
     then_i_see_a_prompt_to_delete_with_a_warning_message
+    when_i_choose_a_taxon_to_redirect_to("Vehicle plating")
     when_i_confirm_deletion
     then_the_taxon_is_deleted
   end
@@ -29,6 +31,7 @@ RSpec.feature "Delete Taxon", type: :feature do
     then_i_expect_to_see_the_tagged_content
     when_i_click_delete_taxon
     then_i_see_a_prompt_to_delete_with_a_warning_message
+    when_i_choose_a_taxon_to_redirect_to("Vehicle plating")
     when_i_confirm_deletion
     then_the_taxon_is_deleted
   end
@@ -103,6 +106,7 @@ RSpec.feature "Delete Taxon", type: :feature do
   end
 
   def when_i_click_delete_taxon
+    @get_linkables_request = publishing_api_has_taxon_linkables("/alpha-taxonomy/vehicle-plating")
     click_on "Delete"
   end
 
@@ -116,13 +120,17 @@ RSpec.feature "Delete Taxon", type: :feature do
     expect(page).to have_text('You are about to delete "internal name for Taxon 1"')
     expect(page).to_not have_text("Before you delete this taxon, make sure you've")
     expect(page).to have_link('Cancel')
-    expect(page).to have_link('Delete')
+    expect(page).to have_button('Delete and redirect')
+  end
+
+  def when_i_choose_a_taxon_to_redirect_to(selection)
+    select selection, from: "Redirect to"
   end
 
   def when_i_confirm_deletion
-    @unpublish_request = stub_publishing_api_unpublish(@taxon_content_id, body: { type: :gone }.to_json)
-    publishing_api_has_taxons([])
-    click_on "Delete"
+    @get_content_request = publishing_api_has_item(stubbed_taxons[0])
+    @unpublish_request = stub_publishing_api_unpublish(@taxon_content_id, body: { type: :redirect, alternative_path: "/alpha-taxonomy/vehicle-plating" }.to_json)
+    click_on "Delete and redirect"
   end
 
   def then_the_taxon_is_deleted
@@ -153,7 +161,7 @@ RSpec.feature "Delete Taxon", type: :feature do
     expect(page).to have_text('You are about to delete "internal name for Taxon 1"')
     expect(page).to have_text("Before you delete this taxon, make sure you've")
     expect(page).to have_link('Cancel')
-    expect(page).to have_link('Delete')
+    expect(page).to have_button('Delete and redirect')
   end
 
 private


### PR DESCRIPTION
This commit adds a requirement to select a taxon to redirect to when deleting a taxon. This will prevent taxon links from breaking, as well as ensuring we can redirect email subscriptions to deleted taxons in future.

Trello: https://trello.com/c/xBViyhvs/553-make-users-choose-a-taxon-to-redirect-to-when-removing-taxons

Deleting a taxon without any children...

![screen shot 2017-03-27 at 13 16 24](https://cloud.githubusercontent.com/assets/444232/24355977/022c474e-12f0-11e7-9d8e-ea1373c2f8b1.png)

...and the error when you don't select a taxon to redirect to

![screen shot 2017-03-27 at 13 16 31](https://cloud.githubusercontent.com/assets/444232/24355991/0fbb715a-12f0-11e7-9136-7464d57463cb.png)

Deleting a taxon with children...

![screen shot 2017-03-27 at 13 17 00](https://cloud.githubusercontent.com/assets/444232/24355995/1606a746-12f0-11e7-9ec7-5e2e85c64577.png)

...and the error when you don't select a taxon to redirect to

![screen shot 2017-03-27 at 13 17 08](https://cloud.githubusercontent.com/assets/444232/24356002/1af625b0-12f0-11e7-84cf-6b71fc70fc3e.png)

What a deleted and redirected taxon looks like:

![screen shot 2017-03-27 at 13 17 50](https://cloud.githubusercontent.com/assets/444232/24356011/2671b648-12f0-11e7-8fb3-de3e7d03b463.png)
