### PR TITLE
Add Bulk publish taxons button

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem 'gds-api-adapters', '~> 47.2'
 gem 'gds-sso', '~> 13.2'
 gem 'govuk_admin_template', '~> 5.0'
 gem 'govuk_sidekiq', '~> 1.0'
-gem 'govuk_taxonomy_helpers', '~> 0.1.0'
+gem 'govuk_taxonomy_helpers', '~> 0.1.1'
 gem 'plek', '~> 2.0'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,7 +129,7 @@ GEM
       sidekiq (~> 4.2.8)
       sidekiq-logging-json (~> 0.0)
       sidekiq-statsd (~> 0.1)
-    govuk_taxonomy_helpers (0.1.0)
+    govuk_taxonomy_helpers (0.1.1)
     hashdiff (0.3.2)
     hashie (3.5.5)
     headless (2.3.1)
@@ -367,7 +367,7 @@ DEPENDENCIES
   govuk-lint
   govuk_admin_template (~> 5.0)
   govuk_sidekiq (~> 1.0)
-  govuk_taxonomy_helpers (~> 0.1.0)
+  govuk_taxonomy_helpers (~> 0.1.1)
   headless
   jquery-ui-rails (= 6.0.1)
   kaminari (~> 0.17)

--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -92,9 +92,18 @@ class TaxonsController < ApplicationController
     render :confirm_publish, locals: { taxon: taxon }
   end
 
+  def confirm_bulk_publish
+    render :confirm_bulk_publish, locals: { page: Taxonomy::ShowPage.new(taxon) }
+  end
+
+  def bulk_publish
+    Taxonomy::BulkUpdateTaxon.call(content_id)
+    redirect_to taxon_path(content_id), success: "The taxons will be published shortly"
+  end
+
   def publish
-    Services.publishing_api.publish(taxon.content_id)
-    redirect_to taxon_path(taxon.content_id), success: "You have successfully published the taxon"
+    Services.publishing_api.publish(content_id)
+    redirect_to taxon_path(content_id), success: "You have successfully published the taxon"
   end
 
   def confirm_discard
@@ -102,7 +111,7 @@ class TaxonsController < ApplicationController
   end
 
   def discard_draft
-    Services.publishing_api.discard_draft(taxon.content_id)
+    Services.publishing_api.discard_draft(content_id)
     redirect_to taxons_path, success: t("controllers.taxons.discard_draft_success")
   end
 
@@ -134,10 +143,11 @@ private
     )
   end
 
+  def content_id
+    params[:id] || params[:taxon_id]
+  end
+
   def taxon
-    @_taxon ||= begin
-      content_id = params[:id] || params[:taxon_id]
-      Taxonomy::BuildTaxon.call(content_id: content_id)
-    end
+    @_taxon ||= Taxonomy::BuildTaxon.call(content_id: content_id)
   end
 end

--- a/app/models/taxonomy/expanded_taxonomy.rb
+++ b/app/models/taxonomy/expanded_taxonomy.rb
@@ -103,17 +103,11 @@ module Taxonomy
     end
 
     def tree_node_based_on(content_item)
-      taxon = Taxon.new(
-        content_id: content_item.fetch('content_id'),
+      GovukTaxonomyHelpers::LinkedContentItem.new(
+        internal_name: content_item.dig('details', 'internal_name'),
         title: content_item.fetch('title'),
         base_path: content_item.fetch('base_path'),
-        internal_name: content_item.fetch('details').fetch('internal_name'),
-      )
-      GovukTaxonomyHelpers::LinkedContentItem.new(
-        internal_name: taxon.internal_name,
-        title: taxon.title,
-        base_path: taxon.base_path,
-        content_id: taxon.content_id
+        content_id: content_item.fetch('content_id')
       )
     end
   end

--- a/app/services/taxonomy/bulk_update_taxon.rb
+++ b/app/services/taxonomy/bulk_update_taxon.rb
@@ -1,0 +1,19 @@
+module Taxonomy
+  class BulkUpdateTaxon
+    def initialize(root_taxon_content_id)
+      @root_taxon_content_id = root_taxon_content_id
+    end
+
+    def self.call(root_taxon_content_id)
+      new(root_taxon_content_id).bulk_publish
+    end
+
+    def bulk_publish
+      linked_content_item = GovukTaxonomyHelpers::LinkedContentItem.from_content_id(content_id: @root_taxon_content_id,
+                                                                                    publishing_api: Services.publishing_api)
+      linked_content_item.each do |taxon|
+        PublishTaxonWorker.perform_async(taxon.content_id)
+      end
+    end
+  end
+end

--- a/app/views/taxons/confirm_bulk_publish.html.erb
+++ b/app/views/taxons/confirm_bulk_publish.html.erb
@@ -1,0 +1,19 @@
+<header class="heading-with-actions">
+  <h1><%= page.title %></h1>
+</header>
+
+<div class="lead">
+  You are about to <strong>publish</strong> this topic and its children - this will make these
+  topics appear to everyone on GOV.UK.
+</div>
+
+<%= render 'taxonomy_tree', taxonomy_tree: page.taxonomy_tree %>
+
+<div class="confirmation-box">
+  <%= button_to "Confirm publish",
+  taxon_bulk_publish_path(page.taxon_content_id),
+  class: 'btn btn-lg btn-success' %>
+
+
+  <%= link_to "Cancel", taxon_path(page.taxon_content_id), class: "cancel-link" %>
+</div>

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -42,6 +42,9 @@
     <%= link_to taxon_confirm_publish_path(page.taxon_content_id), class: 'btn btn-md btn-default' do %>
       Publish
     <% end %>
+    <%= link_to taxon_confirm_bulk_publish_path(page.taxon_content_id), class: 'btn btn-md btn-default' do %>
+        Publish Tree
+    <% end %>
     <%= link_to "Delete", taxon_confirm_discard_path(page.taxon_content_id), class: 'delete-link' %>
   <% elsif page.unpublished? %>
     <%= link_to taxon_confirm_restore_path(page.taxon_content_id), class: 'btn btn-md btn-default' do %>

--- a/app/workers/publish_taxon_worker.rb
+++ b/app/workers/publish_taxon_worker.rb
@@ -1,0 +1,9 @@
+class PublishTaxonWorker
+  include Sidekiq::Worker
+
+  def perform(taxon_content_id)
+    Services.publishing_api.publish(taxon_content_id)
+  rescue GdsApi::HTTPConflict => ex # Ignore attempts to publish already published content
+    puts "409 #{ex.message}"
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,9 +6,11 @@ Rails.application.routes.draw do
     get :confirm_restore
     get :confirm_discard
     get :confirm_publish
+    get :confirm_bulk_publish
     get :download_tagged
     get :download, on: :collection
     post :publish
+    post :bulk_publish
     post :restore
     get :trash, on: :collection
     get :drafts, on: :collection

--- a/spec/controllers/taxons_controller_spec.rb
+++ b/spec/controllers/taxons_controller_spec.rb
@@ -87,6 +87,22 @@ RSpec.describe TaxonsController, type: :controller do
     end
   end
 
+  describe '#bulk_publish' do
+    it 'bulk publishes content' do
+      expect(Taxonomy::BulkUpdateTaxon).to receive(:call).with('123')
+      post :bulk_publish, params: { taxon_id: 123 }
+      expect(response).to redirect_to(taxon_path(123))
+    end
+  end
+
+  describe '#confirm_bulk_publish' do
+    it 'renders confirm bulk publish' do
+      expect(Taxonomy::BuildTaxon).to receive(:call).with(content_id: '123').and_return FactoryGirl.build(:taxon)
+      get :confirm_bulk_publish, params: { taxon_id: 123 }
+      expect(response.code).to eql "200"
+    end
+  end
+
   describe "#restore" do
     it "sends a request to Publishing API to mark the taxon as 'draft'" do
       taxon = build(:taxon, publication_state: "unpublished")

--- a/spec/services/taxonomy/bulk_update_taxon_spec.rb
+++ b/spec/services/taxonomy/bulk_update_taxon_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe Taxonomy::BulkUpdateTaxon do
+  before do
+    item = GovukTaxonomyHelpers::LinkedContentItem.new(title: 'item1', base_path: '/item1', content_id: 'id1')
+    item << GovukTaxonomyHelpers::LinkedContentItem.new(title: 'item2', base_path: '/item2', content_id: 'id2')
+
+    @root_taxon_id = 123
+    allow(GovukTaxonomyHelpers::LinkedContentItem)
+      .to receive(:from_content_id)
+      .with(content_id: @root_taxon_id, publishing_api: Services.publishing_api)
+      .and_return(item)
+  end
+
+  describe '#call' do
+    it 'spawns a worker for each id' do
+      expect(PublishTaxonWorker).to receive(:perform_async).with('id1')
+      expect(PublishTaxonWorker).to receive(:perform_async).with('id2')
+      Taxonomy::BulkUpdateTaxon.call(@root_taxon_id)
+    end
+  end
+end


### PR DESCRIPTION


Adds a 'publish tree' button on the view taxon page of any draft taxon. When pressed, this taxon and all its children will be set to published. A sidekiq job per taxon is used to publish the taxons.

https://trello.com/c/cGImL1qz/47-a-way-to-publish-taxons-in-bulk

![screen shot 2017-07-25 at 12 01 59](https://user-images.githubusercontent.com/6050162/28569284-1b429f36-7131-11e7-999c-028c189ce49d.png)
![screen shot 2017-07-25 at 14 34 03](https://user-images.githubusercontent.com/6050162/28574611-604f0c26-7146-11e7-8cbc-095244e9d761.png)
![screen shot 2017-07-25 at 14 35 04](https://user-images.githubusercontent.com/6050162/28574639-7b2c26aa-7146-11e7-97f0-8d971fddbdd3.png)
