### PR TITLE
Allow users to download tagged content as CSV

### DIFF
--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -106,6 +106,12 @@ class TaxonsController < ApplicationController
     redirect_to taxons_path, success: t("controllers.taxons.discard_draft_success")
   end
 
+  def download_tagged
+    export = Taxonomy::TaxonomyExport.new(taxon.content_id)
+    send_data export.to_csv,
+              filename: "#{Date.today} content tagged to #{taxon.title}.csv"
+  end
+
 private
 
   def taxon_params

--- a/app/services/taxonomy/taxonomy_export.rb
+++ b/app/services/taxonomy/taxonomy_export.rb
@@ -1,0 +1,30 @@
+require 'csv'
+
+module Taxonomy
+  class TaxonomyExport
+    COLUMNS = %w(title description content_id base_path document_type).freeze
+
+    def initialize(content_id)
+      @content_id = content_id
+    end
+
+    def to_csv
+      CSV.generate(headers: true) do |csv|
+        csv << COLUMNS
+        tagged_content.each do |tagged_item|
+          csv << tagged_item.slice(*COLUMNS)
+        end
+      end
+    end
+
+  private
+
+    def tagged_content
+      Services.publishing_api.get_linked_items(
+        @content_id,
+        link_type: 'taxons',
+        fields: COLUMNS
+      )
+    end
+  end
+end

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -51,6 +51,12 @@
 
   <h3><%= t('views.taxons.tagged_content') %></h3>
 
+  <p>
+    <%= link_to 'Download as CSV',
+      taxon_download_tagged_path(page.taxon_content_id),
+      class: 'btn btn-md btn-default' %>
+  </p>
+
   <% if page.tagged.any? %>
     <%= render 'tagged_content', tagged: page.tagged %>
   <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
     get :confirm_restore
     get :confirm_discard
     get :confirm_publish
+    get :download_tagged
     post :publish
     post :restore
     get :trash, on: :collection

--- a/spec/features/download_tagged_content_spec.rb
+++ b/spec/features/download_tagged_content_spec.rb
@@ -1,0 +1,57 @@
+require "rails_helper"
+
+RSpec.feature "Download taggings", type: :feature do
+  include ContentItemHelper
+  include PublishingApiHelper
+
+  scenario "downloading tagged content" do
+    given_a_taxon_with_tagged_content
+    when_i_visit_the_taxon_page
+    when_i_click_the_download_button
+    then_i_should_receive_a_csv_with_tagged_content
+  end
+
+  def given_a_taxon_with_tagged_content
+    @content_id = SecureRandom.uuid
+
+    taxon = content_item_with_details(
+      "Taxon 1",
+      other_fields: { content_id: @content_id }
+    )
+
+    publishing_api_has_item(taxon)
+    publishing_api_has_links(content_id: @content_id, links: {})
+    publishing_api_has_expanded_links(content_id: @content_id, expanded_links: {})
+
+    # for the show page
+    publishing_api_has_linked_items(
+      [basic_content_item("tagged content")],
+      content_id: @content_id,
+      link_type: "taxons",
+    )
+
+    # for the tagged item download
+    publishing_api_has_linked_items(
+      [basic_content_item("tagged content")],
+      content_id: @content_id,
+      link_type: "taxons",
+      fields: Taxonomy::TaxonomyExport::COLUMNS,
+    )
+  end
+
+  def when_i_visit_the_taxon_page
+    visit taxon_path(@content_id)
+  end
+
+  def when_i_click_the_download_button
+    click_link "Download as CSV"
+  end
+
+  def then_i_should_receive_a_csv_with_tagged_content
+    expect(page.body).to eql(<<~doc
+      title,description,content_id,base_path,document_type
+      tagged content,,tagged-content,/path/tagged-content,guidance
+    doc
+    )
+  end
+end


### PR DESCRIPTION
This adds a button to the taxon show page that allows users to download the tagged content as a CSV. The resulting CSV has been checked by using the Upload feature in Google Sheets.

https://trello.com/c/ezC0aq3a