### PR TITLE
Capture uncurated content thats tagged to topic pages

### DIFF
--- a/app/services/legacy_taxonomy/client/search_api.rb
+++ b/app/services/legacy_taxonomy/client/search_api.rb
@@ -10,6 +10,12 @@ module LegacyTaxonomy
           )
         end
 
+        def content_tagged_to_topic(topic_slug)
+          content_from_rummager(
+            filter_specialist_sectors: [remove_leading_slash(topic_slug)]
+          )
+        end
+
         def content_tagged_to_policy_area(policy_area_slug)
           content_from_rummager(filter_policy_areas: [policy_area_slug])
         end
@@ -63,6 +69,10 @@ module LegacyTaxonomy
             Plek.new.find('rummager'),
             timeout: 20
           )
+        end
+
+        def remove_leading_slash(base_path)
+          base_path.gsub(%r{^\/}, '')
         end
       end
     end

--- a/app/services/legacy_taxonomy/three_level_taxonomy.rb
+++ b/app/services/legacy_taxonomy/three_level_taxonomy.rb
@@ -64,7 +64,7 @@ module LegacyTaxonomy
             legacy_content_id: content_id,
             path_slug: base_path,
             path_prefix: path_prefix,
-            tagged_pages: second_level_tagged_pages(content_id)
+            tagged_pages: second_level_tagged_pages(content_id, base_path)
           )
         end
     end
@@ -96,10 +96,11 @@ module LegacyTaxonomy
       end
     end
 
-    def second_level_tagged_pages(content_id)
+    def second_level_tagged_pages(content_id, base_path)
       (
         Client::SearchApi.content_tagged_to_browse_page(content_id) +
-          linked_related_topics(content_id)
+          linked_related_topics(content_id) +
+          Client::SearchApi.content_tagged_to_topic(base_path)
       ).uniq
     end
 

--- a/spec/services/legacy_taxonomy/three_level_taxonomy_spec.rb
+++ b/spec/services/legacy_taxonomy/three_level_taxonomy_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe LegacyTaxonomy::ThreeLevelTaxonomy do
         stub_publishing_api_second_level_browse_pages(basic_taxon['content_id'], [subtaxon])
         stub_publishing_api_third_level_browse_pages(subtaxon['content_id'], [])
         stub_publishing_api_content_id_lookup("/foo/subpath", 'sub_taxon')
-        stub_search_api subtaxon['content_id'], %w(page_content_id)
+        stub_search_api subtaxon, %w(page_content_id)
       end
 
       it 'has second level taxons' do
@@ -68,7 +68,7 @@ RSpec.describe LegacyTaxonomy::ThreeLevelTaxonomy do
         stub_publishing_api_third_level_browse_pages(subtaxon['content_id'], content_groups)
         stub_publishing_api_content_id_lookup('/path-of-group-contents', 'content-id-goes-here')
         stub_publishing_api_content_id_lookup_404('/foo/path/groupo_uno')
-        stub_search_api subtaxon['content_id'], %w(page_content_id)
+        stub_search_api subtaxon, %w(page_content_id)
       end
 
       it "has third level taxons" do
@@ -141,11 +141,16 @@ RSpec.describe LegacyTaxonomy::ThreeLevelTaxonomy do
     stub_publishing_api_second_level_browse_pages(parent_id, [])
   end
 
-  def stub_search_api(base_path, pages = [])
+  def stub_search_api(taxon, pages = [])
     allow(LegacyTaxonomy::Client::SearchApi)
       .to receive(:content_tagged_to_browse_page)
-      .with(base_path)
+      .with(taxon['content_id'])
       .and_return(pages)
+
+    allow(LegacyTaxonomy::Client::SearchApi)
+      .to receive(:content_tagged_to_topic)
+      .with(taxon['base_path'])
+      .and_return([])
   end
 
   def basic_taxon


### PR DESCRIPTION
Content can be tagged to topic pages, but if it's not curated into groups (in `collections-publisher`) then it won't appear in the scraped taxonomy. This change will pull in topic-tagged content from the search api.