### PR TITLE
Set inputs to autocomplete: off

### DIFF
--- a/app/views/projects/_content_item.html.erb
+++ b/app/views/projects/_content_item.html.erb
@@ -4,5 +4,5 @@
   <%= f.input :taxons,
     placeholder: 'Choose one...',
     label: false,
-    input_html: { class: [:select2, :tagging_project] } %>
+    input_html: { class: [:select2, :tagging_project], autocomplete: 'off' } %>
 <% end %>


### PR DESCRIPTION
In the project based tagging interface. As a custom autocomplete
implementation is used, stop the browser from getting involved.

Also, in Firefox, if autocomplete is enabled, Firefox will remember
input values across page refreshes, which for this page can be quite
confusing.