### PR TITLE
Add support for setting the visibility flag

### DIFF
--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -116,6 +116,7 @@ private
       :internal_name,
       :title,
       :description,
+      :visible_to_departmental_editors,
       :notes_for_editors,
       parent_taxons: []
     )

--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -81,4 +81,19 @@ class Taxon
   def notes_for_editors
     @notes_for_editors || ""
   end
+
+  # Lets talk about this.
+  #
+  # This model takes data in either formencoded or JSON formats:
+  #  - the Rails form submission gives us stringified data
+  #  - the JSON API response gives us true booleans.
+  # In an ideal world we wouldn't have to worry about this
+  # but ActiveModel doesn't have decent type coercion yet.
+  def visible_to_departmental_editors=(val)
+    @visible_to_departmental_editors = ('true' == val.to_s)
+  end
+
+  def visible_to_departmental_editors
+    @visible_to_departmental_editors || false
+  end
 end

--- a/app/services/taxonomy/build_taxon.rb
+++ b/app/services/taxonomy/build_taxon.rb
@@ -23,6 +23,7 @@ module Taxonomy
         notes_for_editors: content_item['details']['notes_for_editors'],
         parent_taxons: parent_taxons,
         redirect_to: content_item.dig('unpublishing', 'alternative_path'),
+        visible_to_departmental_editors: content_item.dig('details', 'visible_to_departmental_editors')
       )
     end
 

--- a/app/services/taxonomy/build_taxon_payload.rb
+++ b/app/services/taxonomy/build_taxon_payload.rb
@@ -22,6 +22,7 @@ module Taxonomy
         details: {
           internal_name: internal_name,
           notes_for_editors: notes_for_editors,
+          visible_to_departmental_editors: visible_to_departmental_editors,
         },
         routes: [
           { path: base_path, type: "exact" },
@@ -34,6 +35,7 @@ module Taxonomy
     attr_reader :taxon
     delegate(
       :base_path, :title, :description, :internal_name, :notes_for_editors,
+      :visible_to_departmental_editors,
       to: :taxon
     )
   end

--- a/app/services/taxonomy/edit_page.rb
+++ b/app/services/taxonomy/edit_page.rb
@@ -23,5 +23,9 @@ module Taxonomy
     def path_prefixes_for_select
       Theme.taxon_path_prefixes
     end
+
+    def show_visibilty_checkbox?
+      taxon.draft? && taxon.parent_taxons.empty?
+    end
   end
 end

--- a/app/views/taxons/_form_fields.html.erb
+++ b/app/views/taxons/_form_fields.html.erb
@@ -31,12 +31,14 @@
   hint: I18n.t('views.taxons.displayed_on_govuk'),
   input_html: { class: 'form-control' } %>
 
-<%= f.input :visible_to_departmental_editors,
-  as: :boolean,
-  input_html: { class: 'form-control' },
-  checked_value: 'true',
-  label: I18n.t('views.taxons.visible_to_departmental_editors'),
-  hint: I18n.t('views.taxons.visible_to_departmental_editors_hint')  %>
+<% if page.show_visibilty_checkbox? %>
+  <%= f.input :visible_to_departmental_editors,
+    as: :boolean,
+    input_html: { class: 'form-control' },
+    checked_value: 'true',
+    label: I18n.t('views.taxons.visible_to_departmental_editors'),
+    hint: I18n.t('views.taxons.visible_to_departmental_editors_hint')  %>
+<% end %>
 
 <%= f.input :notes_for_editors, as: :text, input_html: { class: 'form-control' } %>
 

--- a/app/views/taxons/_form_fields.html.erb
+++ b/app/views/taxons/_form_fields.html.erb
@@ -31,6 +31,13 @@
   hint: I18n.t('views.taxons.displayed_on_govuk'),
   input_html: { class: 'form-control' } %>
 
+<%= f.input :visible_to_departmental_editors,
+  as: :boolean,
+  input_html: { class: 'form-control' },
+  checked_value: 'true',
+  label: I18n.t('views.taxons.visible_to_departmental_editors'),
+  hint: I18n.t('views.taxons.visible_to_departmental_editors_hint')  %>
+
 <%= f.input :notes_for_editors, as: :text, input_html: { class: 'form-control' } %>
 
 <%= f.input :parent_taxons, collection: page.taxons_for_select,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -100,6 +100,8 @@ en:
       preview: 'The URL of the navigation page will be:'
       displayed_on_govuk: 'Displayed on GOV.UK'
       view_similar: 'More like this'
+      visible_to_departmental_editors: 'Visible to departmental editors?'
+      visible_to_departmental_editors_hint: 'Affects the visiblity of draft taxonomy root nodes only'
   controllers:
     bulk_taggings:
       failure: We could not perform search, please try again.

--- a/spec/models/taxon_spec.rb
+++ b/spec/models/taxon_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe Taxon do
 
   describe '#visible_to_departmental_editors' do
     it "defaults to false if it's not set" do
-      taxon = Taxon.new()
+      taxon = Taxon.new
       expect(taxon.visible_to_departmental_editors).to be false
     end
 

--- a/spec/models/taxon_spec.rb
+++ b/spec/models/taxon_spec.rb
@@ -94,4 +94,21 @@ RSpec.describe Taxon do
       expect(taxon.theme).to eql("Education")
     end
   end
+
+  describe '#visible_to_departmental_editors' do
+    it "defaults to false if it's not set" do
+      taxon = Taxon.new()
+      expect(taxon.visible_to_departmental_editors).to be false
+    end
+
+    it "can be set through the initializer by value" do
+      taxon = Taxon.new(visible_to_departmental_editors: true)
+      expect(taxon.visible_to_departmental_editors).to be true
+    end
+
+    it "can be set through the initializer by string" do
+      taxon = Taxon.new(visible_to_departmental_editors: "true")
+      expect(taxon.visible_to_departmental_editors).to be true
+    end
+  end
 end

--- a/spec/services/taxonomy/build_taxon_payload_spec.rb
+++ b/spec/services/taxonomy/build_taxon_payload_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe Taxonomy::BuildTaxonPayload do
       base_path: "/taxons/my-taxon",
       description: "This is a taxon.",
       internal_name: "Internal title",
-      notes_for_editors: "Use this taxon wisely."
+      notes_for_editors: "Use this taxon wisely.",
+      visible_to_departmental_editors: true
     )
   end
 

--- a/spec/services/taxonomy/build_taxon_spec.rb
+++ b/spec/services/taxonomy/build_taxon_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Taxonomy::BuildTaxon do
         details: {
           internal_name: 'Internal name',
           notes_for_editors: 'Notes for editors',
+          visible_to_departmental_editors: true
         }
       }
     end
@@ -63,6 +64,10 @@ RSpec.describe Taxonomy::BuildTaxon do
 
     it 'assigns the notes_for_editors correctly' do
       expect(taxon.notes_for_editors).to eq("Notes for editors")
+    end
+
+    it "assigns the visible_to_departmental_editors flag correctly" do
+      expect(taxon.visible_to_departmental_editors).to be true
     end
 
     context 'without taxon parents' do

--- a/spec/services/taxonomy/edit_page_spec.rb
+++ b/spec/services/taxonomy/edit_page_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe Taxonomy::EditPage do
+  describe "#show_visibilty_checkbox?" do
+    it "is true when Taxon is in Draft state and has no parent taxons" do
+      taxon = instance_double(Taxon, draft?: true, parent_taxons: [])
+      result = Taxonomy::EditPage.new(taxon).show_visibilty_checkbox?
+
+      expect(result).to be true
+    end
+
+    it "is false when Taxon is in Draft state and has parent taxons" do
+      taxon = instance_double(Taxon, draft?: true, parent_taxons: [:mama_taxon, :papa_taxon])
+      result = Taxonomy::EditPage.new(taxon).show_visibilty_checkbox?
+
+      expect(result).to be false
+    end
+
+    it "is false when Taxon is not in Draft state and has parent taxons" do
+      taxon = instance_double(Taxon, draft?: false, parent_taxons: [:mama_taxon, :papa_taxon])
+      result = Taxonomy::EditPage.new(taxon).show_visibilty_checkbox?
+
+      expect(result).to be false
+    end
+  end
+end


### PR DESCRIPTION
UI and presenter code to support updating the
`visible_to_departmental_editors` flag on a Taxon.

Setting this flag on a draft taxon will allow editors
to see this taxon, and tag content to it.

It will not affect the public visibility however.

### Edit taxon page with new checkbox:
<img width="426" alt="screen shot 2017-05-09 at 12 00 03" src="https://cloud.githubusercontent.com/assets/12881990/25847734/3620f14a-34af-11e7-85a1-9e65cfa50365.png">

Paired with @whoojemaflip 

[Trello](https://trello.com/c/3xt6aNdb/73-make-certain-taxons-visible-as-drafts-to-whitehall-editors)
