### PR TITLE
Send update type with put content

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'unicorn', '~> 5.0.0'
 
 # GDS managed dependencies
 gem 'airbrake', github: 'alphagov/airbrake', branch: 'silence-dep-warnings-for-rails-5'
-gem 'gds-api-adapters', '~> 41.5'
+gem 'gds-api-adapters', '~> 47.2'
 gem 'gds-sso', '~> 13.2'
 gem 'govuk_admin_template', '~> 5.0'
 gem 'govuk_sidekiq', '~> 1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,7 +96,7 @@ GEM
       railties (>= 3.0.0)
     faraday (0.11.0)
       multipart-post (>= 1.2, < 3)
-    gds-api-adapters (41.5.0)
+    gds-api-adapters (47.2.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -207,7 +207,7 @@ GEM
     pry-byebug (3.4.2)
       byebug (~> 9.0)
       pry (~> 0.10)
-    rack (2.0.1)
+    rack (2.0.3)
     rack-cache (1.7.0)
       rack (>= 0.4)
     rack-protection (1.5.3)
@@ -244,7 +244,7 @@ GEM
     redis-namespace (1.5.3)
       redis (~> 3.0, >= 3.0.4)
     request_store (1.3.2)
-    rest-client (2.0.1)
+    rest-client (2.0.2)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
@@ -361,7 +361,7 @@ DEPENDENCIES
   chartkick
   database_cleaner
   factory_girl_rails
-  gds-api-adapters (~> 41.5)
+  gds-api-adapters (~> 47.2)
   gds-sso (~> 13.2)
   govuk-content-schema-test-helpers
   govuk-lint

--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -48,7 +48,7 @@ class TaxonsController < ApplicationController
       Taxonomy::UpdateTaxon.call(taxon: taxon)
 
       if params[:publish_taxon_on_save] == "true"
-        Services.publishing_api.publish(taxon.content_id, "major")
+        Services.publishing_api.publish(taxon.content_id)
       end
 
       redirect_to taxon_path(taxon.content_id)
@@ -93,7 +93,7 @@ class TaxonsController < ApplicationController
   end
 
   def publish
-    Services.publishing_api.publish(taxon.content_id, "major")
+    Services.publishing_api.publish(taxon.content_id)
     redirect_to taxon_path(taxon.content_id), success: "You have successfully published the taxon"
   end
 

--- a/app/presenters/taxonomy/email_signup_page.rb
+++ b/app/presenters/taxonomy/email_signup_page.rb
@@ -21,6 +21,7 @@ module Taxonomy
           summary: '',
           subscriber_list: { 'taxons' => [] },
         },
+        update_type: 'major',
       }
     end
 

--- a/app/services/legacy_taxonomy/taxonomy_publisher.rb
+++ b/app/services/legacy_taxonomy/taxonomy_publisher.rb
@@ -26,7 +26,7 @@ module LegacyTaxonomy
     def create_remote_taxon(taxon, parent_taxon = nil)
       puts "#{taxon.title} => #{taxon.base_path}"
       Services.publishing_api.put_content(taxon.content_id, taxon_for_publishing_api(taxon))
-      Services.publishing_api.publish(taxon.content_id, 'major')
+      Services.publishing_api.publish(taxon.content_id)
 
       return unless parent_taxon # rubocop
       Services.publishing_api.patch_links(taxon.content_id, links: { parent_taxons: [parent_taxon.content_id] })

--- a/app/services/taxonomy/build_taxon_payload.rb
+++ b/app/services/taxonomy/build_taxon_payload.rb
@@ -26,7 +26,8 @@ module Taxonomy
         },
         routes: [
           { path: base_path, type: "exact" },
-        ]
+        ],
+        update_type: "major",
       }
     end
 

--- a/lib/tasks/taxonomy/register_email_signup_page.rake
+++ b/lib/tasks/taxonomy/register_email_signup_page.rake
@@ -7,6 +7,6 @@ namespace :taxonomy do
     signup_page = Taxonomy::EmailSignupPage.new
 
     Services.publishing_api.put_content(signup_page.content_id, signup_page.payload)
-    Services.publishing_api.publish(signup_page.content_id, 'major')
+    Services.publishing_api.publish(signup_page.content_id)
   end
 end

--- a/lib/tasks/taxonomy/update_worldwide_taxon_summary.rake
+++ b/lib/tasks/taxonomy/update_worldwide_taxon_summary.rake
@@ -254,7 +254,7 @@ namespace :taxonomy do
       begin
         puts "Updating description for #{taxon.base_path}"
         Taxonomy::UpdateTaxon.call(taxon: taxon)
-        Services.publishing_api.publish(taxon.content_id, "major") if taxon.published?
+        Services.publishing_api.publish(taxon.content_id) if taxon.published?
       rescue => e
         puts "Error for #{taxon.base_path}: #{e.message}"
       end


### PR DESCRIPTION
Sending it on publish has been deprecated in favour of including it when sending a put content.

[Trello Card](https://trello.com/c/LnJlkb9e/987-5-deprecate-the-usage-of-updatetype-in-publish-for-publishing-api-and-update-usage-across-govuk)