### PR TITLE
Add rake task to publish world taxons

### DIFF
--- a/lib/tasks/taxonomy/publish_worldwide_taxons.rake
+++ b/lib/tasks/taxonomy/publish_worldwide_taxons.rake
@@ -1,0 +1,18 @@
+namespace :taxonomy do
+  desc "Publish taxons for worldwide taxonomy"
+  task publish_taxons_for_worldwide_taxonomy: :environment do
+    def all_taxons
+      Services
+        .publishing_api
+        .get_content_items(
+          document_type: 'taxon',
+          per_page: 5000,
+        ).to_h["results"]
+    end
+
+    world_taxons = all_taxons.select { |t| t["base_path"].starts_with?("/world") }
+    world_taxons.each do |taxon|
+      Services.publishing_api.publish(taxon["content_id"], "major")
+    end
+  end
+end


### PR DESCRIPTION
For https://trello.com/c/Byxw1gA3/250-automate-publishing-of-worldwide-taxons

We're creating 2300 taxons for the Worldwide taxonomy. This PR adds a rake task to publish them all programmatically rather than having to do it manually in the UI.