### PR TITLE
Force the use of generated expanded links to avoid stale results

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'unicorn', '~> 5.0.0'
 
 # GDS managed dependencies
 gem 'airbrake', github: 'alphagov/airbrake', branch: 'silence-dep-warnings-for-rails-5'
-gem 'gds-api-adapters', '~> 47.2'
+gem 'gds-api-adapters', '~> 47.6'
 gem 'gds-sso', '~> 13.2'
 gem 'govuk_admin_template', '~> 5.0'
 gem 'govuk_sidekiq', '~> 1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,7 +96,7 @@ GEM
       railties (>= 3.0.0)
     faraday (0.11.0)
       multipart-post (>= 1.2, < 3)
-    gds-api-adapters (47.2.0)
+    gds-api-adapters (47.7.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -361,7 +361,7 @@ DEPENDENCIES
   chartkick
   database_cleaner
   factory_girl_rails
-  gds-api-adapters (~> 47.2)
+  gds-api-adapters (~> 47.6)
   gds-sso (~> 13.2)
   govuk-content-schema-test-helpers
   govuk-lint
@@ -389,4 +389,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.15.0
+   1.15.3

--- a/app/models/tagging/content_item_expanded_links.rb
+++ b/app/models/tagging/content_item_expanded_links.rb
@@ -18,7 +18,7 @@ module Tagging
 
     # Find the links for a content item by its content ID
     def self.find(content_id)
-      data = Services.publishing_api.get_expanded_links(content_id).to_h
+      data = Services.publishing_api.get_expanded_links(content_id, generate: true).to_h
 
       links = data.fetch('expanded_links', {})
 

--- a/spec/features/related_item_tagging_spec.rb
+++ b/spec/features/related_item_tagging_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "Tagging content", type: :feature do
         title: 'This Is A Content Item',
       }.to_json)
 
-    stub_request(:get, "#{PUBLISHING_API}/v2/expanded-links/MY-CONTENT-ID")
+    stub_request(:get, "#{PUBLISHING_API}/v2/expanded-links/MY-CONTENT-ID?generate=true")
       .to_return(body: {
         content_id: "MY-CONTENT-ID",
         expanded_links: {},

--- a/spec/features/tag_a_page_spec.rb
+++ b/spec/features/tag_a_page_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe "Tagging content", type: :feature do
         title: 'This Is A Content Item',
       }.to_json)
 
-    stub_request(:get, "#{PUBLISHING_API}/v2/expanded-links/MY-CONTENT-ID")
+    stub_request(:get, "#{PUBLISHING_API}/v2/expanded-links/MY-CONTENT-ID?generate=true")
       .to_return(body: {
         content_id: "MY-CONTENT-ID",
         expanded_links: expanded_links,

--- a/spec/features/tagging_during_migration_spec.rb
+++ b/spec/features/tagging_during_migration_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe "Tagging content during migration", type: :feature do
         title: 'This Is A Content Item',
       }.to_json)
 
-    stub_request(:get, "#{PUBLISHING_API}/v2/expanded-links/MY-CONTENT-ID")
+    stub_request(:get, "#{PUBLISHING_API}/v2/expanded-links/MY-CONTENT-ID?generate=true")
       .to_return(body: {
         content_id: "MY-CONTENT-ID",
         expanded_links: {


### PR DESCRIPTION
Recent changes to publishing-api.expanded-links mean that the
tagging interface will return an error, due to stale data.

Resulting in this error message when trying to change the tags assigned:

![image](https://user-images.githubusercontent.com/608867/29031716-0c61b4d8-7b87-11e7-88db-921c2a85f687.png)

This change should ensure that the tagging interface will always
receive the freshest data.

[Trello](https://trello.com/c/sOMPe5Od/142-error-while-tagging-content-in-content-tagger)