### PR TITLE
Switch Airbrake gem to use gov.uk fork

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,6 @@ source 'https://rubygems.org'
 
 gem 'rails', '5.0.2'
 
-gem 'airbrake', '~> 4.3.1'
 gem 'bootstrap-kaminari-views', '~> 0.0.5'
 gem 'chartkick'
 gem 'jquery-ui-rails', '6.0.1'
@@ -16,6 +15,7 @@ gem 'uglifier', '~> 3.2'
 gem 'unicorn', '~> 5.0.0'
 
 # GDS managed dependencies
+gem 'airbrake', github: 'alphagov/airbrake', branch: 'silence-dep-warnings-for-rails-5'
 gem 'gds-api-adapters', '~> 41.5'
 gem 'gds-sso', '~> 13.2'
 gem 'govuk_admin_template', '~> 5.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,13 @@
+GIT
+  remote: git://github.com/alphagov/airbrake.git
+  revision: ad9c926a56535c48f95c33824a76e10bc8f91179
+  branch: silence-dep-warnings-for-rails-5
+  specs:
+    airbrake (4.3.8)
+      builder
+      multi_json
+      rails (>= 5.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -40,9 +50,6 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     addressable (2.3.8)
-    airbrake (4.3.8)
-      builder
-      multi_json
     arel (7.1.4)
     ast (2.3.0)
     autoprefixer-rails (6.7.7.2)
@@ -348,7 +355,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  airbrake (~> 4.3.1)
+  airbrake!
   awesome_print
   better_errors
   bootstrap-kaminari-views (~> 0.0.5)


### PR DESCRIPTION
The 4.x branch of Airbrake throws a bunch of warning messages on initialization.
There's an alphagov fork which solves this, we just have to use it.