### PR TITLE
Prevent the publish taxonomy task from failing on 404

### DIFF
--- a/app/services/legacy_taxonomy/taxonomy_publisher.rb
+++ b/app/services/legacy_taxonomy/taxonomy_publisher.rb
@@ -40,6 +40,8 @@ module LegacyTaxonomy
       taxons = links.dig('links', 'taxons') || []
       taxons << taxon.content_id
       Services.publishing_api.patch_links(taggable_content_id, links: { taxons: taxons }, previous_version: previous_version)
+    rescue GdsApi::HTTPNotFound
+      puts "404 Taggable Not Found"
     end
 
     def base_path_for_content_id(content_id)


### PR DESCRIPTION
There are errors in certain elements of the content relationships that make up the legacy taxonomies. Missing content that appears to be tagged to mainstream browse pages via curated groups or related topics can be missing from the publishing api, and this would cause the taxonomy publish task to fail.
