### PR TITLE
Make double, triple sure we have a content_id

### DIFF
--- a/app/services/legacy_taxonomy/client/search_api.rb
+++ b/app/services/legacy_taxonomy/client/search_api.rb
@@ -44,7 +44,7 @@ module LegacyTaxonomy
               )
               .dig('results')
               .map { |result| result.slice(*fields) }
-              .compact
+              .delete_if { |_, value| value.empty? }
           end
 
           loop do

--- a/app/services/legacy_taxonomy/taxonomy_publisher.rb
+++ b/app/services/legacy_taxonomy/taxonomy_publisher.rb
@@ -39,7 +39,7 @@ module LegacyTaxonomy
       previous_version = links['version'] || 0
       taxons = links.dig('links', 'taxons') || []
       taxons << taxon.content_id
-      Services.publishing_api.patch_links(taggable['content_id'], links: { taxons: taxons }, previous_version: previous_version)
+      Services.publishing_api.patch_links(taggable['content_id'], links: { taxons: taxons.uniq }, previous_version: previous_version)
     rescue GdsApi::HTTPNotFound
       puts "404 Taggable Not Found"
     end


### PR DESCRIPTION
There was a content_id missing for a placeholder document representing a legacy reserved path. This should ensure that we always have a content_id for taggable content.