### PR TITLE
Fixes NoMethodError on analytics page

### DIFF
--- a/app/services/analytics/show_page.rb
+++ b/app/services/analytics/show_page.rb
@@ -7,7 +7,7 @@ module Analytics
     end
 
     def title
-      @_title ||= TaggingEvent.where(taxon_content_id: id).first.taxon_title
+      @_title ||= taxon.title
     end
 
     def tagging_events
@@ -52,6 +52,10 @@ module Analytics
     end
 
   private
+
+    def taxon
+      @_taxon ||= Taxonomy::BuildTaxon.call(content_id: id)
+    end
 
     def taxon_events_in_week(date_of_start_of_week)
       TaggingEvent

--- a/spec/services/analytics/show_page_spec.rb
+++ b/spec/services/analytics/show_page_spec.rb
@@ -4,6 +4,23 @@ RSpec.describe Analytics::ShowPage do
   subject { described_class.new(taxon_id) }
   let(:taxon_id) { SecureRandom.uuid }
 
+  describe "#title" do
+    let(:result) { subject.title }
+
+    before do
+      allow(Taxonomy::BuildTaxon)
+        .to receive(:call)
+        .with(content_id: taxon_id)
+        .and_return(
+          build(:taxon, title: 'I am a title')
+        )
+    end
+
+    it "returns the title from the taxon in the publishing_api" do
+      expect(result).to eq 'I am a title'
+    end
+  end
+
   describe "#content_count_over_time" do
     before do
       create(:tagging_event, :guidance, taxon_content_id: taxon_id, tagged_on: 2.weeks.ago)


### PR DESCRIPTION
Fixes an assumption that there will always be a `TaggingEvent` for a given taxon.


[Trello](https://trello.com/c/pMTsnht5/19-content-tagger-history-page-crashes)

