### PR TITLE
Allow users to download all taxons

### DIFF
--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -106,6 +106,11 @@ class TaxonsController < ApplicationController
     redirect_to taxons_path, success: t("controllers.taxons.discard_draft_success")
   end
 
+  def download
+    export = Taxonomy::TaxonsExport.new
+    send_data export.to_csv, filename: "#{Date.today} Taxonomy.csv"
+  end
+
   def download_tagged
     export = Taxonomy::TaxonomyExport.new(taxon.content_id)
     send_data export.to_csv,

--- a/app/services/taxonomy/taxons_export.rb
+++ b/app/services/taxonomy/taxons_export.rb
@@ -1,0 +1,26 @@
+require 'csv'
+
+module Taxonomy
+  class TaxonsExport
+    COLUMNS = %w(title description content_id base_path).freeze
+
+    def to_csv
+      CSV.generate(headers: true) do |csv|
+        csv << COLUMNS
+        taxons.each do |taxon|
+          csv << taxon.to_h.slice(*COLUMNS)
+        end
+      end
+    end
+
+  private
+
+    def taxons
+      Services.publishing_api.get_content_items(
+        document_type: 'taxon',
+        fields: COLUMNS,
+        per_page: 1000,
+      )["results"]
+    end
+  end
+end

--- a/app/views/taxons/index.html.erb
+++ b/app/views/taxons/index.html.erb
@@ -4,6 +4,11 @@
       <%= I18n.t('views.taxons.add_taxon') %>
     </i>
   <% end %>
+
+  <%= link_to download_taxons_path, class: 'btn btn-md btn-default' do %>
+    <i class="glyphicon glyphicon-download"></i>
+    Download published taxons as CSV
+  <% end %>
 <% end %>
 
 <ul class="nav nav-tabs">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
     get :confirm_discard
     get :confirm_publish
     get :download_tagged
+    get :download, on: :collection
     post :publish
     post :restore
     get :trash, on: :collection

--- a/spec/features/download_taxons_spec.rb
+++ b/spec/features/download_taxons_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+RSpec.feature "Download taggings", type: :feature do
+  include ContentItemHelper
+  include PublishingApiHelper
+
+  scenario "downloading tagged content" do
+    given_a_taxon_exists
+    when_i_visit_the_taxons_page
+    when_i_click_the_download_button
+    then_i_should_receive_a_csv_with_taxons
+  end
+
+  def given_a_taxon_exists
+    content_id = "dfd51e0c-ce3f-4cb5-8c0d-4a726e54ba1e"
+
+    taxon = content_item_with_details(
+      "My Taxon",
+      other_fields: { content_id: content_id, description: "Foo" }
+    )
+
+    publishing_api_has_item(taxon)
+    publishing_api_has_links(content_id: content_id, links: {})
+    publishing_api_has_expanded_links(content_id: content_id, expanded_links: {})
+
+    stub_request(:get, %r{https://publishing-api.test.gov.uk/v2/content*})
+      .to_return(body: { results: [taxon], total: 1, pages: 1, current_page: 1 }.to_json)
+  end
+
+  def when_i_visit_the_taxons_page
+    visit taxons_path
+  end
+
+  def when_i_click_the_download_button
+    click_link "Download published taxons as CSV"
+  end
+
+  def then_i_should_receive_a_csv_with_taxons
+    expect(page.body).to eql(<<~doc
+      title,description,content_id,base_path
+      My Taxon,Foo,dfd51e0c-ce3f-4cb5-8c0d-4a726e54ba1e,/path/my-taxon
+    doc
+    )
+  end
+end


### PR DESCRIPTION
This adds a new button to the taxons page that allows users to download all published taxons in the system.

![screen shot 2017-06-16 at 16 52 56](https://user-images.githubusercontent.com/233676/27234270-50de7bb0-52b4-11e7-8f1a-ec480a7cb330.png)
![screen shot 2017-06-16 at 16 53 04](https://user-images.githubusercontent.com/233676/27234269-50dde15a-52b4-11e7-86cd-9d5f05f44eab.png)

https://trello.com/c/OthE8021