### PR TITLE
Bare bones taxonomy analytics page

### DIFF
--- a/app/controllers/analytics_controller.rb
+++ b/app/controllers/analytics_controller.rb
@@ -1,0 +1,5 @@
+class AnalyticsController < ApplicationController
+  def index
+    render :index, locals: { page: Analytics::IndexPage.new(params) }
+  end
+end

--- a/app/controllers/analytics_controller.rb
+++ b/app/controllers/analytics_controller.rb
@@ -1,5 +1,5 @@
 class AnalyticsController < ApplicationController
   def index
-    render :index, locals: { page: Analytics::IndexPage.new(params) }
+    render :index, locals: { page: Analytics::IndexPage.new }
   end
 end

--- a/app/models/tagging_event.rb
+++ b/app/models/tagging_event.rb
@@ -10,6 +10,20 @@ class TaggingEvent < ApplicationRecord
       .order(tagged_at: :asc)
   end)
 
+  def self.content_counts_by_taxon
+    group(:taxon_title, :taxon_content_id)
+      .sum(:change)
+      .sort_by { |_, v| v }
+      .reverse
+      .map do |result|
+        {
+          title: result[0][0],
+          id: result[0][1],
+          count: result[1]
+        }
+      end
+  end
+
   def self.content_count_over_time(taxon_id)
     weeks_in_period = (6.months.ago.to_date..Date.today).select(&:monday?)
 

--- a/app/services/analytics/index_page.rb
+++ b/app/services/analytics/index_page.rb
@@ -1,0 +1,19 @@
+module Analytics
+  class IndexPage
+    attr_reader :params
+
+    def initialize(params)
+      @params = params
+    end
+
+    def taxons
+      TaggingEvent.content_counts_by_taxon
+    end
+
+  private
+
+    def remote_taxons
+      @remote_taxons ||= RemoteTaxons.new
+    end
+  end
+end

--- a/app/services/analytics/index_page.rb
+++ b/app/services/analytics/index_page.rb
@@ -1,19 +1,7 @@
 module Analytics
   class IndexPage
-    attr_reader :params
-
-    def initialize(params)
-      @params = params
-    end
-
     def taxons
       TaggingEvent.content_counts_by_taxon
-    end
-
-  private
-
-    def remote_taxons
-      @remote_taxons ||= RemoteTaxons.new
     end
   end
 end

--- a/app/views/analytics/index.html.erb
+++ b/app/views/analytics/index.html.erb
@@ -1,0 +1,19 @@
+<%= display_header title: t("views.analytics"), breadcrumbs: [t('views.analytics')] %>
+
+<table class="table queries-list table-bordered table-striped">
+  <thead>
+    <tr class="table-header">
+      <th>Taxon</th>
+      <th>Content Items</th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% page.taxons.each do |taxon| %>
+      <tr>
+        <td><%= link_to taxon[:title], taxon_history_path(taxon[:id]) %></td>
+        <td><%= taxon[:count] %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,6 +16,10 @@
   <li class='<%= active_navigation_item.in?(%w[taxons taxon_migrations]) ? 'active' : nil %>'>
     <%= link_to t('navigation.taxons'), taxons_path %>
   </li>
+
+  <li class='<%= active_navigation_item == 'analytics' ? 'active' : nil %>'>
+    <%= link_to t('navigation.analytics'), analytics_path %>
+  </li>
 <% end %>
 
 <%= render template: 'layouts/govuk_admin_template' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,5 +1,6 @@
 en:
   navigation:
+    analytics: Analytics
     tagging_content: Edit a page
     tagging_title: Which page do you want to edit?
     taxons: 'Edit taxonomy'
@@ -50,6 +51,7 @@ en:
       imported: Tagging completed
       errored: Errored
   views:
+    analytics: 'Taxonomy analytics'
     tag_update_progress_bar: "%{completed} of %{total} pages updated"
     tag_migrations:
       new:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,8 @@ Rails.application.routes.draw do
     delete :discard_draft
   end
 
+  get '/analytics' => 'analytics#index'
+
   resources :copy_taxons, only: [:index], path: 'copy-taxons'
 
   resources :taggings, only: %i(show update), param: :content_id do

--- a/spec/features/analytics_index_spec.rb
+++ b/spec/features/analytics_index_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.feature "Analytics index", type: :feature do
+  scenario "Viewing the index page" do
+    given_some_tagging_events
+    when_i_visit_the_analytics_page
+    then_i_should_see_the_name_of_the_taxon
+    and_the_count_of_its_tagged_content
+  end
+
+  def given_some_tagging_events
+    id = SecureRandom.uuid
+    create(:tagging_event, taxon_content_id: id, taxon_title: taxon_title)
+    create(:tagging_event, taxon_content_id: id, taxon_title: taxon_title)
+  end
+
+  def when_i_visit_the_analytics_page
+    visit analytics_path
+  end
+
+  def then_i_should_see_the_name_of_the_taxon
+    expect(table_contents).to include(taxon_title)
+  end
+
+  def and_the_count_of_its_tagged_content
+    expect(table_contents).to include(TaggingEvent.all.count.to_s)
+  end
+
+  def table_contents
+    find('table').text
+  end
+
+  def taxon_title
+    "I am a taxon, from taxonia."
+  end
+end


### PR DESCRIPTION
Adds a new page and top level navigation item, for the purposes of exposing the performance of the GOV.UK taxonomy. 

The page shows a list of terms, ordered by the amount of content currently tagged to them.

<img width="1206" alt="screen shot 2017-06-14 at 11 47 46" src="https://user-images.githubusercontent.com/608867/27128655-55c9e6e6-50f7-11e7-8ec5-8f2f87c91290.png">

