### PR TITLE
Add World to Themes

### DIFF
--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -2,6 +2,7 @@ class Theme
   THEMES = {
     '/childcare-parenting' => 'Childcare and Parenting',
     '/education' => 'Education',
+    '/world' => 'World',
   }.freeze
 
   def self.taxon_path_prefixes


### PR DESCRIPTION
Under the proposed new worldwide model, content will live under `/world` which will be a page with the top-level list of countries. Each country will be a taxon with multiple child taxons. 

Adding an entry to `THEMES` such that `World` will surface as an option it the "Theme" drop down when visiting `/taxons/new`.

Trello: https://trello.com/c/Dgb0sE75/149-add-world-theme-to-content-tagger