### PR TITLE
Add chart of tagged content to taxon page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gem 'rails', '5.0.2'
 
 gem 'airbrake', '~> 4.3.1'
 gem 'bootstrap-kaminari-views', '~> 0.0.5'
+gem 'chartkick'
 gem 'jquery-ui-rails', '6.0.1'
 gem 'kaminari', '~> 0.17'
 gem 'logstasher', '~> 1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,7 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    chartkick (2.2.4)
     cliver (0.3.2)
     coderay (1.1.1)
     concurrent-ruby (1.0.5)
@@ -352,6 +353,7 @@ DEPENDENCIES
   better_errors
   bootstrap-kaminari-views (~> 0.0.5)
   capybara
+  chartkick
   database_cleaner
   factory_girl_rails
   faker

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -3,6 +3,8 @@
 //= require js.cookies.js
 //= require_self
 //= require jquery-ui
+//= require Chart.bundle
+//= require chartkick
 
 $(document).ready(function() {
   $(".select2").select2({ allowClear: true });

--- a/app/models/tagging_event.rb
+++ b/app/models/tagging_event.rb
@@ -1,2 +1,23 @@
 class TaggingEvent < ApplicationRecord
+  scope :taxon_events_in_week, (lambda do |taxon_id, date_of_start_of_week|
+    where(taxon_content_id: taxon_id)
+      .where("tagged_on >= ?", date_of_start_of_week)
+      .where("tagged_on < ?", date_of_start_of_week.next_week)
+      .order(tagged_at: :asc)
+  end)
+
+  def self.content_count_over_time(taxon_id)
+    weeks_in_period = (6.months.ago.to_date..Date.today).select(&:monday?)
+
+    content_count_acc = 0
+
+    weeks_in_period.reduce({}) do |acc, week|
+      events = taxon_events_in_week(taxon_id, week)
+      events.each do |e|
+        content_count_acc += e.change
+      end
+
+      acc.merge(week => content_count_acc)
+    end
+  end
 end

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -23,6 +23,10 @@
   <% end %>
 </div>
 
+<div class='tagged-content-chart'>
+  <%= line_chart TaggingEvent.content_count_over_time(page.taxon_content_id) %>
+</div>
+
 <div class="well state-box">
   <div class="state">
     State: <%= page.publication_state_name %>


### PR DESCRIPTION
Adds a simple line chart showing count of content tagged to the taxon, over the last 6 months.

<img width="1215" alt="screen shot 2017-06-13 at 11 21 53" src="https://user-images.githubusercontent.com/608867/27078166-890761f0-502a-11e7-9c68-ccc43db7eb74.png">
