### PR TITLE
Add fallback OAuth ID and secret

### DIFF
--- a/config/initializers/gds-sso.rb
+++ b/config/initializers/gds-sso.rb
@@ -1,0 +1,6 @@
+GDS::SSO.config do |config|
+  config.user_model   = 'User'
+  config.oauth_id     = ENV['OAUTH_ID'] || "abcdefghjasndjkasndcontenttagger"
+  config.oauth_secret = ENV['OAUTH_SECRET'] || "secret"
+  config.oauth_root_url = Plek.find('signon')
+end

--- a/config/initializers/gds_sso.rb
+++ b/config/initializers/gds_sso.rb
@@ -1,6 +1,0 @@
-GDS::SSO.config do |config|
-  config.user_model   = 'User'
-  config.oauth_id     = ENV['OAUTH_ID']
-  config.oauth_secret = ENV['OAUTH_SECRET']
-  config.oauth_root_url = Plek.find('signon')
-end


### PR DESCRIPTION
This commit adds a fallback OAuth ID and secret. This will allow the signon-munging script for development to configure signon for this app locally.

It also renames the file to make it consistent with other apps and allow the munging script to find it.