### PR TITLE
Ensure taxonomy publisher uses custom client instance

### DIFF
--- a/app/services/legacy_taxonomy/client/publishing_api.rb
+++ b/app/services/legacy_taxonomy/client/publishing_api.rb
@@ -4,12 +4,18 @@ module LegacyTaxonomy
   module Client
     class PublishingApi
       class << self
+        delegate :put_content,
+                 :publish,
+                 :patch_links,
+                 :get_links,
+                 to: :client
+
         def new_content_id
           SecureRandom.uuid
         end
 
         def content_id_for_base_path(base_path)
-          Services.publishing_api.lookup_content_id(base_path: base_path)
+          client.lookup_content_id(base_path: base_path)
         end
 
         def get_expanded_links(content_id)
@@ -27,7 +33,7 @@ module LegacyTaxonomy
             Plek.new.find('publishing-api'),
             disable_cache: true,
             bearer_token: ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example',
-            timeout: 120
+            timeout: 20
           )
         end
       end

--- a/app/services/legacy_taxonomy/taxonomy_publisher.rb
+++ b/app/services/legacy_taxonomy/taxonomy_publisher.rb
@@ -25,21 +25,21 @@ module LegacyTaxonomy
 
     def create_remote_taxon(taxon, parent_taxon = nil)
       puts "#{taxon.title} => #{taxon.base_path}"
-      Services.publishing_api.put_content(taxon.content_id, taxon_for_publishing_api(taxon))
-      Services.publishing_api.publish(taxon.content_id)
+      Client::PublishingApi.put_content(taxon.content_id, taxon_for_publishing_api(taxon))
+      Client::PublishingApi.publish(taxon.content_id)
 
       return unless parent_taxon # rubocop
-      Services.publishing_api.patch_links(taxon.content_id, links: { parent_taxons: [parent_taxon.content_id] })
+      Client::PublishingApi.patch_links(taxon.content_id, links: { parent_taxons: [parent_taxon.content_id] })
     end
 
     def tag_content(taggable, taxon)
       puts " - Tagging #{taggable['link']}"
 
-      links = Services.publishing_api.get_links(taggable['content_id'])
+      links = Client::PublishingApi.get_links(taggable['content_id'])
       previous_version = links['version'] || 0
       taxons = links.dig('links', 'taxons') || []
       taxons << taxon.content_id
-      Services.publishing_api.patch_links(taggable['content_id'], links: { taxons: taxons.uniq }, previous_version: previous_version)
+      Client::PublishingApi.patch_links(taggable['content_id'], links: { taxons: taxons.uniq }, previous_version: previous_version)
     rescue GdsApi::HTTPNotFound
       puts "404 Taggable Not Found"
     end

--- a/spec/services/legacy_taxonomy/client/publishing_api_spec.rb
+++ b/spec/services/legacy_taxonomy/client/publishing_api_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe LegacyTaxonomy::Client::PublishingApi do
+  subject { described_class }
+
+  describe "proxies to a publishing api client" do
+    let(:mock_client) { instance_double(GdsApi::PublishingApiV2) }
+
+    before do
+      allow(subject).to receive(:client).and_return(mock_client)
+    end
+
+    it ".put_content" do
+      expect(mock_client)
+        .to receive(:put_content)
+        .with('foo', {})
+
+      subject.put_content('foo', {})
+    end
+
+    it ".publish" do
+      expect(mock_client)
+        .to receive(:publish)
+        .with('foo')
+
+      subject.publish('foo')
+    end
+
+    it ".patch_links" do
+      expect(mock_client)
+        .to receive(:patch_links)
+        .with('foo', {})
+
+      subject.patch_links('foo', {})
+    end
+
+    it ".get_links" do
+      expect(mock_client)
+        .to receive(:get_links)
+        .with('foo')
+
+      subject.get_links('foo')
+    end
+  end
+end


### PR DESCRIPTION
There are timeouts in integration when publishing the taxonomy. This should ensure that all calls to the publishing_api go through the custom client instance with an increased timeout.