### PR TITLE
Rescue publishing api errors

### DIFF
--- a/lib/tasks/taxonomy/publish_worldwide_taxons.rake
+++ b/lib/tasks/taxonomy/publish_worldwide_taxons.rake
@@ -12,7 +12,11 @@ namespace :taxonomy do
 
     world_taxons = all_taxons.select { |t| t["base_path"].starts_with?("/world") }
     world_taxons.each do |taxon|
-      Services.publishing_api.publish(taxon["content_id"], "major")
+      begin
+        Services.publishing_api.publish(taxon["content_id"], "major")
+      rescue => e
+        puts "Error: #{e.message}"
+      end
     end
   end
 end


### PR DESCRIPTION
This script would fail when trying to publish a taxon that's already been published:

```
GdsApi::HTTPClientError: URL: https://publishing-api.integration.publishing.service.gov.uk/v2/content/_some_content_id_/publish
Response body:
{"error":{"code":400,"message":"Cannot publish an already published edition","fields":{}}}
```