### PR TITLE
Tagging content in list view

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,13 @@ SignalException:
   Enabled: true
   EnforcedStyle: only_raise
 
+# This suggests that we use single character variable names as block params.
+# On GOV.UK we prefer to use more descriptive variable naming to make our
+# code easier to read for future developers.
+SingleLineBlockParams:
+  Description: 'Enforces the names of some block params.'
+  Enabled: false
+
 # Add project-specific rubocop rules here
 
 LineLength:
@@ -167,10 +174,6 @@ CommentIndentation:
 
 CyclomaticComplexity:
   Description: 'Avoid complex methods.'
-  Enabled: true
-
-DeprecatedHashMethods:
-  Description: 'Checks for use of deprecated Hash methods.'
   Enabled: true
 
 # Not every class needs to be documented. Making this mandatory will make
@@ -358,14 +361,6 @@ RedundantSelf:
   Description: "Don't use self where it's not needed."
   Enabled: true
 
-RegexpLiteral:
-  Description: >-
-    Use %r for regular expressions matching more than
-    `MaxSlashes` '/' characters.
-    Use %r only for regular expressions matching more than
-    `MaxSlashes` '/' character.
-  Enabled: true
-
 RescueModifier:
   Description: 'Avoid using rescue in its modifier form.'
   Enabled: true
@@ -376,10 +371,6 @@ SelfAssignment:
 
 Semicolon:
   Description: "Don't use semicolons to terminate expressions."
-  Enabled: true
-
-SingleLineBlockParams:
-  Description: 'Enforces the names of some block params.'
   Enabled: true
 
 SingleLineMethods:

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -6,7 +6,8 @@
 //= require Chart.bundle
 //= require chartkick
 //= require vendor/datatables.min
+//= require jquery_ujs
 
 $(document).ready(function() {
-  $(".select2").select2({ allowClear: true });
+  $(".select2:not(.tagging_project)").select2({ allowClear: true });
 });

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -11,6 +11,7 @@ $red: #b10e1e;
 @import 'related-item-tagging';
 @import 'views/taxon';
 @import 'vendor/datatables.min';
+@import 'tagathon_project';
 
 .error-message {
   color: $red;

--- a/app/assets/stylesheets/tagathon_project.scss
+++ b/app/assets/stylesheets/tagathon_project.scss
@@ -1,0 +1,21 @@
+.tagathon-project-content-list {
+  form {
+    margin: 20px 0;
+    border: 1px solid #ccc;
+    padding: 20px;
+    border-width:1px 0 0 0;
+
+    a {
+      font-size: 1.2em;
+    }
+
+    .project_content_item_taxons {
+      margin: 20px 0;
+    }
+
+    &.error-saving {
+      background-color: #ffb6b6;
+      transition: background-color 1s;
+    }
+  }
+}

--- a/app/controllers/project_content_items_controller.rb
+++ b/app/controllers/project_content_items_controller.rb
@@ -1,0 +1,35 @@
+class ProjectContentItemsController < ApplicationController
+  def update
+    tag_content
+    content_item.mark_complete
+    head :ok
+  rescue GdsApi::HTTPClientError
+    head :bad_request
+  end
+
+private
+
+  def tag_content
+    Services.publishing_api
+      .patch_links(
+        content_item_id,
+        links: { taxons: submitted_taxons }
+      )
+  end
+
+  def submitted_taxons
+    params
+      .require(:project_content_item)
+      .permit(:taxons)
+      .fetch(:taxons, "")
+      .split(',')
+  end
+
+  def content_item
+    @_content_item ||= ProjectContentItem.find(params[:id])
+  end
+
+  def content_item_id
+    Services.publishing_api.lookup_content_id(base_path: content_item.base_path)
+  end
+end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -33,6 +33,6 @@ private
   def new_project_params
     params
       .fetch(:new_project_form)
-      .permit(:name, :remote_url)
+      .permit(:name, :remote_url, :taxonomy_branch)
   end
 end

--- a/app/lib/project_builder.rb
+++ b/app/lib/project_builder.rb
@@ -1,13 +1,15 @@
 class ProjectBuilder
-  def self.call(project_name, content_item_attributes_enum)
+  def self.call(project_name, taxonomy_branch_content_id, content_item_attributes_enum)
     ProjectContentItem.transaction do
-      Project.create!(name: project_name).tap do |project|
-        content_item_attributes_enum.each do |content_item_attributes|
-          ProjectContentItem.create!(
-            { project: project }.merge(content_item_attributes)
-          )
+      Project
+        .create!(name: project_name, taxonomy_branch: taxonomy_branch_content_id)
+        .tap do |project|
+          content_item_attributes_enum.each do |content_item_attributes|
+            ProjectContentItem.create!(
+              { project: project }.merge(content_item_attributes)
+            )
+          end
         end
-      end
     end
   end
 end

--- a/app/models/govuk_taxonomy/branches.rb
+++ b/app/models/govuk_taxonomy/branches.rb
@@ -1,0 +1,50 @@
+module GovukTaxonomy
+  class Branches
+    HOMEPAGE_CONTENT_ID = "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a".freeze
+
+    def branch_name_for_content_id(content_id)
+      get_content_item(content_id).dig('title')
+    end
+
+    def all
+      published.map { |taxon| transform(taxon, 'published') } +
+        draft.map { |taxon| transform(taxon, 'draft') }
+    end
+
+    def published
+      @_published_branches ||= get_root_taxons(with_drafts: false)
+    end
+
+    def draft
+      @_draft_branches ||= get_root_taxons(with_drafts: true) - published
+    end
+
+    def taxons_for_branch(content_id)
+      taxon = get_content_item(content_id)
+      taxon['expanded_links_hash'] = get_expanded_links_hash(content_id, with_drafts: true)
+      Tree.new(taxon).root_taxon.tree
+    end
+
+  private
+
+    def transform(taxon, status)
+      taxon.slice("content_id", "title").merge("status" => status)
+    end
+
+    def get_root_taxons(with_drafts:)
+      get_expanded_links_hash(HOMEPAGE_CONTENT_ID, with_drafts: with_drafts)
+        .fetch('expanded_links', {})
+        .fetch('root_taxons', [])
+    end
+
+    def get_expanded_links_hash(content_id, with_drafts:)
+      Services.publishing_api
+        .get_expanded_links(content_id, with_drafts: with_drafts)
+        .to_h
+    end
+
+    def get_content_item(content_id)
+      Services.publishing_api.get_content(content_id).to_h
+    end
+  end
+end

--- a/app/models/govuk_taxonomy/taxon.rb
+++ b/app/models/govuk_taxonomy/taxon.rb
@@ -1,0 +1,58 @@
+# This is lifted almost verbatim from Whitehall
+# If you're changing it, consider extracting to a common Gem first, eh
+module GovukTaxonomy
+  class Taxon
+    extend Forwardable
+    attr_reader :name, :content_id, :base_path
+    attr_accessor :parent_node, :children
+    def_delegators :tree, :map, :each
+
+    def initialize(title:, base_path:, content_id:)
+      @name = title
+      @content_id = content_id
+      @base_path = base_path
+      @children = []
+    end
+
+    def tree
+      children.each_with_object([self]) do |child, tree|
+        tree.concat(child.tree)
+      end
+    end
+
+    def descendants
+      tree.tap(&:shift)
+    end
+
+    # Get ancestors of a taxon
+    #
+    # @return [Array] all taxons in the path from the root of the taxonomy to the parent taxon
+    def ancestors
+      if parent_node.nil?
+        []
+      else
+        parent_node.ancestors + [parent_node]
+      end
+    end
+
+    # Get a breadcrumb trail for a taxon
+    #
+    # @return [Array] all taxons in the path from the root of the taxonomy to this taxon
+    def breadcrumb_trail
+      ancestors + [self]
+    end
+
+    def count
+      tree.count
+    end
+
+    def root?
+      parent_node.nil?
+    end
+
+    def node_depth
+      return 0 if root?
+      1 + parent_node.node_depth
+    end
+  end
+end

--- a/app/models/govuk_taxonomy/tree.rb
+++ b/app/models/govuk_taxonomy/tree.rb
@@ -1,0 +1,38 @@
+# Recursive parser for publishing-api Taxon data
+# This is lifted almost verbatim from Whitehall
+# If you're changing it, consider extracting to a common Gem first, eh
+module GovukTaxonomy
+  class Tree
+    attr_reader :root_taxon
+
+    def initialize(expanded_root_taxon_hash)
+      @root_taxon = build_taxon(expanded_root_taxon_hash)
+      root_taxon.children = parse_taxons(
+        root_taxon,
+        expanded_root_taxon_hash['expanded_links_hash']
+      )
+    end
+
+  private
+
+    def build_taxon(taxon_hash)
+      GovukTaxonomy::Taxon.new taxon_hash.symbolize_keys.slice(:title, :base_path, :content_id)
+    end
+
+    def parse_taxons(parent, item_hash, key: 'expanded_links')
+      child_nodes(item_hash, key).map do |child|
+        taxon = build_taxon(child)
+        taxon.parent_node = parent
+        taxon.children = parse_taxons(taxon, child, key: 'links')
+        taxon
+      end
+    end
+
+    def child_nodes(item_hash, key)
+      item_hash
+        .fetch(key, {})
+        .fetch('child_taxons', [])
+        .sort_by { |hsh| hsh.fetch('title') }
+    end
+  end
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,3 +1,7 @@
 class Project < ActiveRecord::Base
   has_many :content_items, class_name: 'ProjectContentItem'
+
+  def taxonomy_branch_title
+    @_title ||= GovukTaxonomy::Branches.new.branch_name_for_content_id(taxonomy_branch)
+  end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,6 +1,10 @@
 class Project < ActiveRecord::Base
   has_many :content_items, class_name: 'ProjectContentItem'
 
+  def taxons
+    @_taxons ||= GovukTaxonomy::Branches.new.taxons_for_branch(taxonomy_branch)
+  end
+
   def taxonomy_branch_title
     @_title ||= GovukTaxonomy::Branches.new.branch_name_for_content_id(taxonomy_branch)
   end

--- a/app/models/project_content_item.rb
+++ b/app/models/project_content_item.rb
@@ -1,3 +1,18 @@
 class ProjectContentItem < ActiveRecord::Base
   belongs_to :project
+
+  def base_path
+    url.gsub('https://www.gov.uk', '')
+  end
+
+  # taxons don't exist
+  def taxons
+    []
+  end
+
+  def mark_complete
+    update_attributes(done: true)
+  end
+
+  scope :uncompleted, -> { where(done: false) }
 end

--- a/app/views/projects/_content_item.html.erb
+++ b/app/views/projects/_content_item.html.erb
@@ -1,2 +1,8 @@
-<div><%= link_to content_item.title, content_item.url, target: '_blank' %></div>
-<div><%= content_item.description %></div>
+<%= simple_form_for content_item, url: project_content_item_path(content_item.project, content_item), remote: true do |f| %>
+  <%= token_tag %>
+  <%= link_to content_item.title, content_item.url, target: '_blank' %>
+  <%= f.input :taxons,
+    placeholder: 'Choose one...',
+    label: false,
+    input_html: { class: [:select2, :tagging_project] } %>
+<% end %>

--- a/app/views/projects/new.html.erb
+++ b/app/views/projects/new.html.erb
@@ -7,6 +7,10 @@
                 label: 'Name',
                 hint: 'Name of the new project.' %>
 
+    <%= f.input :taxonomy_branch, input_html: { class: 'form-control' },
+                label: 'Branch of GOV.UK taxonomy',
+                collection: form.taxonomy_branches_for_select %>
+
     <%= f.input :remote_url, input_html: { class: 'form-control' },
                 label: 'Remote URL',
                 hint: 'Remote URL with the contents of the project.' %>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -1,5 +1,37 @@
 <h1><%= project.name %></h1>
 
-<div class='content-list'>
-  <%= render partial: 'content_item', collection: project.content_items %>
+<script type='text/javascript'>
+  var taxon_data = <%=
+    project
+      .taxons
+      .map { |taxon| { id: taxon.content_id, text: taxon.name } }
+      .to_json
+      .to_s
+      .html_safe
+  %>;
+
+  $(document).ready(function() {
+    $(".select2.tagging_project").select2({
+      allowClear: true,
+      data: taxon_data,
+      multiple: true
+    });
+
+    $(".select2.tagging_project").change(function() {
+      $(this).parents('form').trigger('submit.rails');
+    });
+
+    $("form").on('ajax:success', function(event, data, status, xhr) {
+      $(this).removeClass('error-saving');
+      $(this).effect("highlight", {color: "#d8f3d8"}, 1000);
+    });
+
+    $("form").on('ajax:error', function(event, data, status, xhr) {
+      $(this).addClass('error-saving');
+    });
+  });
+</script>
+
+<div class='tagathon-project-content-list'>
+  <%= render partial: 'content_item', collection: project.content_items.uncompleted %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,7 +32,9 @@ Rails.application.routes.draw do
   get '/content/:content_id', to: redirect { |params, _| "/taggings/#{params[:content_id]}" }
   get '/lookup', to: redirect("/taggings/lookup")
 
-  resources :projects, only: %i[index show new create]
+  resources :projects, only: %i(index show new create) do
+    resources :project_content_items, only: [:update], as: 'content_item'
+  end
 
   resources :tagging_spreadsheets, except: %i(update edit), path: '/tag-importer' do
     post 'refetch'

--- a/db/migrate/20170808153503_add_taxonomy_branch_to_project.rb
+++ b/db/migrate/20170808153503_add_taxonomy_branch_to_project.rb
@@ -1,0 +1,5 @@
+class AddTaxonomyBranchToProject < ActiveRecord::Migration[5.0]
+  def change
+    add_column :projects, :taxonomy_branch, :uuid
+  end
+end

--- a/db/migrate/20170809131403_add_done_column_to_project_content_items.rb
+++ b/db/migrate/20170809131403_add_done_column_to_project_content_items.rb
@@ -1,0 +1,5 @@
+class AddDoneColumnToProjectContentItems < ActiveRecord::Migration[5.0]
+  def change
+    add_column :project_content_items, :done, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170808153502) do
+ActiveRecord::Schema.define(version: 20170809131403) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -19,16 +19,18 @@ ActiveRecord::Schema.define(version: 20170808153502) do
     t.string   "url"
     t.string   "title"
     t.string   "description"
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
+    t.datetime "created_at",                  null: false
+    t.datetime "updated_at",                  null: false
     t.integer  "project_id"
+    t.boolean  "done",        default: false
     t.index ["project_id"], name: "index_project_content_items_on_project_id", using: :btree
   end
 
   create_table "projects", force: :cascade do |t|
     t.string   "name"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
+    t.uuid     "taxonomy_branch"
   end
 
   create_table "tag_mappings", force: :cascade do |t|

--- a/spec/controllers/project_content_items_controller_spec.rb
+++ b/spec/controllers/project_content_items_controller_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe ProjectContentItemsController, type: :request do
+  include TaxonomyHelper
+
+  describe "#update" do
+    before { create(:project, :with_content_item) }
+    let(:project) { Project.first }
+    let(:content_item) { project.content_items.first }
+
+    it "responds with a 200 code when content item is updated successfully" do
+      id = stub_content_id_lookup(content_item.base_path)
+      stub_tag_content(id)
+
+      patch(
+        project_content_item_path(project, content_item),
+        params: { project_content_item: { taxons: valid_taxon_uuid } }
+      )
+
+      expect(response.code).to eql "200"
+    end
+
+    it "responds with a 400 code when content item fails to update" do
+      id = stub_content_id_lookup(content_item.base_path)
+      stub_tag_content(id, success: false)
+
+      patch(
+        project_content_item_path(project, content_item),
+        params: { project_content_item: { taxons: invalid_taxon_uuid } }
+      )
+
+      expect(response.code).to eql "400"
+    end
+  end
+
+  def stub_content_id_lookup(base_path)
+    id = SecureRandom.uuid
+    stub_request(:post, "https://publishing-api.test.gov.uk/lookup-by-base-path")
+      .to_return(status: 200, body: { base_path => id }.to_json)
+    id
+  end
+end

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -2,8 +2,11 @@ require 'rails_helper'
 
 RSpec.describe ProjectsController, type: :controller do
   include RemoteCsvHelper
+  include TaxonomyHelper
+
   describe "#index" do
     it "gets projects" do
+      stub_draft_taxonomy_branch
       create(:project)
       get :index
       expect(response.code).to eql "200"
@@ -28,7 +31,8 @@ RSpec.describe ProjectsController, type: :controller do
   describe "#create" do
     it "creates a new (empty) project" do
       stub_remote_csv
-      post :create, params: { new_project_form: { name: 'myproject', remote_url: RemoteCsvHelper::CSV_URL } }
+      stub_draft_taxonomy_branch
+      post :create, params: { new_project_form: { name: 'myproject', taxonomy_branch: valid_taxon_uuid,remote_url: RemoteCsvHelper::CSV_URL } }
       expect(response).to redirect_to projects_path
     end
     it "fails validation and rerenders the page" do

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe ProjectsController, type: :controller do
     it "creates a new (empty) project" do
       stub_remote_csv
       stub_draft_taxonomy_branch
-      post :create, params: { new_project_form: { name: 'myproject', taxonomy_branch: valid_taxon_uuid,remote_url: RemoteCsvHelper::CSV_URL } }
+      post :create, params: { new_project_form: { name: 'myproject', taxonomy_branch: valid_taxon_uuid, remote_url: RemoteCsvHelper::CSV_URL } }
       expect(response).to redirect_to projects_path
     end
     it "fails validation and rerenders the page" do

--- a/spec/factories/project.rb
+++ b/spec/factories/project.rb
@@ -2,8 +2,15 @@ FactoryGirl.define do
   factory :project do
     name 'project title'
 
+    # TaxonomyHelper.valid_taxon_uuid
+    taxonomy_branch 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+
     trait :with_content_items do
       content_items { build_list :project_content_item, 3 }
+    end
+
+    trait :with_content_item do
+      content_items { build_list :project_content_item, 1 }
     end
   end
 end

--- a/spec/features/project_spec.rb
+++ b/spec/features/project_spec.rb
@@ -2,18 +2,21 @@ require 'rails_helper'
 
 RSpec.feature "Projects", type: :feature do
   include RemoteCsvHelper
+  include TaxonomyHelper
 
   scenario "viewing a project" do
     given_there_is_a_project_with_content_items
+    and_there_is_a_draft_taxonomy_branch
     when_i_visit_the_project_page
     then_i_can_see_all_the_content_items_for_that_project
   end
 
   scenario "creating a new project" do
     given_there_is_a_remote_spreadsheet
+    and_there_is_a_draft_taxonomy_branch
     when_i_visit_the_project_index_page
     and_i_click_the_new_project_link
-    and_i_fill_in_a_name_and_url
+    and_i_fill_in_a_name_and_url_and_select_a_branch_of_the_taxonomy
     and_i_click_new_project
     then_i_can_see_my_new_project_in_the_list
   end
@@ -24,6 +27,10 @@ RSpec.feature "Projects", type: :feature do
 
   def given_there_is_a_remote_spreadsheet
     stub_remote_csv
+  end
+
+  def and_there_is_a_draft_taxonomy_branch
+    stub_draft_taxonomy_branch
   end
 
   def when_i_visit_the_project_page
@@ -43,8 +50,9 @@ RSpec.feature "Projects", type: :feature do
     expect(page).to have_content 'New Project'
   end
 
-  def and_i_fill_in_a_name_and_url
+  def and_i_fill_in_a_name_and_url_and_select_a_branch_of_the_taxonomy
     fill_in 'new_project_form_name', with: 'my_project'
+    select draft_taxon_title, from: 'Branch of GOV.UK taxonomy'
     fill_in 'new_project_form_remote_url', with: 'http://www.example.com/my_csv'
   end
 

--- a/spec/forms/new_project_form_spec.rb
+++ b/spec/forms/new_project_form_spec.rb
@@ -2,27 +2,105 @@ require 'rails_helper'
 
 RSpec.describe NewProjectForm do
   include RemoteCsvHelper
-  before :each do
-    stub_remote_csv
+  include TaxonomyHelper
+
+  before { stub_remote_csv }
+
+  let(:valid_params) do
+    {
+      name: 'my_name',
+      remote_url: RemoteCsvHelper::CSV_URL,
+      taxonomy_branch: valid_taxon_uuid
+    }
   end
+
   describe '#create' do
-    context 'valid form' do
-      before :each do
-        @valid_form = NewProjectForm.new(name: 'my_name', remote_url: RemoteCsvHelper::CSV_URL)
+    context 'with a valid form' do
+      it 'returns the Project' do
+        valid_form = NewProjectForm.new(valid_params)
+        expect(valid_form.create).to be_a Project
       end
-      it 'is valid' do
-        expect(@valid_form.create).to be_truthy
-      end
-      it 'creates a new Project' do
-        expect { @valid_form.create }.to change { Project.count }.by(1)
+
+      it 'persists the Project' do
+        valid_form = NewProjectForm.new(valid_params)
+        expect { valid_form.create }.to change { Project.count }.by(1)
       end
     end
-    context 'invalid form' do
-      it 'is invalid' do
-        stub_request(:get, 'http://invalid_url').to_raise(SocketError)
-        invalid_form = NewProjectForm.new(name: 'my_name', remote_url: 'http://invalid_url')
-        expect(invalid_form.create).to be_falsey
+
+    context 'when the form is invalid' do
+      it 'returns false' do
+        invalid_form = NewProjectForm.new
+        allow(invalid_form).to receive(:valid?).and_return false
+        expect(invalid_form.create).to be false
       end
+    end
+
+    context 'with an exploding CSV' do
+      it 'returns false' do
+        allow_any_instance_of(RemoteCsv)
+          .to receive(:to_enum)
+          .and_raise(SocketError)
+        params = valid_params.merge(remote_url: 'http://invalid.url')
+        invalid_form = NewProjectForm.new(params)
+        expect(invalid_form.create).to be false
+      end
+    end
+  end
+
+  describe "#valid?" do
+    context 'with an invalid CSV URL' do
+      it 'returns false' do
+        params = valid_params.merge(remote_url: 'not.a.url')
+        invalid_form = NewProjectForm.new(params)
+        expect(invalid_form.valid?).to be false
+      end
+    end
+
+    context 'without a chosen taxonomy_branch' do
+      it 'returns false' do
+        params = valid_params.except(:taxonomy_branch)
+        invalid_form = NewProjectForm.new(params)
+        expect(invalid_form.valid?).to be false
+      end
+    end
+
+    context 'without a name' do
+      it 'returns false' do
+        params = valid_params.except(:name)
+        invalid_form = NewProjectForm.new(params)
+        expect(invalid_form.valid?).to be false
+      end
+    end
+  end
+
+  describe "#taxonomy_branches_for_select" do
+    before do
+      allow_any_instance_of(GovukTaxonomy::Branches)
+        .to receive(:all)
+        .and_return(
+          [
+            {
+              'status' => 'published',
+              'title' => 'Published Title',
+              'content_id' => 'published_id'
+            },
+            {
+              'status' => 'draft',
+              'title' => 'Draft Title',
+              'content_id' => 'draft_id'
+            }
+          ]
+        )
+    end
+
+    it 'returns a hash of title => id' do
+      result = NewProjectForm.new.taxonomy_branches_for_select
+      expect(result['Draft Title']).to eq 'draft_id'
+    end
+
+    it 'only returns draft root taxons' do
+      result = NewProjectForm.new.taxonomy_branches_for_select
+      expect(result.size).to eq 1
     end
   end
 end

--- a/spec/lib/project_builder_spec.rb
+++ b/spec/lib/project_builder_spec.rb
@@ -2,12 +2,12 @@ require "rails_helper"
 
 RSpec.describe ProjectBuilder do
   it 'creates a new project' do
-    expect { ProjectBuilder.call('project', []) }
+    expect { ProjectBuilder.call('project', '', []) }
       .to change { Project.count }
             .by(1)
   end
   it 'creates two new content items' do
-    expect { ProjectBuilder.call('project', [{ title: 'one' }, { title: 'two' }]) }
+    expect { ProjectBuilder.call('project', '', [{ title: 'one' }, { title: 'two' }]) }
       .to change { ProjectContentItem.count }
             .by(2)
   end

--- a/spec/support/taxonomy_helper.rb
+++ b/spec/support/taxonomy_helper.rb
@@ -1,0 +1,51 @@
+module TaxonomyHelper
+  def draft_taxon_title
+    'Test Taxon'
+  end
+
+  def valid_taxon_uuid
+    'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+  end
+
+  def invalid_taxon_uuid
+    'nope'
+  end
+
+  def stub_draft_taxonomy_branch
+    content_id = GovukTaxonomy::Branches::HOMEPAGE_CONTENT_ID
+
+    draft_root_taxons = {
+      'root_taxons' => [
+        {
+          'content_id' => valid_taxon_uuid,
+          'title' => draft_taxon_title
+        }
+      ]
+    }
+
+    root_taxon_content = {
+      'title' => draft_taxon_title,
+      'base_path' => '/foo',
+      'content_id' => valid_taxon_uuid
+    }
+
+    root_taxon_expanded_links = {}
+
+    stub_request(:get, "https://publishing-api.test.gov.uk/v2/expanded-links/#{content_id}?with_drafts=false")
+      .to_return(status: 200, body: {}.to_json)
+
+    stub_request(:get, "https://publishing-api.test.gov.uk/v2/expanded-links/#{content_id}")
+      .to_return(status: 200, body: { expanded_links: draft_root_taxons }.to_json)
+
+    stub_request(:get, "https://publishing-api.test.gov.uk/v2/content/#{valid_taxon_uuid}")
+      .to_return(status: 200, body: root_taxon_content.to_json)
+
+    stub_request(:get, "https://publishing-api.test.gov.uk/v2/expanded-links/#{valid_taxon_uuid}")
+      .to_return(status: 200, body: root_taxon_expanded_links.to_json)
+  end
+
+  def stub_tag_content(content_id, success: true)
+    stub_request(:patch, "https://publishing-api.test.gov.uk/v2/links/#{content_id}")
+      .to_return(status: success ? 200 : 400)
+  end
+end


### PR DESCRIPTION
Enables the linking of a new project to a draft branch of the GOV.UK taxonomy.

![image](https://user-images.githubusercontent.com/608867/29125474-b7de8d1c-7d13-11e7-8385-09b4e4d75640.png)

The list view interface has changed to support adding tags to content.

![image](https://user-images.githubusercontent.com/608867/29125459-aa8a0970-7d13-11e7-84b9-9c46b4ab724b.png)

[Trello](https://trello.com/c/xHPG53DN/101-edit-tags-for-a-piece-of-content-in-table-view)