### PR TITLE
Improve legacy imports by naming created Themes

### DIFF
--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -18,12 +18,12 @@ class Taxon
   include ActiveModel::Model
 
   validates_presence_of :title, :description, :internal_name, :path_prefix
-  validates :path_prefix, inclusion: { in: Theme.taxon_path_prefixes }
+  validates :path_prefix, inclusion: { in: proc { Theme.taxon_path_prefixes } }
   validates :path_slug, allow_blank: true, format: { with: %r{\A/[a-zA-Z0-9\-]+\z} }
   validates_with CircularDependencyValidator
 
   def theme
-    Theme::THEMES[path_prefix] || "Other"
+    Theme.prefix_to_name(path_prefix) || "Other"
   end
 
   def draft?

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -1,11 +1,9 @@
-class Theme
-  THEMES = {
-    '/childcare-parenting' => 'Childcare and Parenting',
-    '/education' => 'Education',
-    '/world' => 'World',
-  }.freeze
-
+class Theme < ActiveRecord::Base
   def self.taxon_path_prefixes
-    THEMES.keys
+    pluck(:path_prefix)
+  end
+
+  def self.prefix_to_name(prefix)
+    where(path_prefix: prefix).pluck(:name).first
   end
 end

--- a/app/services/legacy_taxonomy/three_level_taxonomy.rb
+++ b/app/services/legacy_taxonomy/three_level_taxonomy.rb
@@ -2,11 +2,7 @@ module LegacyTaxonomy
   class ThreeLevelTaxonomy
     attr_accessor :path_prefix
 
-    def initialize(path_prefix,
-                   base_path: '/browse',
-                   title: 'Imported Mainstream Browse',
-                   first_level_key: 'top_level_browse_pages',
-                   second_level_key: 'second_level_browse_pages')
+    def initialize(path_prefix, base_path:, title:, first_level_key:, second_level_key:)
       @path_prefix = path_prefix
       @base_path = base_path
       @title = title

--- a/app/services/legacy_taxonomy/three_level_taxonomy.rb
+++ b/app/services/legacy_taxonomy/three_level_taxonomy.rb
@@ -4,7 +4,7 @@ module LegacyTaxonomy
 
     def initialize(path_prefix,
                    base_path: '/browse',
-                   title: 'Mainstream Browse Taxonomy',
+                   title: 'Imported Mainstream Browse',
                    first_level_key: 'top_level_browse_pages',
                    second_level_key: 'second_level_browse_pages')
       @path_prefix = path_prefix
@@ -18,8 +18,8 @@ module LegacyTaxonomy
       root_content_id = Client::PublishingApi.content_id_for_base_path(@base_path)
 
       TaxonData.new(
-        title: 'Browse',
-        description: @title,
+        title: @title,
+        description: '',
         legacy_content_id: root_content_id,
         path_slug: @base_path,
         path_prefix: path_prefix,

--- a/db/migrate/20170801103028_create_themes.rb
+++ b/db/migrate/20170801103028_create_themes.rb
@@ -1,0 +1,12 @@
+class CreateThemes < ActiveRecord::Migration[5.0]
+  def change
+    create_table :themes, id: false do |t|
+      t.string :path_prefix, null: false
+      t.string :name, null: false
+
+      t.timestamps
+    end
+
+    add_index :themes, :path_prefix
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170627094157) do
+ActiveRecord::Schema.define(version: 20170801103028) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -78,6 +78,14 @@ ActiveRecord::Schema.define(version: 20170627094157) do
     t.text     "error_message"
     t.datetime "deleted_at"
     t.string   "description"
+  end
+
+  create_table "themes", id: false, force: :cascade do |t|
+    t.string   "path_prefix", null: false
+    t.string   "name",        null: false
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
+    t.index ["path_prefix"], name: "index_themes_on_path_prefix", using: :btree
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,0 +1,3 @@
+Theme.find_or_create_by(name: 'Childcare and Parenting', path_prefix: '/childcare-parenting')
+Theme.find_or_create_by(name: 'Education', path_prefix: '/education')
+Theme.find_or_create_by(name: 'World', path_prefix: '/world')

--- a/lib/tasks/legacy_taxonomy.rake
+++ b/lib/tasks/legacy_taxonomy.rake
@@ -16,7 +16,11 @@ namespace :legacy_taxonomy do
   namespace :mainstream_browse do
     desc "Generates structure for mainstream browse at www.gov.uk/browse"
     task generate_taxons: :environment do
-      taxonomy = LegacyTaxonomy::ThreeLevelTaxonomy.new('/imported-browse').to_taxonomy_branch
+      taxonomy = LegacyTaxonomy::ThreeLevelTaxonomy.new('/imported-browse',
+                                                        title: 'Imported Mainstream Browse',
+                                                        first_level_key: 'top_level_browse_pages',
+                                                        second_level_key: 'second_level_browse_pages',
+                                                        base_path: '/browse').to_taxonomy_branch
       LegacyTaxonomy::Yamlizer.new('tmp/msbp.yml').write(taxonomy)
     end
 

--- a/lib/tasks/legacy_taxonomy.rake
+++ b/lib/tasks/legacy_taxonomy.rake
@@ -35,7 +35,7 @@ namespace :legacy_taxonomy do
                                                         base_path: '/topic',
                                                         first_level_key: 'children',
                                                         second_level_key: 'children',
-                                                        title: 'Topic Taxonomy').to_taxonomy_branch
+                                                        title: 'Imported Topic').to_taxonomy_branch
       LegacyTaxonomy::Yamlizer.new('tmp/topic.yml').write(taxonomy)
     end
 

--- a/lib/tasks/legacy_taxonomy.rake
+++ b/lib/tasks/legacy_taxonomy.rake
@@ -1,13 +1,28 @@
 namespace :legacy_taxonomy do
+  namespace :all do
+    desc "Scrape and import legacy taxonomies"
+    task import: :environment do
+      taxonomies = %w(mainstream_browse topic)
+      tasks = %w(generate_taxons publish_taxons)
+
+      tasks.each do |tsk|
+        taxonomies.each do |taxonomy|
+          Rake::Task["legacy_taxonomy:#{taxonomy}:#{tsk}"].execute
+        end
+      end
+    end
+  end
+
   namespace :mainstream_browse do
     desc "Generates structure for mainstream browse at www.gov.uk/browse"
     task generate_taxons: :environment do
-      taxonomy = LegacyTaxonomy::ThreeLevelTaxonomy.new('/foo').to_taxonomy_branch
+      taxonomy = LegacyTaxonomy::ThreeLevelTaxonomy.new('/imported-browse').to_taxonomy_branch
       LegacyTaxonomy::Yamlizer.new('tmp/msbp.yml').write(taxonomy)
     end
 
     desc "Send the Mainstream Browse taxonomy to the publishing platform"
     task publish_taxons: :environment do
+      Theme.find_or_create_by(name: 'Mainstream Browse', path_prefix: '/imported-browse')
       taxonomy_branch = LegacyTaxonomy::Yamlizer.new('tmp/msbp.yml').as_yaml
       LegacyTaxonomy::TaxonomyPublisher.perform_async(taxonomy_branch)
     end
@@ -16,7 +31,7 @@ namespace :legacy_taxonomy do
   namespace :topic do
     desc "Generates structure for Topic taxonomy at www.gov.uk/browse"
     task generate_taxons: :environment do
-      taxonomy = LegacyTaxonomy::ThreeLevelTaxonomy.new('/qux',
+      taxonomy = LegacyTaxonomy::ThreeLevelTaxonomy.new('/imported-topic',
                                                         base_path: '/topic',
                                                         first_level_key: 'children',
                                                         second_level_key: 'children',
@@ -26,6 +41,7 @@ namespace :legacy_taxonomy do
 
     desc "Send the Topic taxonomy to the publishing platform"
     task publish_taxons: :environment do
+      Theme.find_or_create_by(name: 'Topic', path_prefix: '/imported-topic')
       taxonomy_branch = LegacyTaxonomy::Yamlizer.new('tmp/topic.yml').as_yaml
       LegacyTaxonomy::TaxonomyPublisher.perform_async(taxonomy_branch)
     end

--- a/spec/controllers/taxons_controller_spec.rb
+++ b/spec/controllers/taxons_controller_spec.rb
@@ -89,6 +89,7 @@ RSpec.describe TaxonsController, type: :controller do
 
   describe "#restore" do
     it "sends a request to Publishing API to mark the taxon as 'draft'" do
+      create(:theme, :education)
       taxon = build(:taxon, publication_state: "unpublished")
       payload = Taxonomy::BuildTaxonPayload.call(taxon: taxon)
       links = {

--- a/spec/factories/theme.rb
+++ b/spec/factories/theme.rb
@@ -1,0 +1,11 @@
+FactoryGirl.define do
+  factory :theme do
+    name 'A theme'
+    path_prefix '/foo'
+
+    trait :education do
+      name 'Education'
+      path_prefix '/education'
+    end
+  end
+end

--- a/spec/features/delete_taxon_spec.rb
+++ b/spec/features/delete_taxon_spec.rb
@@ -79,6 +79,7 @@ RSpec.feature "Delete Taxon", type: :feature do
   end
 
   def given_a_deleted_taxon
+    create(:theme, :education)
     @taxon_content_id = SecureRandom.uuid
     @taxon = content_item_with_details(
       "Taxon 2",

--- a/spec/features/taxonomy_editing_spec.rb
+++ b/spec/features/taxonomy_editing_spec.rb
@@ -5,6 +5,8 @@ RSpec.feature "Taxonomy editing" do
   include ContentItemHelper
 
   before do
+    create(:theme, :education)
+
     @taxon_1 = content_item_with_details(
       "I Am A Taxon",
       other_fields: {
@@ -129,6 +131,7 @@ RSpec.feature "Taxonomy editing" do
   end
 
   def given_there_are_taxons
+    create(:theme, :education)
     publishing_api_has_linkables(
       [@linkable_taxon_1, @linkable_taxon_2, @linkable_taxon_3],
       document_type: 'taxon'

--- a/spec/models/taxon_spec.rb
+++ b/spec/models/taxon_spec.rb
@@ -1,6 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe Taxon do
+  before do
+    create(:theme, :education)
+  end
+
   context 'validations' do
     it 'is not valid without a title' do
       taxon = described_class.new

--- a/spec/services/legacy_taxonomy/three_level_taxonomy_spec.rb
+++ b/spec/services/legacy_taxonomy/three_level_taxonomy_spec.rb
@@ -7,7 +7,11 @@ RSpec.describe LegacyTaxonomy::ThreeLevelTaxonomy do
 
   describe "#to_taxonomy_branch" do
     let(:result) do
-      described_class.new('/foo').to_taxonomy_branch
+      described_class.new('/foo',
+                          base_path: '/browse',
+                          title: 'taxonomy title',
+                          first_level_key: 'top_level_browse_pages',
+                          second_level_key: 'second_level_browse_pages').to_taxonomy_branch
     end
 
     context 'there is only one root, no children' do
@@ -16,7 +20,7 @@ RSpec.describe LegacyTaxonomy::ThreeLevelTaxonomy do
       end
 
       it 'returns the root browse taxon' do
-        expect(result.title).to eq 'Browse'
+        expect(result.title).to eq 'taxonomy title'
         expect(result.base_path).to eq '/foo/browse'
         expect(result.child_taxons).to be_empty
       end

--- a/spec/services/taxonomy/update_taxon_spec.rb
+++ b/spec/services/taxonomy/update_taxon_spec.rb
@@ -2,6 +2,8 @@ require 'rails_helper'
 
 RSpec.describe Taxonomy::UpdateTaxon do
   before do
+    create(:theme, :education)
+
     @taxon = Taxon.new(
       title: 'A Title',
       description: 'Description',


### PR DESCRIPTION
When importing the legacy taxonomies, content-tagger would list the newly created taxons under the `other` theme.

These changes allow the importer to create a new `Theme` at import time. 