### PR TITLE
Mainstream Browse taxonomy import tools

### DIFF
--- a/app/lib/services.rb
+++ b/app/lib/services.rb
@@ -1,4 +1,5 @@
 require 'gds_api/publishing_api_v2'
+require 'gds_api/rummager'
 
 module Services
   def self.publishing_api
@@ -15,5 +16,11 @@ module Services
       statsd_client.namespace = "govuk.app.content-tagger"
       statsd_client
     end
+  end
+
+  def self.search
+    @search ||= GdsApi::Rummager.new(
+      Plek.new.find('rummager'),
+    )
   end
 end

--- a/app/services/legacy_taxonomy/client/publishing_api.rb
+++ b/app/services/legacy_taxonomy/client/publishing_api.rb
@@ -1,0 +1,29 @@
+module LegacyTaxonomy
+  module Client
+    class PublishingApi
+      class << self
+        def new_content_id
+          SecureRandom.uuid
+        end
+
+        def content_id_for_base_path(base_path)
+          Services.publishing_api.lookup_content_id(base_path: base_path)
+        end
+
+        def get_expanded_links(content_id)
+          response = client.get_expanded_links(content_id)
+          response.to_h.fetch("expanded_links", {})
+        end
+
+        def get_content_groups(content_id)
+          response = client.get_content(content_id)
+          response.dig('details', 'groups') || []
+        end
+
+        def client
+          Services.publishing_api
+        end
+      end
+    end
+  end
+end

--- a/app/services/legacy_taxonomy/client/search_api.rb
+++ b/app/services/legacy_taxonomy/client/search_api.rb
@@ -1,0 +1,17 @@
+module LegacyTaxonomy
+  module Client
+    class SearchApi
+      def self.content_ids_tagged_to_browse_page(taxon_content_id)
+        tagged = Services.search.search(
+          fields: %w(content_id),
+          filter_mainstream_browse_page_content_ids: [taxon_content_id],
+          count: 1000
+        )
+
+        tagged["results"]
+          .map { |result| result['content_id'] }
+          .compact
+      end
+    end
+  end
+end

--- a/app/services/legacy_taxonomy/mainstream_browse_taxonomy.rb
+++ b/app/services/legacy_taxonomy/mainstream_browse_taxonomy.rb
@@ -1,0 +1,86 @@
+module LegacyTaxonomy
+  class MainstreamBrowseTaxonomy
+    attr_accessor :path_prefix
+
+    BASE_PATH = '/browse'.freeze
+
+    def initialize(path_prefix)
+      @path_prefix = path_prefix
+    end
+
+    def to_taxonomy_branch
+      root_content_id = Client::PublishingApi.content_id_for_base_path(BASE_PATH)
+      @taxon = TaxonData.new(
+        title: 'Browse',
+        description: 'Mainstream Browse Taxonomy',
+        browse_page_content_id: root_content_id,
+        path_slug: BASE_PATH,
+        path_prefix: path_prefix,
+        child_taxons: child_taxons(root_content_id)
+      )
+    end
+
+  private
+
+    def child_taxons(root_content_id)
+      first_level_taxons(root_content_id).each do |first_level_taxon|
+        first_level_taxon.child_taxons =
+          second_level_taxons(first_level_taxon).each do |second_level_taxon|
+            second_level_taxon.child_taxons = third_level_taxons(second_level_taxon)
+            second_level_taxon.tagged_pages -=
+              second_level_taxon.child_taxons.map(&:tagged_pages).flatten
+          end
+      end
+    end
+
+    def first_level_taxons(root_content_id)
+      Client::PublishingApi
+        .get_expanded_links(root_content_id)
+        .fetch("top_level_browse_pages", [])
+        .map do |browse_page|
+          TaxonData.new(
+            title: browse_page['title'],
+            description: browse_page['description'],
+            browse_page_content_id: browse_page['content_id'],
+            path_slug: browse_page['base_path'],
+            path_prefix: path_prefix
+          )
+        end
+    end
+
+    def second_level_taxons(parent_taxon)
+      Client::PublishingApi
+        .get_expanded_links(parent_taxon.browse_page_content_id)
+        .fetch('second_level_browse_pages', [])
+        .map do |browse_page|
+          base_path = browse_page['base_path']
+          content_id = browse_page['content_id']
+          TaxonData.new(
+            title: browse_page['title'],
+            description: browse_page['description'],
+            browse_page_content_id: content_id,
+            path_slug: base_path,
+            path_prefix: path_prefix,
+            tagged_pages: Client::SearchApi.content_ids_tagged_to_browse_page(content_id)
+          )
+        end
+    end
+
+    def third_level_taxons(parent_taxon)
+      Client::PublishingApi.get_content_groups(parent_taxon.browse_page_content_id)
+        .reject { |g| g['name'].empty? || g['contents'].empty? }
+        .map do |group|
+          path_slug = parent_taxon.path_slug + '/' + group['name'].parameterize
+          TaxonData.new(
+            title: group['name'],
+            description: group['name'],
+            path_slug: path_slug,
+            path_prefix: path_prefix,
+            tagged_pages: group['contents']
+              .map { |content_base_path| Client::PublishingApi.content_id_for_base_path(content_base_path) }
+              .compact
+          )
+        end
+    end
+  end
+end

--- a/app/services/legacy_taxonomy/taxon_data.rb
+++ b/app/services/legacy_taxonomy/taxon_data.rb
@@ -1,0 +1,43 @@
+module LegacyTaxonomy
+  class TaxonData
+    attr_accessor(
+      :title,
+      :description,
+      :browse_page_content_id,
+      :path_slug,
+      :path_prefix,
+      :tagged_pages,
+      :child_taxons
+    )
+
+    include ActiveModel::Model
+
+    def child_taxons
+      @child_taxons || []
+    end
+
+    def base_path
+      path_prefix + path_slug
+    end
+
+    def tagged_pages
+      @tagged_pages || []
+    end
+
+    def content_id
+      @_content_id ||= begin
+        Client::PublishingApi.content_id_for_base_path(base_path) || SecureRandom.uuid
+      end
+    end
+
+    def hash_for_publishing_api
+      {
+        title: title,
+        description: description,
+        path_slug: path_slug,
+        path_prefix: path_prefix,
+        content_id: content_id
+      }
+    end
+  end
+end

--- a/app/services/legacy_taxonomy/taxonomy_writer.rb
+++ b/app/services/legacy_taxonomy/taxonomy_writer.rb
@@ -1,0 +1,55 @@
+module LegacyTaxonomy
+  class TaxonomyWriter
+    attr_reader :root_taxon
+
+    def initialize(root_taxon)
+      @root_taxon = root_taxon
+    end
+
+    def commit
+      create_remote_taxon(root_taxon)
+      commit_tree(root_taxon)
+    end
+
+  private
+
+    def commit_tree(taxon)
+      taxon.child_taxons.each do |sub_taxon|
+        create_remote_taxon(sub_taxon, taxon)
+        sub_taxon.tagged_pages.each do |taggable_id|
+          tag_content(taggable_id, sub_taxon)
+        end
+        commit_tree(sub_taxon)
+      end
+    end
+
+    def create_remote_taxon(taxon, parent_taxon = nil)
+      puts "#{taxon.title} => #{taxon.base_path}"
+      Services.publishing_api.put_content(taxon.content_id, taxon_for_publishing_api(taxon))
+      Services.publishing_api.publish(taxon.content_id, 'major')
+
+      return unless parent_taxon # rubocop
+      Services.publishing_api.patch_links(taxon.content_id, links: { parent_taxons: [parent_taxon.content_id] })
+    end
+
+    def tag_content(taggable_content_id, taxon)
+      puts " - Tagging #{base_path_for_content_id(taggable_content_id)}"
+
+      links = Services.publishing_api.get_links(taggable_content_id)
+      previous_version = links['version'] || 0
+      taxons = links.dig('links', 'taxons') || []
+      taxons << taxon.content_id
+      Services.publishing_api.patch_links(taggable_content_id, links: { taxons: taxons }, previous_version: previous_version)
+    end
+
+    def base_path_for_content_id(content_id)
+      Services.publishing_api.get_content(content_id)['base_path']
+    end
+
+    def taxon_for_publishing_api(taxon)
+      taxon_attrs = taxon.hash_for_publishing_api
+      taxon_ = Taxon.new(taxon_attrs)
+      Taxonomy::BuildTaxonPayload.call(taxon: taxon_)
+    end
+  end
+end

--- a/lib/tasks/legacy_taxonomy.rake
+++ b/lib/tasks/legacy_taxonomy.rake
@@ -1,0 +1,16 @@
+namespace :legacy_taxonomy do
+  desc "Generates structure for mainstream browse at www.gov.uk/browse"
+  task generate_mainstream_browse_page_taxons: :environment do
+    taxonomy = LegacyTaxonomy::MainstreamBrowseTaxonomy.new('/foo').to_taxonomy_branch
+    File.write('tmp/msbp.yml', YAML.dump(taxonomy))
+  end
+
+  desc "Send the Mainstream Browse taxonomy to the publishing platform"
+  task publish_mainstream_browse_page_taxons: :environment do
+    # The psych YAML parser doesn't work with the Rails class autoloader.
+    # And while there are more complicated ways of fixing this...
+    _ = LegacyTaxonomy::TaxonData
+    taxonomy_branch = YAML.load_file('tmp/msbp.yml')
+    LegacyTaxonomy::TaxonomyWriter.new(taxonomy_branch).commit
+  end
+end

--- a/spec/services/legacy_taxonomy/mainstream_browse_taxonomy_spec.rb
+++ b/spec/services/legacy_taxonomy/mainstream_browse_taxonomy_spec.rb
@@ -1,0 +1,167 @@
+require 'rails_helper'
+
+RSpec.describe LegacyTaxonomy::MainstreamBrowseTaxonomy do
+  before do
+    stub_publishing_api_root_taxon
+  end
+
+  describe "#to_taxonomy_branch" do
+    let(:result) do
+      described_class.new('/foo').to_taxonomy_branch
+    end
+
+    context 'there is only one root, no children' do
+      before do
+        stub_publishing_api_top_level_browse_pages([])
+      end
+
+      it 'returns the root browse taxon' do
+        expect(result.title).to eq 'Browse'
+        expect(result.base_path).to eq '/foo/browse'
+        expect(result.child_taxons).to be_empty
+      end
+    end
+
+    context 'there are children of the root taxon, no second level taxons' do
+      before do
+        stub_publishing_api_top_level_browse_pages([basic_taxon])
+        stub_nil_second_level_browse_pages(basic_taxon['content_id'])
+      end
+
+      it 'has first level taxons' do
+        expect(result.child_taxons).to be_an Array
+        child_taxon = result.child_taxons.first
+        expect(child_taxon.child_taxons).to be_empty
+        expect(child_taxon.title).to eq "foo"
+        expect(child_taxon.description).to eq "bar"
+        expect(child_taxon.base_path).to eq "/foo/path"
+      end
+    end
+
+    context 'there are second level taxons' do
+      before do
+        stub_publishing_api_top_level_browse_pages([basic_taxon])
+        stub_publishing_api_second_level_browse_pages(basic_taxon['content_id'], [subtaxon])
+        stub_publishing_api_third_level_browse_pages(subtaxon['content_id'], [])
+        stub_publishing_api_content_id_lookup("/foo/subpath", 'sub_taxon')
+        stub_search_api subtaxon['content_id'], %w(page_content_id)
+      end
+
+      it 'has second level taxons' do
+        expect(result.child_taxons).to be_an Array
+        expect(result.child_taxons.first.child_taxons).to be_an Array
+        child_taxon = result.child_taxons.first.child_taxons.first
+        expect(child_taxon.child_taxons).to be_empty
+        expect(child_taxon.content_id).to eq subtaxon['content_id']
+        expect(child_taxon.tagged_pages).to eq %w(page_content_id)
+      end
+    end
+
+    context "there are third level taxons" do
+      before do
+        stub_publishing_api_top_level_browse_pages([basic_taxon])
+        stub_publishing_api_second_level_browse_pages(basic_taxon['content_id'], [subtaxon])
+        stub_publishing_api_third_level_browse_pages(subtaxon['content_id'], content_groups)
+        stub_publishing_api_content_id_lookup('/path-of-group-contents', 'content-id-goes-here')
+        stub_publishing_api_content_id_lookup_404('/foo/path/groupo_uno')
+        stub_search_api subtaxon['content_id'], %w(page_content_id)
+      end
+
+      it "has third level taxons" do
+        l3_taxon = result.child_taxons.first.child_taxons.first.child_taxons.first
+        expect(l3_taxon.title).to eq 'groupo_uno'
+        expect(l3_taxon.tagged_pages).to eq %w(content-id-goes-here)
+      end
+    end
+  end
+
+  ####################
+  #  HELPER METHODS  #
+  ####################
+
+  def stub_publishing_api_root_taxon
+    allow(LegacyTaxonomy::Client::PublishingApi)
+      .to receive(:content_id_for_base_path)
+      .with('/browse')
+      .and_return root_browse_page_content_id
+  end
+
+  def stub_publishing_api_content_id_lookup(path, content_id)
+    allow(LegacyTaxonomy::Client::PublishingApi)
+      .to receive(:content_id_for_base_path)
+      .with(path)
+      .and_return content_id
+  end
+
+  def stub_publishing_api_content_id_lookup_404(path)
+    allow(LegacyTaxonomy::Client::PublishingApi)
+      .to receive(:content_id_for_base_path)
+      .with(path)
+      .and_return nil
+  end
+
+  def stub_publishing_api_top_level_browse_pages(pages_hash)
+    allow(LegacyTaxonomy::Client::PublishingApi)
+      .to receive(:get_expanded_links)
+      .with(root_browse_page_content_id)
+      .and_return("top_level_browse_pages" => pages_hash)
+  end
+
+  def stub_publishing_api_second_level_browse_pages(parent_id, pages_hash)
+    allow(LegacyTaxonomy::Client::PublishingApi)
+      .to receive(:get_expanded_links)
+      .with(parent_id)
+      .and_return("second_level_browse_pages" => pages_hash)
+  end
+
+  def stub_publishing_api_third_level_browse_pages(parent_id, groups)
+    allow(LegacyTaxonomy::Client::PublishingApi)
+      .to receive(:get_content_groups)
+      .with(parent_id)
+      .and_return(groups)
+  end
+
+  def stub_nil_second_level_browse_pages(parent_id)
+    stub_publishing_api_second_level_browse_pages(parent_id, [])
+  end
+
+  def stub_search_api(base_path, pages = [])
+    allow(LegacyTaxonomy::Client::SearchApi)
+      .to receive(:content_ids_tagged_to_browse_page)
+      .with(base_path)
+      .and_return(pages)
+  end
+
+  def basic_taxon
+    {
+      'title' => 'foo',
+      'description' => 'bar',
+      'content_id' => 'foobar',
+      'base_path' => '/path'
+    }
+  end
+
+  def subtaxon
+    {
+      'title' => 'foo',
+      'description' => 'bar',
+      'content_id' => 'sub_taxon',
+      'base_path' => '/subpath'
+    }
+  end
+
+  def content_groups
+    [
+      {
+        'name' => 'groupo_uno',
+        'contents' => [
+          '/path-of-group-contents'
+        ]
+      }
+    ]
+  end
+
+  def root_browse_page_content_id
+    "foo-bar-baz"
+  end
+end


### PR DESCRIPTION
Provides a framework for creating the modern GOV.UK taxonomy from the Mainstream Browse taxonomy.

The UI provides two rake tasks:
 - `rake taxonomy:mainstream_browse` 
 - `rake taxonomy:load`

The first of these will construct a taxonomy data structure and save it to `tmp/msbp.yml`
The second command will load this YAML file and persist it to the publishing platform via publishing-api endpoints.

