### PR TITLE
Add task to create a new taxonomy tree

### DIFF
--- a/lib/tasks/taxonomy/promote_taxon_to_taxonomy_root.rake
+++ b/lib/tasks/taxonomy/promote_taxon_to_taxonomy_root.rake
@@ -1,0 +1,28 @@
+namespace :taxonomy do
+  desc "Promote a taxon to become a taxonomy root"
+  task :promote_taxon_to_taxonomy_root, [:taxon_id] => :environment do |_, args|
+    taxon_id = args.fetch(:taxon_id)
+    homepage_content_id = "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a"
+
+    puts "Promoting content with ID: #{taxon_id} to a taxonomic root node."
+
+    begin
+      homepage_links = Services.publishing_api.get_links(
+        homepage_content_id
+      )
+
+      root_taxons = homepage_links['links'].fetch('root_taxons', [])
+      root_taxons << taxon_id
+
+      Services.publishing_api.patch_links(
+        homepage_content_id,
+        links: { root_taxons: root_taxons.uniq },
+      )
+
+      puts '✅  OK'
+    rescue GdsApi::BaseError => e
+      puts "❌  FAILURE #{e.code}"
+      exit(1)
+    end
+  end
+end


### PR DESCRIPTION
Run this `rake` task with the content_id of a taxon node as an argument.

```
$ rake taxonomy:promote_taxon_to_taxonomy_root[8a2141ae-2493-491c-8e5f-2bd23c1a6afe]
```

It will patch this content_item, setting the Homepage `/` as it's parent
taxon. Causing the chosen taxon to become the root node of a top level
taxonomy tree.

[Trello](https://trello.com/c/wHZQz5Yk/64-build-joe-s-designs-to-allow-publishers-to-tag-across-multiple-themes-in-whitehall)

Paired with @klssmith 