### PR TITLE
Allow tagging of content items rendered by government-frontend

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -72,6 +72,7 @@ private
       smartanswers
       licencefinder
       frontend
+      government-frontend
       multipage-frontend
       calculators
     ).include?(rendering_app)


### PR DESCRIPTION
Travel Advice is rendered by [government-frontend](https://github.com/alphagov/government-frontend) so it should not be blacklisted for tagging.

See:

- https://trello.com/c/fnqWUB1w
- https://github.com/alphagov/government-frontend/pull/255