### PR TITLE
Update taxons_tagged_to_content.rake to output data

### DIFF
--- a/lib/tasks/taxonomy/analysis/taxons_tagged_to_content.rake
+++ b/lib/tasks/taxonomy/analysis/taxons_tagged_to_content.rake
@@ -32,8 +32,6 @@ namespace :taxonomy do
           .join('; ')
 
         csv_row = [
-          organisations,
-          content_item['content_id'],
           content_item['link'],
           content_item['taxons'].length,
         ]

--- a/lib/tasks/taxonomy/analysis/taxons_tagged_to_content.rake
+++ b/lib/tasks/taxonomy/analysis/taxons_tagged_to_content.rake
@@ -3,7 +3,7 @@ require 'csv'
 
 namespace :taxonomy do
   namespace :analysis do
-    desc "Produces a CSV list of content items under a root taxon ID, and the taxons they are tagged to"
+    desc "Produces a CSV list of links under a root taxon ID, and the base paths they are tagged to"
     task :taxons_tagged_to_content, [:root_taxon_id] => [:environment] do |_, args|
       root_taxon_id = args.fetch(:root_taxon_id)
 
@@ -13,7 +13,7 @@ namespace :taxonomy do
       loop do
         results = GdsApi::Rummager.new(Plek.find('rummager')).search(
           filter_part_of_taxonomy_tree: root_taxon_id,
-          fields: %w(link taxons content_id organisations),
+          fields: %w(link taxons),
           start: page * results_per_page,
           count: results_per_page,
         )['results']
@@ -24,20 +24,33 @@ namespace :taxonomy do
         page += 1
       end
 
-      puts %w(organisations content_id base_path number_of_taxons).to_csv
+      content_items.each do |item|
+        details = []
+        item["taxons"].each do |taxon|
+          resp = Services.publishing_api.get_content(taxon)
+          details << resp["base_path"]
+        end
+        item["base_paths"] = details
+      end
+
+      puts %w(Link Number_of_taxons Base_path_1 Taxon_id_1 Base_path_2
+        Taxon_id_2 Base_path_3 Taxon_id_3).to_csv
 
       content_items.each do |content_item|
-        organisations = content_item.fetch('organisations', [])
-          .map { |org| org['title'] }
-          .join('; ')
-
         csv_row = [
           content_item['link'],
           content_item['taxons'].length,
         ]
 
-        content_item['taxons'].each { |taxon_id| csv_row << taxon_id }
+        max = [content_item['base_paths'].length, content_item['taxons'].length].max
 
+        for i in 0...max
+          content_item['base_paths'][i].nil? ? nil
+            : csv_row.push(content_item['base_paths'][i])
+
+          content_item['taxons'][i].nil? ? nil
+            : csv_row.push(content_item['taxons'][i])
+        end
         puts csv_row.to_csv
       end
     end

--- a/lib/tasks/taxonomy/analysis/taxons_tagged_to_content.rake
+++ b/lib/tasks/taxonomy/analysis/taxons_tagged_to_content.rake
@@ -3,7 +3,7 @@ require 'csv'
 
 namespace :taxonomy do
   namespace :analysis do
-    desc "Produces a CSV list of links under a root taxon ID, and the base paths they are tagged to"
+    desc "Produces a CSV list of document base paths from a root taxon ID, and the taxon base paths they are tagged to"
     task :taxons_tagged_to_content, [:root_taxon_id] => [:environment] do |_, args|
       root_taxon_id = args.fetch(:root_taxon_id)
 
@@ -33,8 +33,7 @@ namespace :taxonomy do
         item["base_paths"] = details
       end
 
-      puts %w(Link Number_of_taxons Base_path_1 Taxon_id_1 Base_path_2
-        Taxon_id_2 Base_path_3 Taxon_id_3).to_csv
+      puts %w(Link Number_of_taxons Base_path_1 Taxon_id_1 Base_path_2 Taxon_id_2 Base_path_3 Taxon_id_3).to_csv
 
       content_items.each do |content_item|
         csv_row = [
@@ -42,15 +41,9 @@ namespace :taxonomy do
           content_item['taxons'].length,
         ]
 
-        max = [content_item['base_paths'].length, content_item['taxons'].length].max
+        taxon_details = content_item['base_paths'].zip(content_item['taxons']).flatten
+        csv_row += taxon_details
 
-        for i in 0...max
-          content_item['base_paths'][i].nil? ? nil
-            : csv_row.push(content_item['base_paths'][i])
-
-          content_item['taxons'][i].nil? ? nil
-            : csv_row.push(content_item['taxons'][i])
-        end
         puts csv_row.to_csv
       end
     end


### PR DESCRIPTION
Update taxons_tagged_to_content.rake to output data that does not require pivoting in Google Sheets

Removed fields that are not necessary.