### PR TITLE
Import events from CSV

### DIFF
--- a/db/migrate/20170613095944_update_tagging_events.rb
+++ b/db/migrate/20170613095944_update_tagging_events.rb
@@ -1,0 +1,9 @@
+class UpdateTaggingEvents < ActiveRecord::Migration[5.0]
+  def change
+    rename_column :tagging_events, :taxon_content_title, :taxon_title
+    rename_column :tagging_events, :content_id, :taggable_content_id
+    rename_column :tagging_events, :content_title, :taggable_title
+    rename_column :tagging_events, :user_id, :user_uid
+    remove_column :tagging_events, :user_email, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170612151306) do
+ActiveRecord::Schema.define(version: 20170613095944) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -47,17 +47,16 @@ ActiveRecord::Schema.define(version: 20170612151306) do
 
   create_table "tagging_events", force: :cascade do |t|
     t.uuid     "taxon_content_id",    null: false
-    t.string   "taxon_content_title", null: false
-    t.uuid     "content_id",          null: false
-    t.string   "content_title",       null: false
-    t.uuid     "user_id",             null: false
-    t.string   "user_email",          null: false
+    t.string   "taxon_title",         null: false
+    t.uuid     "taggable_content_id", null: false
+    t.string   "taggable_title",      null: false
+    t.uuid     "user_uid",            null: false
     t.date     "tagged_on",           null: false
     t.datetime "tagged_at",           null: false
     t.integer  "change",              null: false
     t.datetime "created_at",          null: false
     t.datetime "updated_at",          null: false
-    t.index ["content_id"], name: "index_tagging_events_on_content_id", using: :btree
+    t.index ["taggable_content_id"], name: "index_tagging_events_on_taggable_content_id", using: :btree
     t.index ["tagged_on"], name: "index_tagging_events_on_tagged_on", using: :btree
     t.index ["taxon_content_id"], name: "index_tagging_events_on_taxon_content_id", using: :btree
   end

--- a/lib/tasks/import_tagging_events.rake
+++ b/lib/tasks/import_tagging_events.rake
@@ -1,0 +1,6 @@
+task import_tagging_events: [:environment] do
+  TaggingEvent.delete_all
+  CSV.foreach(ENV['FILENAME'], headers: true) do |row|
+    TaggingEvent.create!(row.to_h)
+  end
+end


### PR DESCRIPTION
This PR changes the table layout a bit (superseding https://github.com/alphagov/content-tagger/pull/361). It allows us to import events from a CSV created by publishing-api (PR forthcoming).

Trello: https://trello.com/c/GRPCKmbU