### PR TITLE
Build policy taxonomy branch

### DIFF
--- a/app/services/legacy_taxonomy/client/search_api.rb
+++ b/app/services/legacy_taxonomy/client/search_api.rb
@@ -58,6 +58,17 @@ module LegacyTaxonomy
           results
         end
 
+        def content_tagged_to_policy(policy_slug)
+          tagged = client.search(
+            fields: %w(content_id),
+            filter_policies: policy_slug,
+            count: 1000
+          )
+
+          tagged['results']
+            .map { |result| result['content_id'] }
+        end
+
         def client
           Services.search
         end

--- a/app/services/legacy_taxonomy/client/whitehall.rb
+++ b/app/services/legacy_taxonomy/client/whitehall.rb
@@ -1,0 +1,30 @@
+module LegacyTaxonomy
+  module Client
+    class Whitehall
+      class << self
+        def policies_for_policy_area(policy_area_slug)
+          client.get_policy_area(policy_area_slug)
+            .to_h
+            .fetch('classification_policies', [])
+            .map { |policy| policy['policy_content_id'] }
+        end
+
+        def client
+          @_client ||= GdsApi::Whitehall.new(
+            Plek.new.find('whitehall-admin'),
+            timeout: 20
+          )
+        end
+      end
+    end
+  end
+end
+
+module GdsApi
+  class Whitehall < Base
+    def get_policy_area(slug)
+      request_path = "#{endpoint}/government/admin/topics/#{slug}.json"
+      get_json(request_path)
+    end
+  end
+end

--- a/app/services/legacy_taxonomy/policy_taxonomy.rb
+++ b/app/services/legacy_taxonomy/policy_taxonomy.rb
@@ -1,0 +1,52 @@
+module LegacyTaxonomy
+  class PolicyTaxonomy
+    attr_reader :path_prefix
+
+    TITLE = 'Policy Areas + Policies'.freeze
+    BASE_PATH = '/government/topics'.freeze
+
+    def initialize(path_prefix)
+      @path_prefix = path_prefix
+    end
+
+    def to_taxonomy_branch
+      @taxon = TaxonData.new(
+        title: TITLE,
+        description: TITLE + ' Taxonomy',
+        path_slug: BASE_PATH,
+        path_prefix: path_prefix,
+        child_taxons: policy_areas
+      )
+    end
+
+    def policy_areas
+      areas = Client::SearchApi.policy_areas
+      areas.map do |policy_area|
+        TaxonData.new(
+          title: policy_area['title'],
+          description: policy_area['description'],
+          path_slug: policy_area['link'],
+          path_prefix: path_prefix,
+          legacy_content_id: Client::PublishingApi.content_id_for_base_path(policy_area['link']),
+          child_taxons: policies_for_policy_area(policy_area['slug'])
+        )
+      end
+    end
+
+    def policies_for_policy_area(policy_area_slug)
+      policies = Client::Whitehall.policies_for_policy_area(policy_area_slug)
+      policies.map do |policy_id|
+        policy_content_item = Client::PublishingApi.client.get_content(policy_id)
+        policy_slug = policy_content_item.dig('details', 'filter', 'policies')
+        TaxonData.new(
+          title: policy_content_item['title'],
+          description: policy_content_item['description'],
+          path_slug: policy_content_item['base_path'],
+          path_prefix: path_prefix,
+          legacy_content_id: policy_id,
+          tagged_pages: Client::SearchApi.content_tagged_to_policy(policy_slug)
+        )
+      end
+    end
+  end
+end

--- a/lib/tasks/legacy_taxonomy.rake
+++ b/lib/tasks/legacy_taxonomy.rake
@@ -32,4 +32,10 @@ namespace :legacy_taxonomy do
     taxonomy = LegacyTaxonomy::PolicyAreaTaxonomy.new('/bar').to_taxonomy_branch
     LegacyTaxonomy::Yamlizer.new('tmp/policy_area.yml').write(taxonomy)
   end
+
+  desc "Generates structure for Policy Areas / Policy"
+  task generate_policy_area_and_policy_taxons: :environment do
+    taxonomy = LegacyTaxonomy::PolicyTaxonomy.new('/baz').to_taxonomy_branch
+    File.write('tmp/policy.yml', YAML.dump(taxonomy))
+  end
 end


### PR DESCRIPTION
Builds a taxonomy based on the relationship between Policy Areas and Policies. 

Uses [a Whitehall API](https://github.com/alphagov/whitehall/pull/3346) that doesn't exist yet.

[Trello](https://trello.com/c/xE7wHKTI/60-import-policies-into-new-taxonomy)