### PR TITLE
Add temporary rake task to unpublish /api

### DIFF
--- a/lib/tasks/unpublish.rake
+++ b/lib/tasks/unpublish.rake
@@ -1,0 +1,15 @@
+namespace :unpublish do
+  desc "Unpublish the content item related to the content api: /api"
+  task content_api: :environment do
+    content_id =
+      Services.publishing_api.lookup_content_id(base_path: '/api')
+
+    raise "Could not find content ID for '/api'." if content_id.nil?
+
+    Services.publishing_api.unpublish(
+      content_id,
+      type: 'gone',
+      explanation: "The Content API has been retired."
+    )
+  end
+end


### PR DESCRIPTION
We are retiring the Content API. The application used to publish a
special route: `/api`. Since the application has now been retired, we
need to unpublish that content item.

This commit adds a temporary rake task that will unpublish the enpoint.

**Note**:

Ideally, this should have been done in the app itself. When I realised I
needed to unpublish it, the app was no longer deployable, which is why
I'm creating this temporary rake task in `content-tagger`.

After the rake task runs in production, we should delete it.

Trello: https://trello.com/c/2MF97xce/154-retire-content-api