### PR TITLE
Add associated taxons input form

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -425,6 +425,9 @@ SpecialGlobalVars:
   Description: 'Avoid Perl-style global variables.'
   Enabled: true
 
+Style/VariableNumber:
+  Enabled: false
+
 UnneededCapitalW:
   Description: 'Checks for %W when interpolation is not needed.'
   Enabled: true

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ searches for a collection, if the search is too broad, we will only show the top
 results. Instead, we ask the user to be more specific in the search query in
 order to find the collection they are looking for.
 
+### Tagging taxons to associated taxons
+
+When adding or editing a taxon, it is possible to associate it with other taxons.
+These associated taxons are stored in the links hash of a taxon's content item,
+and can be used to pull in associated content from other taxons.
+
 ## Screenshots
 
 ![Homepage](docs/screenshot-homepage.png)

--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -129,6 +129,7 @@ private
       :visible_to_departmental_editors,
       :notes_for_editors,
       :parent,
+      associated_taxons: [],
     )
   end
 

--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -11,7 +11,8 @@ class Taxon
     :internal_name,
     :notes_for_editors,
     :document_type,
-    :redirect_to
+    :redirect_to,
+    :associated_taxons,
   )
 
   include ActiveModel::Model

--- a/app/services/taxonomy/build_taxon.rb
+++ b/app/services/taxonomy/build_taxon.rb
@@ -22,6 +22,7 @@ module Taxonomy
         internal_name: content_item['details']['internal_name'],
         notes_for_editors: content_item['details']['notes_for_editors'],
         parent: parent,
+        associated_taxons: associated_taxons,
         redirect_to: content_item.dig('unpublishing', 'alternative_path'),
         visible_to_departmental_editors: content_item.dig('details', 'visible_to_departmental_editors')
       )
@@ -31,6 +32,10 @@ module Taxonomy
 
     def parent
       links.dig('parent_taxons', 0)
+    end
+
+    def associated_taxons
+      links.dig('associated_taxons')
     end
 
     def content_item

--- a/app/services/taxonomy/show_page.rb
+++ b/app/services/taxonomy/show_page.rb
@@ -48,5 +48,9 @@ module Taxonomy
     def taxons_for_select
       Linkables.new.taxons(exclude_ids: taxon_content_id)
     end
+
+    def associated_taxons
+      taxonomy_tree.root_expanded_links.dig('expanded_links', 'associated_taxons')
+    end
   end
 end

--- a/app/services/taxonomy/update_taxon.rb
+++ b/app/services/taxonomy/update_taxon.rb
@@ -1,7 +1,7 @@
 module Taxonomy
   class UpdateTaxon
     attr_reader :taxon
-    delegate :content_id, :parent, to: :taxon
+    delegate :content_id, :parent, :associated_taxons, to: :taxon
 
     class InvalidTaxonError < StandardError; end
 
@@ -44,8 +44,10 @@ module Taxonomy
     end
 
     def links
-      parent_taxons = parent.empty? ? [] : Array(parent)
-      { parent_taxons: parent_taxons }
+      {
+        parent_taxons: parent.empty? ? [] : Array(parent),
+        associated_taxons: associated_taxons.empty? ? [] : Array(associated_taxons.reject(&:blank?)),
+      }
     end
   end
 end

--- a/app/views/taxons/_form_fields.html.erb
+++ b/app/views/taxons/_form_fields.html.erb
@@ -44,3 +44,8 @@
 
 <%= f.input :parent, collection: page.taxons_for_select,
   input_html: { class: 'form-control', include_blank: true } %>
+
+<%= f.input :associated_taxons,
+    collection: page.taxons_for_select,
+    placeholder: "Choose associated taxons...",
+    input_html: { multiple: true, class: :select2 } %>

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -55,6 +55,19 @@
 
   <%= render 'taxonomy_tree', taxonomy_tree: page.taxonomy_tree %>
 
+  <% if page.associated_taxons.present? %>
+    <h3><%= t('views.taxons.associated_taxons') %></h3>
+    <div class="associated-taxons">
+      <ul>
+        <% page.associated_taxons.each do |t| %>
+          <li>
+            <%= link_to t["title"], taxon_path(t["content_id"]) %>
+          </li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
   <h3><%= t('views.taxons.tagged_content') %></h3>
 
   <p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -103,6 +103,7 @@ en:
       view_similar: 'More like this'
       visible_to_departmental_editors: 'Visible to departmental editors?'
       visible_to_departmental_editors_hint: 'Affects the visiblity of draft taxonomy root nodes only'
+      associated_taxons: Associated taxons
   controllers:
     bulk_taggings:
       failure: We could not perform search, please try again.

--- a/spec/controllers/taxons_controller_spec.rb
+++ b/spec/controllers/taxons_controller_spec.rb
@@ -93,7 +93,8 @@ RSpec.describe TaxonsController, type: :controller do
       payload = Taxonomy::BuildTaxonPayload.call(taxon: taxon)
       links = {
         links: {
-          parent_taxons: ['guid']
+          parent_taxons: ['guid'],
+          associated_taxons: ['1234'],
         }
       }
 

--- a/spec/features/delete_taxon_spec.rb
+++ b/spec/features/delete_taxon_spec.rb
@@ -93,7 +93,10 @@ RSpec.feature "Delete Taxon", type: :feature do
     publishing_api_has_item(@taxon)
     publishing_api_has_links(
       content_id: @taxon_content_id,
-      links: { parent_taxons: ["guid"] }
+      links: {
+        parent_taxons: ["guid"],
+        associated_taxons: ["1234"],
+      }
     )
 
     stub_request(:get, "https://publishing-api.test.gov.uk/v2/expanded-links/#{@taxon_content_id}")

--- a/spec/services/taxonomy/update_taxon_spec.rb
+++ b/spec/services/taxonomy/update_taxon_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe Taxonomy::UpdateTaxon do
       description: 'Description',
       path_prefix: "/education",
       path_slug: '/slug',
-      parent: 'guid'
+      parent: 'guid',
+      associated_taxons: ['1234']
     )
   end
   let(:publish) { described_class.call(taxon: @taxon) }
@@ -29,7 +30,32 @@ RSpec.describe Taxonomy::UpdateTaxon do
         expect(Services.publishing_api).to receive(:put_content)
         expect(Services.publishing_api)
           .to receive(:patch_links)
-          .with(@taxon.content_id, links: { parent_taxons: [] })
+          .with(
+            @taxon.content_id,
+            links: {
+              parent_taxons: [],
+              associated_taxons: ['1234'],
+            }
+          )
+
+        expect { publish }.to_not raise_error
+      end
+    end
+
+    context "when the taxon has no associated taxons" do
+      before { @taxon.associated_taxons = [] }
+
+      it "patches the links hash with an empty array" do
+        expect(Services.publishing_api).to receive(:put_content)
+        expect(Services.publishing_api)
+          .to receive(:patch_links)
+          .with(
+            @taxon.content_id,
+            links: {
+              parent_taxons: ['guid'],
+              associated_taxons: [],
+            }
+          )
 
         expect { publish }.to_not raise_error
       end


### PR DESCRIPTION
For https://trello.com/c/fkKqW1rA/206-allow-taxons-to-be-associated-to-each-other-in-content-tagger

This PR adds the ability to add associated taxons to taxons. It's part of the work we're doing around world locations to be rendered as taxon pages. This PR adds a new input field and shows them on the show page (if present).

When deleting a taxon that is being associated from another taxon, the publishing api automatically updates to remove the taxon accordingly, so there's no need to cater for this explicitly in the ContentTagger app.

TODO

- [x]  Add explanation to README

-------------------------
# Screenshots

## Before - edit/new

<img width="399" alt="screen shot 2017-06-13 at 14 37 22" src="https://user-images.githubusercontent.com/5112255/27085014-e057f738-5045-11e7-9fe3-b852ff3b0067.png">

## After - edit/new 
<img width="524" alt="screen shot 2017-06-13 at 14 36 59" src="https://user-images.githubusercontent.com/5112255/27085015-e44c855c-5045-11e7-85e0-95bc57e0671f.png">

-------------------------


## Before - show
<img width="813" alt="screen shot 2017-06-13 at 14 36 10" src="https://user-images.githubusercontent.com/5112255/27085029-f54d65c4-5045-11e7-8cad-22c3bc070821.png">

## After - show
<img width="781" alt="screen shot 2017-06-13 at 14 36 33" src="https://user-images.githubusercontent.com/5112255/27085032-fa9bdfb0-5045-11e7-9490-6f433c8d5470.png">
