### PR TITLE
Create taxon tagging history page

### DIFF
--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -37,6 +37,10 @@ class TaxonsController < ApplicationController
     render "taxon_not_found", status: 404
   end
 
+  def history
+    render :history, locals: { page: Taxonomy::HistoryPage.new(taxon) }
+  end
+
   def edit
     render :edit, locals: { page: Taxonomy::EditPage.new(taxon) }
   end

--- a/app/models/tagging_event.rb
+++ b/app/models/tagging_event.rb
@@ -1,6 +1,10 @@
 class TaggingEvent < ApplicationRecord
-  scope :taxon_events_in_week, (lambda do |taxon_id, date_of_start_of_week|
+  scope :for_taxon_id, (lambda do |taxon_id|
     where(taxon_content_id: taxon_id)
+  end)
+
+  scope :taxon_events_in_week, (lambda do |taxon_id, date_of_start_of_week|
+    self.for_taxon_id(taxon_id)
       .where("tagged_on >= ?", date_of_start_of_week)
       .where("tagged_on < ?", date_of_start_of_week.next_week)
       .order(tagged_at: :asc)
@@ -19,5 +23,13 @@ class TaggingEvent < ApplicationRecord
 
       acc.merge(week => content_count_acc)
     end
+  end
+
+  def added?
+    change.positive?
+  end
+
+  def removed?
+    change.negative?
   end
 end

--- a/app/services/taxonomy/history_page.rb
+++ b/app/services/taxonomy/history_page.rb
@@ -1,0 +1,21 @@
+module Taxonomy
+  class HistoryPage
+    attr_reader :taxon
+
+    def initialize(taxon)
+      @taxon = taxon
+    end
+
+    def title
+      taxon.internal_name
+    end
+
+    def taxon_content_id
+      taxon.content_id
+    end
+
+    def tagging_events
+      @_tagging_events ||= TaggingEvent.for_taxon_id(taxon_content_id).order(tagged_at: :desc)
+    end
+  end
+end

--- a/app/views/taxons/history.html.erb
+++ b/app/views/taxons/history.html.erb
@@ -1,0 +1,36 @@
+<%= display_header title: page.title, breadcrumbs: [:taxons, page.taxon] do %>
+  <%= link_to I18n.t('views.taxons.view'), taxon_path(page.taxon_content_id),
+    class: 'btn btn-md btn-default' %>
+<% end %>
+
+<div class='tagged-content-chart'>
+  <%= line_chart TaggingEvent.content_count_over_time(page.taxon_content_id) %>
+</div>
+
+<div class="tagged-content">
+  <table class="table queries-list table-bordered table-striped" data-module="filterable-table">
+    <thead>
+      <tr class="table-header">
+        <th>Date</th>
+        <th>Page</th>
+        <th>User</th>
+      </tr>
+
+      <%= render partial: 'shared/table_filter' %>
+    </thead>
+
+    <tbody>
+      <% page.tagging_events.each do |tagging_event| %>
+        <tr>
+          <td><%= tagging_event.tagged_on %></td>
+          <td>
+            <% if tagging_event.removed? %>
+              <s>
+            <% end %>
+            <%= tagging_event['taggable_title'] %></td>
+          <td><%= User.find_by(uid: tagging_event['user_uid'])&.name || "A Whitehall User" %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -12,8 +12,14 @@
       <i class="glyphicon glyphicon-download-alt"></i>
       <%= I18n.t('views.taxons.download_csv') %>
     <% end %>
+
+    <%= link_to taxon_history_path(page.taxon_content_id), class: 'btn btn-default' do %>
+      <i class='glyphicon glyphicon-time'></i>
+      <%= I18n.t('views.taxons.history') %>
+    <% end %>
   <% end %>
 <% end %>
+
 
 <div class='view-on-site'>
   <% if page.published? %>
@@ -21,10 +27,6 @@
   <% elsif page.draft? %>
     <%= link_to "View draft page", website_url(page.base_path, draft: true) %>
   <% end %>
-</div>
-
-<div class='tagged-content-chart'>
-  <%= line_chart TaggingEvent.content_count_over_time(page.taxon_content_id) %>
 </div>
 
 <div class="well state-box">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -75,6 +75,7 @@ en:
       deleted_title: Deleted taxons
       edit: Edit taxon
       view: View taxon
+      history: Taxon history
       add_taxon: Add a taxon
       copy_taxon: Export taxons with IDs for spreadsheet
       delete_taxon: Delete taxon

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
     get :confirm_discard
     get :confirm_publish
     get :download_tagged
+    get :history
     post :publish
     post :restore
     get :trash, on: :collection

--- a/spec/factories/tagging_event.rb
+++ b/spec/factories/tagging_event.rb
@@ -1,0 +1,12 @@
+FactoryGirl.define do
+  factory :tagging_event do
+    taxon_content_id { SecureRandom.uuid }
+    taxon_title 'Test taxon title'
+    taggable_content_id { SecureRandom.uuid }
+    taggable_title 'Test taggable title'
+    user_uid { SecureRandom.uuid }
+    tagged_on { 1.week.ago }
+    tagged_at { DateTime.now - 1.week }
+    change 1
+  end
+end

--- a/spec/features/taxon_history_spec.rb
+++ b/spec/features/taxon_history_spec.rb
@@ -1,0 +1,68 @@
+require "rails_helper"
+
+RSpec.feature "Taxon history", type: :feature do
+  include ContentItemHelper
+
+  scenario "deleting a taxon with no children or tagged content" do
+    given_taxon_with_some_tagging_events
+    when_i_visit_the_taxon_page
+    and_i_click_taxon_history_button
+    then_i_see_a_table_of_related_tagging_events
+  end
+
+  def given_taxon_with_some_tagging_events
+    @tagging_events = [
+      create(:tagging_event, taxon_content_id: taxon.content_id),
+      create(:tagging_event, taxon_content_id: taxon.content_id)
+    ]
+  end
+
+  def when_i_visit_the_taxon_page
+    visit taxon_path(taxon.content_id)
+  end
+
+  def and_i_click_taxon_history_button
+    click_link "Taxon history"
+  end
+
+  def then_i_see_a_table_of_related_tagging_events
+    table = find('table')
+    table_head = table.all('thead th').map(&:text)
+    table_body = table.find('tbody').text
+
+    expect(table_head).to include(/Date/i)
+    expect(table_head).to include(/Page/i)
+    expect(table_head).to include(/User/i)
+
+    expect(table_body).to include(@tagging_events[0].taggable_title)
+    expect(table_body).to include(@tagging_events[1].taggable_title)
+  end
+
+  def taxon
+    @_taxon ||= begin
+      id = SecureRandom.uuid
+
+      publishing_api_has_item content_item_with_details(
+        "blah",
+        other_fields: { content_id: id }
+      )
+
+      publishing_api_has_links(
+        content_id: id,
+        links: {}
+      )
+
+      publishing_api_has_expanded_links(
+        content_id: id,
+        expanded_links: {}
+      )
+      publishing_api_has_linked_items(
+        [],
+        content_id: id,
+        link_type: "taxons"
+      )
+
+      build(:taxon, content_id: id)
+    end
+  end
+end

--- a/spec/models/tagging_event_spec.rb
+++ b/spec/models/tagging_event_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe TaggingEvent do
+  describe ".content_count_over_time" do
+    before do
+      @taxon_id = SecureRandom.uuid
+      create(:tagging_event, taxon_content_id: @taxon_id, tagged_on: 2.weeks.ago)
+      create(:tagging_event, taxon_content_id: @taxon_id, tagged_on: 4.weeks.ago)
+    end
+
+    let(:result) { TaggingEvent.content_count_over_time(@taxon_id) }
+
+    it "returns 6 months worth of weeks" do
+      expect(result.size).to be_in (25..27).to_a
+    end
+
+    it "returns the cumulative count of content tagged to a taxon" do
+      expect(result[Date.today.monday]).to eq 2
+    end
+  end
+
+  describe "#added?" do
+    it "is true when change is +ve" do
+      expect(TaggingEvent.new(change: 1).added?).to be true
+    end
+
+    it "is false when change is -ve" do
+      expect(TaggingEvent.new(change: -1).added?).to be false
+    end
+  end
+
+  describe "#removed?" do
+    it "is true when change is -ve" do
+      expect(TaggingEvent.new(change: -1).removed?).to be true
+    end
+
+    it "is false when change is +ve" do
+      expect(TaggingEvent.new(change: 1).removed?).to be false
+    end
+  end
+end


### PR DESCRIPTION
The tagging history view of a taxon shows a graph of total content
tagged to this taxon, weekly, for the last 6 months.
There is a list showing the changes over time.

<img width="1170" alt="screen shot 2017-06-13 at 16 37 41" src="https://user-images.githubusercontent.com/608867/27090969-a5994bd6-5056-11e7-9acd-b362daba8476.png">