### PR TITLE
Add confirmation for restoring taxons

### DIFF
--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -84,6 +84,10 @@ class TaxonsController < ApplicationController
     redirect_to trash_taxons_path, danger: e.message
   end
 
+  def confirm_restore
+    render :confirm_restore, locals: { page: Taxonomy::ShowPage.new(taxon) }
+  end
+
   def confirm_publish
     render :confirm_publish, locals: { taxon: taxon }
   end

--- a/app/views/taxons/confirm_restore.html.erb
+++ b/app/views/taxons/confirm_restore.html.erb
@@ -1,0 +1,11 @@
+<h1><%= t('views.taxons.confirm_restore_title') %> "<%= page.title %>"</h1>
+
+<div class="lead"><%= t('views.taxons.confirm_restore_redirect') %></div>
+
+<div class="confirmation-box">
+  <%= button_to "Confirm restore",
+  taxon_restore_path(page.taxon_content_id),
+  class: 'btn btn-lg btn-success' %>
+
+  <%= link_to "Cancel", taxon_path(page.taxon_content_id), class: "cancel-link" %>
+</div>

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -38,7 +38,7 @@
     <% end %>
     <%= link_to "Delete", taxon_confirm_discard_path(page.taxon_content_id), class: 'delete-link' %>
   <% elsif page.unpublished? %>
-    <%= link_to taxon_restore_path(page.taxon_content_id), class: 'btn btn-md btn-default' do %>
+    <%= link_to taxon_confirm_restore_path(page.taxon_content_id), class: 'btn btn-md btn-default' do %>
       Restore
     <% end %>
   <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -86,6 +86,8 @@ en:
       confirm_deletion_title: You are about to delete
       confirm_deletion_restore: Deleted taxons can be restored.
       confirm_deletion: Delete and redirect
+      confirm_restore_title: You are about to restore
+      confirm_restore_redirect: This topic will become a draft, but the redirect will stay live until this topic is re-published.
       cancel_button: Cancel
       delete_warning_1: "Before you delete this taxon, make sure you've:"
       delete_warning_2: given its child taxons a new parent

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,10 +3,11 @@ Rails.application.routes.draw do
 
   resources :taxons do
     get :confirm_delete
+    get :confirm_restore
     get :confirm_discard
     get :confirm_publish
     post :publish
-    get :restore
+    post :restore
     get :trash, on: :collection
     get :drafts, on: :collection
     delete :discard_draft

--- a/spec/factories/taxon.rb
+++ b/spec/factories/taxon.rb
@@ -1,9 +1,10 @@
 FactoryGirl.define do
   factory :taxon do
     title 'A taxon'
+    description 'A description'
     parent_taxons []
     content_id 'taxon-content-id'
-    base_path '/taxon-base-path'
+    base_path '/education/taxon-base-path'
     publication_state 'published'
     internal_name 'An internal name'
   end

--- a/spec/features/delete_taxon_spec.rb
+++ b/spec/features/delete_taxon_spec.rb
@@ -39,8 +39,9 @@ RSpec.feature "Delete Taxon", type: :feature do
   scenario "restoring a deleted taxon" do
     given_a_deleted_taxon
     when_i_visit_the_taxon_page
-
     when_i_click_restore_taxon
+    then_i_see_a_prompt_to_restore_with_an_informative_message
+    when_i_confirm_restoration
     then_the_taxon_is_restored
   end
 
@@ -111,8 +112,6 @@ RSpec.feature "Delete Taxon", type: :feature do
   end
 
   def when_i_click_restore_taxon
-    @put_content_request = stub_publishing_api_put_content(@taxon_content_id, {})
-    @patch_links_request = stub_publishing_api_patch_links(@taxon_content_id, {})
     click_link "Restore"
   end
 
@@ -131,6 +130,12 @@ RSpec.feature "Delete Taxon", type: :feature do
     @get_content_request = publishing_api_has_item(stubbed_taxons[0])
     @unpublish_request = stub_publishing_api_unpublish(@taxon_content_id, body: { type: :redirect, alternative_path: "/alpha-taxonomy/vehicle-plating" }.to_json)
     click_on "Delete and redirect"
+  end
+
+  def when_i_confirm_restoration
+    @put_content_request = stub_publishing_api_put_content(@taxon_content_id, {})
+    @patch_links_request = stub_publishing_api_patch_links(@taxon_content_id, {})
+    click_on "Confirm restore"
   end
 
   def then_the_taxon_is_deleted
@@ -162,6 +167,10 @@ RSpec.feature "Delete Taxon", type: :feature do
     expect(page).to have_text("Before you delete this taxon, make sure you've")
     expect(page).to have_link('Cancel')
     expect(page).to have_button('Delete and redirect')
+  end
+
+  def then_i_see_a_prompt_to_restore_with_an_informative_message
+    expect(page).to have_text('This topic will become a draft, but the redirect will stay live until this topic is re-published.')
   end
 
 private

--- a/spec/support/publishing_api_helper.rb
+++ b/spec/support/publishing_api_helper.rb
@@ -34,6 +34,19 @@ module PublishingApiHelper
     publishing_api_has_content(taxons, default_options.merge(options))
   end
 
+  def publishing_api_has_draft_taxons(taxons, options = {})
+    default_options = {
+      document_type: "taxon",
+      order: '-public_updated_at',
+      page: 1,
+      per_page: 50,
+      q: '',
+      states: ["draft"],
+    }
+
+    publishing_api_has_content(taxons, default_options.merge(options))
+  end
+
   def publishing_api_has_deleted_taxons(taxons, options = {})
     default_options = {
       document_type: "taxon",


### PR DESCRIPTION
This commit adds a confirmation page that is shown when restoring a deleted taxon. The page informs the user that the redirect that was put in place when the taxon was deleted will remain live until the restored taxon is re-published.

Trello: https://trello.com/c/xBViyhvs/553-make-users-choose-a-taxon-to-redirect-to-when-removing-taxons