### PR TITLE
Added manage root taxons option to the Edit taxonomy page.

### DIFF
--- a/app/controllers/root_taxons_controller.rb
+++ b/app/controllers/root_taxons_controller.rb
@@ -1,0 +1,16 @@
+class RootTaxonsController < ApplicationController
+  def index
+    render :index, locals: { page: RootTaxonsForm.new }
+  end
+
+  def update
+    RootTaxonsForm.new(root_taxons_params).update
+    redirect_to taxons_path
+  end
+
+private
+
+  def root_taxons_params
+    params.require(:root_taxons_form).permit(root_taxons: [])
+  end
+end

--- a/app/forms/root_taxons_form.rb
+++ b/app/forms/root_taxons_form.rb
@@ -1,0 +1,28 @@
+class RootTaxonsForm
+  include ActiveModel::Model
+
+  HOMEPAGE_CONTENT_ID = "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a".freeze
+
+  attr_accessor :root_taxons
+
+  def initialize(attributes = {})
+    super
+    @root_taxons ||= fetch_root_taxons
+  end
+
+  def taxons_for_select
+    Linkables.new.taxons
+  end
+
+  def update
+    Services.publishing_api.patch_links(HOMEPAGE_CONTENT_ID,
+                                        links: { root_taxons: root_taxons.reject(&:empty?) })
+  end
+
+private
+
+  def fetch_root_taxons
+    homepage_links = Services.publishing_api.get_links(HOMEPAGE_CONTENT_ID)
+    homepage_links.dig('links', 'root_taxons') || []
+  end
+end

--- a/app/views/root_taxons/index.html.erb
+++ b/app/views/root_taxons/index.html.erb
@@ -1,0 +1,19 @@
+<%= display_header title: t('navigation.manage_root_taxons'),
+                   breadcrumbs: [t('navigation.manage_root_taxons')] %>
+
+<div class="lead">
+  Add or remove root taxons.
+</div>
+
+
+<%= simple_form_for page, url: root_taxons_path, method: :put do |f| %>
+
+
+    <%= f.input :root_taxons,
+                collection: page.taxons_for_select,
+                placeholder: "Choose root taxons...",
+                input_html: { multiple: true, class: :select2 } %>
+
+    <%= f.submit "Save & publish", class: "btn btn-lg btn-success submit-button" %>
+
+<% end %>

--- a/app/views/taxons/index.html.erb
+++ b/app/views/taxons/index.html.erb
@@ -5,6 +5,12 @@
     </i>
   <% end %>
 
+  <%= link_to root_taxons_path, class: 'btn btn-default' do %>
+      <i class="glyphicon glyphicon-plus"></i>
+        Manage root taxons
+      </i>
+  <% end %>
+
   <%= link_to download_taxons_path, class: 'btn btn-md btn-default' do %>
     <i class="glyphicon glyphicon-download"></i>
     Download published taxons as CSV

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,9 +12,7 @@ Bundler.require(*Rails.groups)
 
 module ContentTagger
   class Application < Rails::Application
-
     # Configure blacklisted tag types by publishing app
     config.blacklisted_tag_types = config_for(:blacklisted_tag_types)
-
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -47,7 +47,7 @@ Rails.application.configure do
   config.log_level = :debug
 
   # Prepend all log lines with the following tags.
-  config.log_tags = [ :request_id ]
+  config.log_tags = [:request_id]
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store

--- a/config/initializers/customize_error.rb
+++ b/config/initializers/customize_error.rb
@@ -1,3 +1,3 @@
-ActionView::Base.field_error_proc = Proc.new do |html_tag, _|
+ActionView::Base.field_error_proc = proc do |html_tag, _|
   html_tag
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,6 +7,7 @@ en:
     bulk_tag: 'Bulk tag'
     tag_migration: 'Bulk tag history'
     tag_importer: 'Bulk tag by upload'
+    manage_root_taxons: 'Manage root taxons'
   errors:
     invalid_taxon: There was a problem with your request. We have been notified of the issue and will fix it as soon as possible.
     invalid_taxon_base_path: A taxon with this slug already exists. If the taxon has been deleted, you can restore it.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,6 +53,9 @@ Rails.application.routes.draw do
 
   resources :taxonomies, only: %i(show), param: :content_id
 
+  resources :root_taxons, only: [:index]
+  resource :root_taxons, only: [:update]
+
   if Rails.env.development?
     mount GovukAdminTemplate::Engine, at: '/style-guide'
 

--- a/spec/controllers/root_taxons_controller_spec.rb
+++ b/spec/controllers/root_taxons_controller_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe RootTaxonsController, type: :controller do
+  describe "#index" do
+    it "gets root links" do
+      publishing_api_has_links("content_id" => RootTaxonsForm::HOMEPAGE_CONTENT_ID,
+                               "links" => { "root_taxons" => [] })
+
+      get :index
+
+      expect(response.code).to eql "200"
+    end
+  end
+
+  describe "#update" do
+    it "redirects to the taxons index page" do
+      stub_any_publishing_api_patch_links
+      put :update, params: { 'root_taxons_form' => { root_taxons: ["", "ID-1", "ID-2"] } }
+
+      expect(response).to redirect_to(taxons_path)
+    end
+  end
+end

--- a/spec/factories/linkable_taxon_hash.rb
+++ b/spec/factories/linkable_taxon_hash.rb
@@ -1,0 +1,19 @@
+FactoryGirl.define do
+  factory :linkable_taxon_hash, class: Hash do
+    sequence :title, 1 do |n|
+      "Title of Taxon #{n}"
+    end
+    sequence :content_id, 1 do |n|
+      "ID-#{n}"
+    end
+    sequence :base_path, 1 do |n|
+      "/education/#{n}"
+    end
+    sequence :internal_name, 1 do |n|
+      "Internal name of Taxon #{n}"
+    end
+    publication_state 'published'
+
+    initialize_with { attributes }
+  end
+end

--- a/spec/features/manage_root_taxons_spec.rb
+++ b/spec/features/manage_root_taxons_spec.rb
@@ -1,0 +1,75 @@
+require "rails_helper"
+
+RSpec.feature "Manage Root Taxons" do
+  include PublishingApiHelper
+  include ContentItemHelper
+
+  scenario "Add a root taxon" do
+    given_there_are_taxons
+    given_there_are_links
+    given_that_one_link_is_a_root_taxon
+    when_i_visit_the_edit_taxonomy_page
+    and_i_click_the_add_root_taxon_button
+    then_i_see_the_current_root_taxons
+  end
+
+  scenario "Update the list of root taxons" do
+    given_there_are_taxons
+    given_there_are_links
+    given_that_one_link_is_a_root_taxon
+    when_i_visit_the_edit_taxonomy_page
+    and_i_click_the_add_root_taxon_button
+    and_i_add_a_new_taxon
+    when_i_click_save
+    then_the_set_of_root_taxons_is_updated
+  end
+
+  def given_there_are_taxons
+    publishing_api_has_taxons(
+      [],
+      page: 1,
+      states: ["published"]
+    )
+  end
+
+  def given_there_are_links
+    @linkable_taxon_hash = FactoryGirl.build_list(:linkable_taxon_hash, 2)
+    publishing_api_has_linkables(
+      @linkable_taxon_hash,
+      document_type: 'taxon'
+    )
+  end
+
+  def given_that_one_link_is_a_root_taxon
+    links = { "content_id" => "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a",
+              "links" =>
+               { "root_taxons" => @linkable_taxon_hash.first[:content_id] } }
+    publishing_api_has_links(links)
+  end
+
+  def when_i_visit_the_edit_taxonomy_page
+    visit taxons_path
+  end
+
+  def and_i_click_the_add_root_taxon_button
+    click_link "Manage root taxons"
+  end
+
+  def then_i_see_the_current_root_taxons
+    expect(page).to have_text(@linkable_taxon_hash.first[:internal_name])
+  end
+
+  def and_i_add_a_new_taxon
+    select @linkable_taxon_hash[1][:internal_name], from: "root_taxons_form_root_taxons"
+  end
+
+  def when_i_click_save
+    stub_any_publishing_api_patch_links
+    click_on "Save & publish"
+  end
+
+  def then_the_set_of_root_taxons_is_updated
+    assert_publishing_api_patch_links("f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a", "links" =>
+      { "root_taxons" => @linkable_taxon_hash.map { |t| t[:content_id] } })
+  end
+end

--- a/spec/forms/root_taxons_form_spec.rb
+++ b/spec/forms/root_taxons_form_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe RootTaxonsForm do
+  include PublishingApiHelper
+  include ContentItemHelper
+
+  describe '#taxons_for_select' do
+    before :each do
+      publishing_api_has_links("content_id" => RootTaxonsForm::HOMEPAGE_CONTENT_ID,
+                               "links" => { "root_taxons" => [""] })
+    end
+    it 'returns all taxons for the select box' do
+      @linkable_taxon_hash = FactoryGirl.build_list(:linkable_taxon_hash, 2)
+
+      publishing_api_has_linkables(
+        @linkable_taxon_hash,
+        document_type: 'taxon'
+      )
+
+      taxons_for_select = RootTaxonsForm.new.taxons_for_select
+
+      expect(taxons_for_select).to eq(@linkable_taxon_hash.map { |l| [l[:internal_name], l[:content_id]] })
+    end
+  end
+
+  describe '#update' do
+    before :each do
+      stub_any_publishing_api_patch_links
+    end
+    it 'updates given taxons, ignoring empty strings' do
+      RootTaxonsForm.new(root_taxons: ["", "ID-3", "ID-4"]).update
+      assert_publishing_api_patch_links(RootTaxonsForm::HOMEPAGE_CONTENT_ID, "links" =>
+        { "root_taxons" => ["ID-3", "ID-4"] })
+    end
+    it 'removes all taxons' do
+      RootTaxonsForm.new(root_taxons: [""]).update
+      assert_publishing_api_patch_links(RootTaxonsForm::HOMEPAGE_CONTENT_ID, "links" =>
+        { "root_taxons" => [] })
+    end
+  end
+end


### PR DESCRIPTION
To make a draft taxon or taxonomy branch visible to editors, the following must be true:

 - The taxon must be in draft
 - The taxon must not be associated with a parent taxon 

Previously, it was not possible to create or edit a taxon without a parent taxon in the UI; instead this was done using a Rake task.

This PR adds a link on the Edit taxonomy page that allows users to manage root taxons. A new 'Manage root taxons' page was added, in which a set of root taxons can be selected and saved.

![screen shot 2017-06-26 at 11 26 29](https://user-images.githubusercontent.com/6050162/27542116-29e376d8-5a7e-11e7-8710-d7f17199afa1.png)
![screen shot 2017-06-26 at 11 27 12](https://user-images.githubusercontent.com/6050162/27542119-2c3c536e-5a7e-11e7-93fb-ecdf0bb236d8.png)
