### PR TITLE
Add migration for Tagging Events table

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ end
 group :development do
   gem 'better_errors'
   gem 'web-console'
+  gem 'faker'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,8 @@ GEM
     factory_girl_rails (4.8.0)
       factory_girl (~> 4.8.0)
       railties (>= 3.0.0)
+    faker (1.7.3)
+      i18n (~> 0.5)
     faraday (0.11.0)
       multipart-post (>= 1.2, < 3)
     gds-api-adapters (41.5.0)
@@ -352,6 +354,7 @@ DEPENDENCIES
   capybara
   database_cleaner
   factory_girl_rails
+  faker
   gds-api-adapters (~> 41.5)
   gds-sso (~> 13.2)
   govuk-content-schema-test-helpers

--- a/app/models/tagging_event.rb
+++ b/app/models/tagging_event.rb
@@ -1,0 +1,2 @@
+class TaggingEvent < ApplicationRecord
+end

--- a/db/migrate/20170612151306_create_tagging_events.rb
+++ b/db/migrate/20170612151306_create_tagging_events.rb
@@ -1,0 +1,25 @@
+class CreateTaggingEvents < ActiveRecord::Migration[5.0]
+  def change
+    create_table :tagging_events do |t|
+      t.uuid :taxon_content_id, null: false
+      t.string :taxon_content_title, null: false
+
+      t.uuid :content_id, null: false
+      t.string :content_title, null: false
+
+      t.uuid :user_id, null: false
+      t.string :user_email, null: false
+
+      t.date :tagged_on, null: false
+      t.timestamp :tagged_at, null: false
+
+      t.integer :change, null: false
+
+      t.timestamps
+    end
+
+    add_index :tagging_events, :tagged_on
+    add_index :tagging_events, :taxon_content_id
+    add_index :tagging_events, :content_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -11,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161019130634) do
+ActiveRecord::Schema.define(version: 20170612151306) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -29,9 +28,8 @@ ActiveRecord::Schema.define(version: 20161019130634) do
     t.string   "state",                null: false
     t.string   "messages"
     t.string   "tagging_source_type"
+    t.index ["tagging_source_id"], name: "index_tag_mappings_on_tagging_source_id", using: :btree
   end
-
-  add_index "tag_mappings", ["tagging_source_id"], name: "index_tag_mappings_on_tagging_source_id", using: :btree
 
   create_table "tag_migrations", force: :cascade do |t|
     t.datetime "created_at",                           null: false
@@ -45,6 +43,23 @@ ActiveRecord::Schema.define(version: 20161019130634) do
     t.boolean  "delete_source_link",   default: false
     t.string   "source_title"
     t.string   "source_document_type"
+  end
+
+  create_table "tagging_events", force: :cascade do |t|
+    t.uuid     "taxon_content_id",    null: false
+    t.string   "taxon_content_title", null: false
+    t.uuid     "content_id",          null: false
+    t.string   "content_title",       null: false
+    t.uuid     "user_id",             null: false
+    t.string   "user_email",          null: false
+    t.date     "tagged_on",           null: false
+    t.datetime "tagged_at",           null: false
+    t.integer  "change",              null: false
+    t.datetime "created_at",          null: false
+    t.datetime "updated_at",          null: false
+    t.index ["content_id"], name: "index_tagging_events_on_content_id", using: :btree
+    t.index ["tagged_on"], name: "index_tagging_events_on_tagged_on", using: :btree
+    t.index ["taxon_content_id"], name: "index_tagging_events_on_taxon_content_id", using: :btree
   end
 
   create_table "tagging_spreadsheets", force: :cascade do |t|

--- a/lib/tasks/alternative_facts.rake
+++ b/lib/tasks/alternative_facts.rake
@@ -1,0 +1,56 @@
+require 'securerandom'
+
+namespace :alternative_facts do
+  desc "seed the tagging_events table with made up data"
+  task seed: :environment do
+    raise unless Rails.env.development?
+
+    # invent some taxons
+    taxons = (0..10).map do
+      {
+        content_title: Faker::Color.unique.color_name,
+        content_id: SecureRandom.uuid
+      }
+    end
+
+    # invent some content items
+    content_items = (0..2000).map do
+      {
+        title: Faker::Lorem.sentence,
+        id: SecureRandom.uuid
+      }
+    end
+
+    # invent some users
+    users = (0..100).map do
+      {
+        id: SecureRandom.uuid,
+        email: Faker::Internet.unique.email
+      }
+    end
+
+    # invent a date range
+    period_starts = 100.days.ago
+    period_ends = Date.yesterday
+
+    # let's invent some facts
+    10_000.times do
+      taxon = taxons.sample
+      content_item = content_items.sample
+      user = users.sample
+      timestamp = Faker::Time.between(period_starts, period_ends)
+
+      TaggingEvent.create(
+        taxon_content_id: taxon[:content_id],
+        taxon_content_title: taxon[:content_title],
+        content_id: content_item[:id],
+        content_title: content_item[:title],
+        user_id: user[:id],
+        user_email: user[:email],
+        tagged_on: timestamp.to_date,
+        tagged_at: timestamp,
+        change: [-1, 1].sample
+      )
+    end
+  end
+end


### PR DESCRIPTION
For the MVP of [the content tagging history](https://trello.com/c/GRPCKmbU/134-history-of-content-tagged-to-a-taxon), this adds the reporting-table.

Includes  a random-data seed task, which will generate 10,000 rows of `tagging_events`

```
$ bundle exec rake alternative_facts:seed
```

