### PR TITLE
Allow a Taxon to be saved without a linked parent taxon

### DIFF
--- a/app/services/taxonomy/update_taxon.rb
+++ b/app/services/taxonomy/update_taxon.rb
@@ -19,10 +19,8 @@ module Taxonomy
       end
 
       Services.publishing_api.put_content(content_id, payload)
-      Services.publishing_api.patch_links(
-        content_id,
-        links: { parent_taxons: Array(parent) }
-      )
+      Services.publishing_api.patch_links(content_id, links: links)
+
     rescue GdsApi::HTTPUnprocessableEntity => e
       # Since we cannot easily differentiate the reasons for getting a 422
       # error code, we do a lookup to see if a content item with the slug
@@ -43,6 +41,11 @@ module Taxonomy
 
     def payload
       Taxonomy::BuildTaxonPayload.call(taxon: taxon)
+    end
+
+    def links
+      parent_taxons = parent.empty? ? [] : Array(parent)
+      { parent_taxons: parent_taxons }
     end
   end
 end

--- a/spec/controllers/taxons_controller_spec.rb
+++ b/spec/controllers/taxons_controller_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe TaxonsController, type: :controller do
       payload = Taxonomy::BuildTaxonPayload.call(taxon: taxon)
       links = {
         links: {
-          parent_taxons: []
+          parent_taxons: ['guid']
         }
       }
 

--- a/spec/features/delete_taxon_spec.rb
+++ b/spec/features/delete_taxon_spec.rb
@@ -93,7 +93,7 @@ RSpec.feature "Delete Taxon", type: :feature do
     publishing_api_has_item(@taxon)
     publishing_api_has_links(
       content_id: @taxon_content_id,
-      links: {}
+      links: { parent_taxons: ["guid"] }
     )
 
     stub_request(:get, "https://publishing-api.test.gov.uk/v2/expanded-links/#{@taxon_content_id}")

--- a/spec/features/taxonomy_editing_spec.rb
+++ b/spec/features/taxonomy_editing_spec.rb
@@ -132,6 +132,7 @@ RSpec.feature "Taxonomy editing" do
     fill_in :taxon_internal_name, with: "My updated taxon"
     fill_in :taxon_description, with: "Description of my updated taxon."
     fill_in :taxon_notes_for_editors, with: @dummy_editor_notes
+    select "foo", from: "Parent"
 
     @update_item = stub_request(:put, %r{https://publishing-api.test.gov.uk/v2/content*})
       .with(body: /details.*#{@dummy_editor_notes}/)
@@ -157,7 +158,7 @@ RSpec.feature "Taxonomy editing" do
 
     # dropdown of parent taxons
     stub_request(:get, "https://publishing-api.test.gov.uk/v2/linkables?document_type=taxon")
-      .to_return(status: 200, body: "[]", headers: {})
+      .to_return(status: 200, body: parent_taxon_json, headers: {})
 
     stub_request(:get, "https://publishing-api.test.gov.uk/v2/links/ID-1")
       .to_return(status: 200, body: "{}", headers: {})
@@ -173,7 +174,7 @@ RSpec.feature "Taxonomy editing" do
 
     # dropdown of parent taxons
     stub_request(:get, "https://publishing-api.test.gov.uk/v2/linkables?document_type=taxon")
-      .to_return(status: 200, body: "[]", headers: {})
+      .to_return(status: 200, body: parent_taxon_json, headers: {})
 
     stub_request(:get, "https://publishing-api.test.gov.uk/v2/links/ID-1")
       .to_return(status: 200, body: "{}", headers: {})
@@ -269,5 +270,9 @@ RSpec.feature "Taxonomy editing" do
 
   def then_the_base_path_preview_is_updated
     expect(find('.js-base-path .base-path').text).to eql('/education/changed-slug')
+  end
+
+  def parent_taxon_json
+    '[{ "internal_name": "foo", "content_id": "bar", "publication_state": "baz" }]'
   end
 end

--- a/spec/services/taxonomy/update_taxon_spec.rb
+++ b/spec/services/taxonomy/update_taxon_spec.rb
@@ -1,21 +1,35 @@
 require 'rails_helper'
 
 RSpec.describe Taxonomy::UpdateTaxon do
-  let(:taxon) do
-    Taxon.new(
+  before do
+    @taxon = Taxon.new(
       title: 'A Title',
       description: 'Description',
       path_prefix: "/education",
       path_slug: '/slug',
+      parent: 'guid'
     )
   end
-  let(:publish) { described_class.call(taxon: taxon) }
+  let(:publish) { described_class.call(taxon: @taxon) }
 
   describe '.call' do
     context 'with a valid taxon form' do
       it 'publishes the document via the publishing API' do
         expect(Services.publishing_api).to receive(:put_content)
         expect(Services.publishing_api).to receive(:patch_links)
+
+        expect { publish }.to_not raise_error
+      end
+    end
+
+    context "when the taxon has no parent" do
+      before { @taxon.parent = "" }
+
+      it "patches the links hash with an empty array" do
+        expect(Services.publishing_api).to receive(:put_content)
+        expect(Services.publishing_api)
+          .to receive(:patch_links)
+          .with(@taxon.content_id, links: { parent_taxons: [] })
 
         expect { publish }.to_not raise_error
       end


### PR DESCRIPTION
It should be possible to save a Taxon in content-tagger without
a parent taxon. Previously, publishing-api would error on the patch-links call.

This makes it possible to save a taxon without a linked parent taxon.