### PR TITLE
Improve trending topics

### DIFF
--- a/app/services/analytics/trends_page.rb
+++ b/app/services/analytics/trends_page.rb
@@ -8,10 +8,10 @@ module Analytics
 
     DEFAULT_QUERY = 'changes_in_the_last_two_weeks'.freeze
 
-    attr_reader :time_query
+    attr_reader :time_span_query
 
     def initialize(time_span_query)
-      @time_query = TIME_QUERIES[time_span_query || DEFAULT_QUERY]
+      @time_span_query = time_span_query
     end
 
     def self.queries
@@ -20,6 +20,10 @@ module Analytics
 
     def queries
       TIME_QUERIES.keys
+    end
+
+    def time_query
+      TIME_QUERIES[time_span_query || DEFAULT_QUERY]
     end
 
     def taxons

--- a/app/views/analytics/trends.html.erb
+++ b/app/views/analytics/trends.html.erb
@@ -17,6 +17,10 @@
   <% end %>
 </ul>
 
+<div class='tagged-content-chart'>
+  <%= column_chart page.change_over_time, stacked: true, min: 0 %>
+</div>
+
 <table class="table queries-list table-bordered table-striped">
   <thead>
     <tr class="table-header">

--- a/app/views/analytics/trends.html.erb
+++ b/app/views/analytics/trends.html.erb
@@ -10,9 +10,10 @@
   <li role="presentation"><%= link_to "Tagging activity", activity_path %></li>
 </ul>
 
-<ul class='filters'>
+<ul class='filters list-inline'>
   <% page.queries.each do |query| %>
-    <li><%= link_to query.humanize, trends_path(query: query) %></li>
+    <% classes = (page.time_span_query == query) ? 'btn btn-success active' : 'btn btn-default' %>
+    <li><%= button_to query.humanize, trends_path(query: query), class: classes, method: :get %></li>
   <% end %>
 </ul>
 
@@ -20,8 +21,8 @@
   <thead>
     <tr class="table-header">
       <th>Taxon</th>
-      <th>Guidance Change</th>
-      <th>Other Change</th>
+      <th>Guidance</th>
+      <th>Other</th>
     </tr>
   </thead>
 


### PR DESCRIPTION
Improves the time query links on the trending topics page, and adds a graph showing content changes over the selected time period

<img width="1210" alt="screen shot 2017-06-15 at 13 22 47" src="https://user-images.githubusercontent.com/608867/27181064-d500ccf0-51cd-11e7-9335-c0e48c2df7d7.png">
