### PR TITLE
Allow UpdateTaxon to handle nil for associated taxons

### DIFF
--- a/app/services/taxonomy/update_taxon.rb
+++ b/app/services/taxonomy/update_taxon.rb
@@ -46,7 +46,7 @@ module Taxonomy
     def links
       {
         parent_taxons: parent.empty? ? [] : Array(parent),
-        associated_taxons: associated_taxons.empty? ? [] : Array(associated_taxons.reject(&:blank?)),
+        associated_taxons: associated_taxons.blank? ? [] : Array(associated_taxons.reject(&:blank?)),
       }
     end
   end

--- a/spec/services/taxonomy/update_taxon_spec.rb
+++ b/spec/services/taxonomy/update_taxon_spec.rb
@@ -61,6 +61,25 @@ RSpec.describe Taxonomy::UpdateTaxon do
       end
     end
 
+    context "when the taxon has nil for associated taxons" do
+      before { @taxon.associated_taxons = nil }
+
+      it "patches the links hash with an empty array" do
+        expect(Services.publishing_api).to receive(:put_content)
+        expect(Services.publishing_api)
+          .to receive(:patch_links)
+          .with(
+            @taxon.content_id,
+            links: {
+              parent_taxons: ['guid'],
+              associated_taxons: [],
+            }
+          )
+
+        expect { publish }.to_not raise_error
+      end
+    end
+
     context 'with an unprocessable entity error from the API' do
       let(:error) do
         GdsApi::HTTPUnprocessableEntity.new(


### PR DESCRIPTION
When attempting to programmatically update taxons, an error is
thrown for `empty?` not being a method of `nil`. When loading
a taxon by content_id, the associated_taxons are returned as
`nil`. I think this error has not previously been seen since when 
using the UI, the form will return an empty selection to an empty 
array. It's still useful to be able to update taxons programmatically
though, so changing `empty?` to `blank?` enables that.