### PR TITLE
Add Legacy Topic Taxonomy Importer

### DIFF
--- a/app/services/legacy_taxonomy/three_level_taxonomy.rb
+++ b/app/services/legacy_taxonomy/three_level_taxonomy.rb
@@ -1,20 +1,26 @@
 module LegacyTaxonomy
-  class MainstreamBrowseTaxonomy
+  class ThreeLevelTaxonomy
     attr_accessor :path_prefix
 
-    BASE_PATH = '/browse'.freeze
-
-    def initialize(path_prefix)
+    def initialize(path_prefix,
+                   base_path: '/browse',
+                   title: 'Mainstream Browse Taxonomy',
+                   first_level_key: 'top_level_browse_pages',
+                   second_level_key: 'second_level_browse_pages')
       @path_prefix = path_prefix
+      @base_path = base_path
+      @title = title
+      @first_level_key = first_level_key
+      @second_level_key = second_level_key
     end
 
     def to_taxonomy_branch
-      root_content_id = Client::PublishingApi.content_id_for_base_path(BASE_PATH)
+      root_content_id = Client::PublishingApi.content_id_for_base_path(@base_path)
       @taxon = TaxonData.new(
         title: 'Browse',
-        description: 'Mainstream Browse Taxonomy',
+        description: @title,
         browse_page_content_id: root_content_id,
-        path_slug: BASE_PATH,
+        path_slug: @base_path,
         path_prefix: path_prefix,
         child_taxons: child_taxons(root_content_id)
       )
@@ -36,7 +42,7 @@ module LegacyTaxonomy
     def first_level_taxons(root_content_id)
       Client::PublishingApi
         .get_expanded_links(root_content_id)
-        .fetch("top_level_browse_pages", [])
+        .fetch(@first_level_key, [])
         .map do |browse_page|
           TaxonData.new(
             title: browse_page['title'],
@@ -51,7 +57,7 @@ module LegacyTaxonomy
     def second_level_taxons(parent_taxon)
       Client::PublishingApi
         .get_expanded_links(parent_taxon.browse_page_content_id)
-        .fetch('second_level_browse_pages', [])
+        .fetch(@second_level_key, [])
         .map do |browse_page|
           base_path = browse_page['base_path']
           content_id = browse_page['content_id']

--- a/lib/tasks/legacy_taxonomy.rake
+++ b/lib/tasks/legacy_taxonomy.rake
@@ -1,8 +1,18 @@
 namespace :legacy_taxonomy do
   desc "Generates structure for mainstream browse at www.gov.uk/browse"
   task generate_mainstream_browse_page_taxons: :environment do
-    taxonomy = LegacyTaxonomy::MainstreamBrowseTaxonomy.new('/foo').to_taxonomy_branch
+    taxonomy = LegacyTaxonomy::ThreeLevelTaxonomy.new('/foo').to_taxonomy_branch
     File.write('tmp/msbp.yml', YAML.dump(taxonomy))
+  end
+
+  desc "Generates structure for Topic taxonomy at www.gov.uk/browse"
+  task generate_topic_taxons: :environment do
+    taxonomy = LegacyTaxonomy::ThreeLevelTaxonomy.new('/foo',
+                                                      base_path: '/topic',
+                                                      first_level_key: 'children',
+                                                      second_level_key: 'children',
+                                                      title: 'Topic Taxonomy').to_taxonomy_branch
+    File.write('tmp/topic.yml', YAML.dump(taxonomy))
   end
 
   desc "Send the Mainstream Browse taxonomy to the publishing platform"
@@ -11,6 +21,15 @@ namespace :legacy_taxonomy do
     # And while there are more complicated ways of fixing this...
     _ = LegacyTaxonomy::TaxonData
     taxonomy_branch = YAML.load_file('tmp/msbp.yml')
+    LegacyTaxonomy::TaxonomyWriter.new(taxonomy_branch).commit
+  end
+
+  desc "Send the Topic taxonomy to the publishing platform"
+  task publish_topic_taxons: :environment do
+    # The psych YAML parser doesn't work with the Rails class autoloader.
+    # And while there are more complicated ways of fixing this...
+    _ = LegacyTaxonomy::TaxonData
+    taxonomy_branch = YAML.load_file('tmp/topic.yml')
     LegacyTaxonomy::TaxonomyWriter.new(taxonomy_branch).commit
   end
 end

--- a/spec/services/legacy_taxonomy/three_level_taxonomy_spec.rb
+++ b/spec/services/legacy_taxonomy/three_level_taxonomy_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe LegacyTaxonomy::MainstreamBrowseTaxonomy do
+RSpec.describe LegacyTaxonomy::ThreeLevelTaxonomy do
   before do
     stub_publishing_api_root_taxon
   end


### PR DESCRIPTION
Changed the 'legacy mainstream browse taxonomy importer' so it can import a more general three-level taxonomy.

Added Rspec tasks to import the Legacy Topic taxonomy, using the refactored importer.