### PR TITLE
Graphing tool for legacy taxonomies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ end
 
 group :development do
   gem 'better_errors'
+  gem 'ruby-graphviz'
   gem 'web-console'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -271,6 +271,7 @@ GEM
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-graphviz (1.2.3)
     ruby-progressbar (1.8.1)
     safe_yaml (1.0.4)
     sass (3.4.23)
@@ -378,6 +379,7 @@ DEPENDENCIES
   pry-byebug
   rails (= 5.0.2)
   rspec-rails
+  ruby-graphviz
   sass-rails (~> 5.0)
   select2-rails (~> 3.5.9)
   simple_form (~> 3.2, >= 3.2.1)
@@ -389,4 +391,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.15.0
+   1.15.3

--- a/app/services/legacy_taxonomy/graph.rb
+++ b/app/services/legacy_taxonomy/graph.rb
@@ -1,0 +1,27 @@
+require 'graphviz'
+
+module LegacyTaxonomy
+  class Graph
+    attr_reader :root_taxon, :graph, :filename
+
+    def initialize(taxonomy, filename)
+      @root_taxon = taxonomy
+      @graph = GraphViz.new(:G, rankdir: 'LR', type: :digraph)
+      @filename = filename
+    end
+
+    def plot
+      build_graph(root_taxon)
+      graph.output(png: filename)
+    end
+
+    def build_graph(taxon)
+      parent = graph.add_nodes("#{taxon.title} (#{taxon.tagged_pages.count})")
+      taxon.child_taxons.each do |node|
+        child = graph.add_nodes("#{node.title} (#{node.tagged_pages.count})")
+        graph.add_edges(parent, child)
+        build_graph(node)
+      end
+    end
+  end
+end

--- a/lib/tasks/legacy_taxonomy.rake
+++ b/lib/tasks/legacy_taxonomy.rake
@@ -11,6 +11,12 @@ namespace :legacy_taxonomy do
       taxonomy_branch = LegacyTaxonomy::Yamlizer.new('tmp/msbp.yml').read
       LegacyTaxonomy::TaxonomyPublisher.new(taxonomy_branch).commit
     end
+
+    desc "Generate a visualisation of the Mainstream Browse taxonomy"
+    task visualise: :environment do
+      taxonomy_branch = LegacyTaxonomy::Yamlizer.new('tmp/msbp.yml').read
+      LegacyTaxonomy::Graph.new(taxonomy_branch, 'tmp/msbp_graph.png').plot
+    end
   end
 
   namespace :topic do
@@ -29,6 +35,12 @@ namespace :legacy_taxonomy do
       taxonomy_branch = LegacyTaxonomy::Yamlizer.new('tmp/topic.yml').read
       LegacyTaxonomy::TaxonomyPublisher.new(taxonomy_branch).commit
     end
+
+    desc "Generate a visualisation of the Topic taxonomy"
+    task visualise: :environment do
+      taxonomy_branch = LegacyTaxonomy::Yamlizer.new('tmp/topic.yml').read
+      LegacyTaxonomy::Graph.new(taxonomy_branch, 'tmp/topic_graph.png').plot
+    end
   end
 
   namespace :policy_area do
@@ -37,6 +49,12 @@ namespace :legacy_taxonomy do
       taxonomy = LegacyTaxonomy::PolicyAreaTaxonomy.new('/bar').to_taxonomy_branch
       LegacyTaxonomy::Yamlizer.new('tmp/policy_area.yml').write(taxonomy)
     end
+
+    desc "Generate a visualisation of the Policy Area taxonomy"
+    task visualise: :environment do
+      taxonomy_branch = LegacyTaxonomy::Yamlizer.new('tmp/policy_area.yml').read
+      LegacyTaxonomy::Graph.new(taxonomy_branch, 'tmp/policy_area_graph.png').plot
+    end
   end
 
   namespace :policy do
@@ -44,6 +62,12 @@ namespace :legacy_taxonomy do
     task generate_taxons: :environment do
       taxonomy = LegacyTaxonomy::PolicyTaxonomy.new('/baz').to_taxonomy_branch
       File.write('tmp/policy.yml', YAML.dump(taxonomy))
+    end
+
+    desc "Generate a visualisation of the Policy Area => Policy taxonomy"
+    task visualise: :environment do
+      taxonomy_branch = LegacyTaxonomy::Yamlizer.new('tmp/policy.yml').read
+      LegacyTaxonomy::Graph.new(taxonomy_branch, 'tmp/policy_graph.png').plot
     end
   end
 


### PR DESCRIPTION
Assumes the requested taxonomy has been generated to the `tmp` folder.
Generates a quickie visualisation looking like this:

![graph](https://user-images.githubusercontent.com/608867/28624557-620f5572-7211-11e7-838a-b75e988a3b01.png)

Requires `graphvis` to be installed:

```
$ brew install graphviz
```

