### PR TITLE
Inline taxonomy helpers gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,6 @@ gem 'govuk_sidekiq', '~> 0.0.4'
 
 gem 'kaminari', '~> 0.17'
 gem 'bootstrap-kaminari-views', '~> 0.0.5'
-gem 'govuk_taxonomy_helpers', '~> 0.1.0'
 
 group :development, :test do
   gem 'quiet_assets'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,7 +122,6 @@ GEM
       sidekiq (~> 4.1)
       sidekiq-logging-json (~> 0.0)
       sidekiq-statsd (~> 0.1)
-    govuk_taxonomy_helpers (0.1.0)
     hashdiff (0.3.2)
     hashie (3.5.3)
     headless (2.3.1)
@@ -362,7 +361,6 @@ DEPENDENCIES
   govuk-lint
   govuk_admin_template (~> 4.4)
   govuk_sidekiq (~> 0.0.4)
-  govuk_taxonomy_helpers (~> 0.1.0)
   headless
   jquery-ui-rails (= 6.0.1)
   kaminari (~> 0.17)

--- a/app/models/taxonomy/expanded_taxonomy.rb
+++ b/app/models/taxonomy/expanded_taxonomy.rb
@@ -102,17 +102,11 @@ module Taxonomy
     end
 
     def tree_node_based_on(content_item)
-      taxon = Taxon.new(
-        content_id: content_item.fetch('content_id'),
+      GovukTaxonomyHelpers::LinkedContentItem.new(
+        internal_name: content_item.fetch('details').fetch('internal_name'),
         title: content_item.fetch('title'),
         base_path: content_item.fetch('base_path'),
-        internal_name: content_item.fetch('details').fetch('internal_name'),
-      )
-      GovukTaxonomyHelpers::LinkedContentItem.new(
-        internal_name: taxon.internal_name,
-        title: taxon.title,
-        base_path: taxon.base_path,
-        content_id: taxon.content_id
+        content_id: content_item.fetch('content_id'),
       )
     end
   end

--- a/lib/govuk_taxonomy_helpers/linked_content_item.rb
+++ b/lib/govuk_taxonomy_helpers/linked_content_item.rb
@@ -1,0 +1,127 @@
+require 'forwardable'
+
+module GovukTaxonomyHelpers
+  # A LinkedContentItem can be anything that has a content store representation
+  # on GOV.UK.
+  #
+  # It can be used with "taxon" content items (a topic in the taxonomy) or
+  # other document types that link to taxons.
+  #
+  # Taxon instances can have an optional parent and any number of child taxons.
+  class LinkedContentItem
+    extend Forwardable
+    attr_reader :title, :content_id, :base_path, :children, :internal_name
+    attr_accessor :parent
+    attr_reader :taxons
+    def_delegators :tree, :map, :each
+
+    # Extract a LinkedContentItem from publishing api response data.
+    #
+    # @param content_item [Hash] Publishing API `get_content` response hash
+    # @param expanded_links [Hash] Publishing API `get_expanded_links` response hash
+    # @return [LinkedContentItem]
+    # @see http://www.rubydoc.info/gems/gds-api-adapters/GdsApi/PublishingApiV2#get_content-instance_method
+    # @see http://www.rubydoc.info/gems/gds-api-adapters/GdsApi%2FPublishingApiV2:get_expanded_links
+    def self.from_publishing_api(content_item:, expanded_links:)
+      PublishingApiResponse.new(
+        content_item: content_item,
+        expanded_links: expanded_links,
+      ).linked_content_item
+    end
+
+    # @param title [String] the user facing name for the content item
+    # @param base_path [String] the relative URL, starting with a leading "/"
+    # @param content_id [UUID] unique identifier of the content item
+    # @param internal_name [String] an internal name for the content item
+    def initialize(title:, base_path:, content_id:, internal_name: nil)
+      @title = title
+      @internal_name = internal_name
+      @content_id = content_id
+      @base_path = base_path
+      @children = []
+      @taxons = []
+    end
+
+    # Add a LinkedContentItem as a child of this one
+    def <<(child_node)
+      child_node.parent = self
+      @children << child_node
+    end
+
+    # Get taxons in the taxon's branch of the taxonomy.
+    #
+    # @return [Array] all taxons in this branch of the taxonomy, including the content item itself
+    def tree
+      return [self] if @children.empty?
+
+      @children.each_with_object([self]) do |child, tree|
+        tree.concat(child.tree)
+      end
+    end
+
+
+    # Get descendants of a taxon
+    #
+    # @return [Array] all taxons in this branch of the taxonomy, excluding the content item itself
+    def descendants
+      tree.tap(&:shift)
+    end
+
+    # Get ancestors of a taxon
+    #
+    # @return [Array] all taxons in the path from the root of the taxonomy to the parent taxon
+    def ancestors
+      if parent.nil?
+        []
+      else
+        parent.ancestors + [parent]
+      end
+    end
+
+    # Get a breadcrumb trail for a taxon
+    #
+    # @return [Array] all taxons in the path from the root of the taxonomy to this taxon
+    def breadcrumb_trail
+      ancestors + [self]
+    end
+
+    # Get all linked taxons and their ancestors
+    #
+    # @return [Array] all taxons that this content item can be found in
+    def taxons_with_ancestors
+      taxons.flat_map(&:breadcrumb_trail)
+    end
+
+    # @return [Integer] the number of taxons in this branch of the taxonomy
+    def count
+      tree.count
+    end
+
+    # @return [Boolean] whether this taxon is the root of its taxonomy
+    def root?
+      parent.nil?
+    end
+
+    # @return [Integer] the number of taxons between this taxon and the taxonomy root
+    def depth
+      return 0 if root?
+      1 + parent.depth
+    end
+
+    # Link this content item to a taxon
+    #
+    # @param taxon_node [LinkedContentItem] A taxon content item
+    def add_taxon(taxon_node)
+      taxons << taxon_node
+    end
+
+    # @return [String] the string representation of the content item
+    def inspect
+      if internal_name.nil?
+        "LinkedContentItem(title: '#{title}', content_id: '#{content_id}', base_path: '#{base_path}')"
+      else
+        "LinkedContentItem(title: '#{title}', internal_name: '#{internal_name}', content_id: '#{content_id}', base_path: '#{base_path}')"
+      end
+    end
+  end
+end

--- a/lib/govuk_taxonomy_helpers/linked_content_item.rb
+++ b/lib/govuk_taxonomy_helpers/linked_content_item.rb
@@ -59,7 +59,6 @@ module GovukTaxonomyHelpers
       end
     end
 
-
     # Get descendants of a taxon
     #
     # @return [Array] all taxons in this branch of the taxonomy, excluding the content item itself

--- a/lib/govuk_taxonomy_helpers/publishing_api_response.rb
+++ b/lib/govuk_taxonomy_helpers/publishing_api_response.rb
@@ -1,0 +1,91 @@
+module GovukTaxonomyHelpers
+  class PublishingApiResponse
+    attr_accessor :linked_content_item
+
+    # @param content_item [Hash] Publishing API `get_content` response hash
+    # @param expanded_links [Hash] Publishing API `get_expanded_links` response hash
+    def initialize(content_item:, expanded_links:)
+      details = content_item["details"] || {}
+
+      @linked_content_item = LinkedContentItem.new(
+        title: content_item["title"],
+        internal_name: details["internal_name"],
+        content_id: content_item["content_id"],
+        base_path: content_item["base_path"]
+      )
+
+      add_expanded_links(expanded_links)
+    end
+
+  private
+
+    def add_expanded_links(expanded_links_response)
+      child_taxons = expanded_links_response["expanded_links"]["child_taxons"]
+      parent_taxons = expanded_links_response["expanded_links"]["parent_taxons"]
+      taxons = expanded_links_response["expanded_links"]["taxons"]
+
+      if !child_taxons.nil?
+        child_taxons.each do |child|
+          linked_content_item << parse_nested_child(child)
+        end
+      end
+
+      if !parent_taxons.nil?
+        # Assume no taxon has multiple parents
+        single_parent = parent_taxons.first
+
+        parse_nested_parent(single_parent) << linked_content_item
+      end
+
+      if !taxons.nil?
+        taxons.each do |taxon|
+          taxon_node = parse_nested_parent(taxon)
+          linked_content_item.add_taxon(taxon_node)
+        end
+      end
+    end
+
+    def parse_nested_child(nested_item)
+      details = nested_item["details"] || {}
+      links = nested_item["links"] || {}
+
+      nested_linked_content_item = LinkedContentItem.new(
+        title: nested_item["title"],
+        internal_name: details["internal_name"],
+        content_id: nested_item["content_id"],
+        base_path: nested_item["base_path"]
+      )
+
+      child_taxons = links["child_taxons"]
+
+      if !child_taxons.nil?
+        child_taxons.each do |child|
+          nested_linked_content_item << parse_nested_child(child)
+        end
+      end
+
+      nested_linked_content_item
+    end
+
+    def parse_nested_parent(nested_item)
+      details = nested_item["details"] || {}
+      links = nested_item["links"] || {}
+
+      nested_linked_content_item = LinkedContentItem.new(
+        title: nested_item["title"],
+        internal_name: details["internal_name"],
+        content_id: nested_item["content_id"],
+        base_path: nested_item["base_path"]
+      )
+
+      parent_taxons = links["parent_taxons"]
+
+      if !parent_taxons.nil?
+        single_parent = parent_taxons.first
+        parse_nested_parent(single_parent) << nested_linked_content_item
+      end
+
+      nested_linked_content_item
+    end
+  end
+end

--- a/lib/govuk_taxonomy_helpers/publishing_api_response.rb
+++ b/lib/govuk_taxonomy_helpers/publishing_api_response.rb
@@ -24,20 +24,20 @@ module GovukTaxonomyHelpers
       parent_taxons = expanded_links_response["expanded_links"]["parent_taxons"]
       taxons = expanded_links_response["expanded_links"]["taxons"]
 
-      if !child_taxons.nil?
+      unless child_taxons.nil?
         child_taxons.each do |child|
           linked_content_item << parse_nested_child(child)
         end
       end
 
-      if !parent_taxons.nil?
+      unless parent_taxons.nil?
         # Assume no taxon has multiple parents
         single_parent = parent_taxons.first
 
         parse_nested_parent(single_parent) << linked_content_item
       end
 
-      if !taxons.nil?
+      unless taxons.nil?
         taxons.each do |taxon|
           taxon_node = parse_nested_parent(taxon)
           linked_content_item.add_taxon(taxon_node)
@@ -58,7 +58,7 @@ module GovukTaxonomyHelpers
 
       child_taxons = links["child_taxons"]
 
-      if !child_taxons.nil?
+      unless child_taxons.nil?
         child_taxons.each do |child|
           nested_linked_content_item << parse_nested_child(child)
         end
@@ -80,7 +80,7 @@ module GovukTaxonomyHelpers
 
       parent_taxons = links["parent_taxons"]
 
-      if !parent_taxons.nil?
+      unless parent_taxons.nil?
         single_parent = parent_taxons.first
         parse_nested_parent(single_parent) << nested_linked_content_item
       end


### PR DESCRIPTION
This inlines the relevant classes from the https://github.com/alphagov/govuk_taxonomy_helpers gem.

The taxonomy gem was part of an effort to avoid duplication between applications dealing with the taxonomy. Unfortunately we ran out of time last quarter, which left us with an API that was still in flux
(alphagov/govuk_taxonomy_helpers#11).

To avoid confusion, I think it's best to inline the code in the places where we use the taxonomy helpers. We're going to be doing work around the taxonomy in the next couple of months and I think it will be easier to extract code than trying to nail the API right now.

Trello: https://trello.com/c/FVfbiKxn