### PR TITLE
Add new columns to tagging events

### DIFF
--- a/db/migrate/20170613155946_add_document_super_type_to_tagging_events.rb
+++ b/db/migrate/20170613155946_add_document_super_type_to_tagging_events.rb
@@ -1,0 +1,7 @@
+class AddDocumentSuperTypeToTaggingEvents < ActiveRecord::Migration[5.0]
+  def change
+    execute 'DELETE FROM tagging_events'
+    add_column :tagging_events, :taggable_navigation_document_supertype, :string, null: false
+    add_column :tagging_events, :taggable_base_path, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170613095944) do
+ActiveRecord::Schema.define(version: 20170613155946) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -46,16 +46,18 @@ ActiveRecord::Schema.define(version: 20170613095944) do
   end
 
   create_table "tagging_events", force: :cascade do |t|
-    t.uuid     "taxon_content_id",    null: false
-    t.string   "taxon_title",         null: false
-    t.uuid     "taggable_content_id", null: false
-    t.string   "taggable_title",      null: false
-    t.uuid     "user_uid",            null: false
-    t.date     "tagged_on",           null: false
-    t.datetime "tagged_at",           null: false
-    t.integer  "change",              null: false
-    t.datetime "created_at",          null: false
-    t.datetime "updated_at",          null: false
+    t.uuid     "taxon_content_id",                       null: false
+    t.string   "taxon_title",                            null: false
+    t.uuid     "taggable_content_id",                    null: false
+    t.string   "taggable_title",                         null: false
+    t.uuid     "user_uid",                               null: false
+    t.date     "tagged_on",                              null: false
+    t.datetime "tagged_at",                              null: false
+    t.integer  "change",                                 null: false
+    t.datetime "created_at",                             null: false
+    t.datetime "updated_at",                             null: false
+    t.string   "taggable_navigation_document_supertype", null: false
+    t.string   "taggable_base_path",                     null: false
     t.index ["taggable_content_id"], name: "index_tagging_events_on_taggable_content_id", using: :btree
     t.index ["tagged_on"], name: "index_tagging_events_on_tagged_on", using: :btree
     t.index ["taxon_content_id"], name: "index_tagging_events_on_taxon_content_id", using: :btree

--- a/spec/factories/tagging_event.rb
+++ b/spec/factories/tagging_event.rb
@@ -4,6 +4,8 @@ FactoryGirl.define do
     taxon_title 'Test taxon title'
     taggable_content_id { SecureRandom.uuid }
     taggable_title 'Test taggable title'
+    taggable_base_path '/some/example'
+    taggable_navigation_document_supertype 'guidance'
     user_uid { SecureRandom.uuid }
     tagged_on { 1.week.ago }
     tagged_at { DateTime.now - 1.week }


### PR DESCRIPTION
- `navigation_document_supertype` is the a supertype which is used to differentiate guidance and other content
- `base_path` is useful to link out to the tagged page

https://trello.com/c/GRPCKmbU