### PR TITLE
Bring back /api prefix by publishing it to publishing-api

### DIFF
--- a/lib/tasks/publishing_api/publish_api_prefix.rake
+++ b/lib/tasks/publishing_api/publish_api_prefix.rake
@@ -1,0 +1,33 @@
+require 'logger'
+require 'gds_api/publishing_api'
+require 'gds_api/publishing_api/special_route_publisher'
+
+namespace :publishing_api do
+  desc "Publish /api route to publishing_api"
+  task publish_api_prefix: :environment do
+    puts "Content Tagger is claiming path /api"
+    endpoint = Services.publishing_api.options[:endpoint_url]
+    Services.publishing_api.put_json("#{endpoint}/paths/api", publishing_app: "content-tagger", override_existing: true)
+
+    publishing_api = GdsApi::PublishingApiV2.new(
+      Plek.new.find('publishing-api'),
+      bearer_token: ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example'
+    )
+
+    special_route_publisher = GdsApi::PublishingApi::SpecialRoutePublisher.new(
+      logger: Logger.new(STDOUT),
+      publishing_api: publishing_api
+    )
+
+    puts "Publishing /api..."
+    special_route_publisher.publish(
+      title: 'Public content API',
+      description: '/api was used by Content API which has been retired. It is used by other applications such as search, whitehall, content-store and calendars.',
+      content_id: "363a1f3a-5e80-4ff7-8f6f-be1bec62821f",
+      base_path: '/api',
+      type: 'prefix',
+      publishing_app: 'content-tagger',
+      rendering_app: 'publicapi'
+    )
+  end
+end


### PR DESCRIPTION
This commit makes content-tagger the publishing-app of `/api` prefix,
this is because content-api has been retired.

This commit also aims to fix the unpublishing of the /api prefix which was
done [here](https://github.com/alphagov/content-tagger/pull/369/commits/42a2bbcd98847a3b63a8ec77f7d89f4abb59e2ec)

The majority of the code was brought from:

- https://github.com/gds-attic/govuk_content_api/blob/d292c2ce0059e7899a7f03dd8e8587a6116c802b/lib/tasks/publishing_api.rake
- https://github.com/alphagov/publisher/blob/c91569eda28cfd6768f65b4e1444dbbb71f8dc46/lib/tasks/calculators.rake#L5-L11
