### PR TITLE
Persist search query across tabs of Taxon Index page

### DIFF
--- a/app/services/taxonomy/index_page.rb
+++ b/app/services/taxonomy/index_page.rb
@@ -21,8 +21,7 @@ module Taxonomy
     end
 
     def query
-      return '' unless params[:taxon_search].present?
-      params[:taxon_search][:query]
+      params[:q]
     end
 
   private

--- a/app/views/taxons/index.html.erb
+++ b/app/views/taxons/index.html.erb
@@ -12,9 +12,9 @@
 <% end %>
 
 <ul class="nav nav-tabs">
-  <li role="presentation" class="<%= current_page?(taxons_path) ? "active" : nil%>"><%= link_to "Published", taxons_path %></li>
-  <li role="presentation" class="<%= current_page?(drafts_taxons_path) ? "active" : nil%>"><%= link_to "Draft", drafts_taxons_path %></li>
-  <li role="presentation" class="<%= current_page?(trash_taxons_path) ? "active" : nil%>"><%= link_to "Deleted", trash_taxons_path %></li>
+  <li role="presentation" class="<%= current_page?(taxons_path) ? "active" : nil%>"><%= link_to "Published", taxons_path(q: page.query) %></li>
+  <li role="presentation" class="<%= current_page?(drafts_taxons_path) ? "active" : nil%>"><%= link_to "Draft", drafts_taxons_path(q: page.query) %></li>
+  <li role="presentation" class="<%= current_page?(trash_taxons_path) ? "active" : nil%>"><%= link_to "Deleted", trash_taxons_path(q: page.query) %></li>
 </ul>
 
 <div class="lead">
@@ -24,7 +24,7 @@
 <%= simple_form_for :taxon_search, url: '', method: :get do |f| %>
   <div class="form-group">
     <%= f.input :query,
-      input_html: { type: :text, class: 'form-control', value: page.query },
+      input_html: { type: :text, class: 'form-control', value: page.query, name: 'q' },
       label: false %>
     <%= f.submit "Search", class: "btn btn-md btn-success" %>
   </div>


### PR DESCRIPTION
And improve the URL with a more idiomatic search query param.

[Trello](https://trello.com/c/ObqB9fiw/152-make-sure-search-term-is-persisted-when-changing-tabs-in-content-tagger)