### PR TITLE
Use consistent breadcrumbs in the tagathon section

### DIFF
--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -1,11 +1,8 @@
-<header class="heading-with-actions"/>
-<h1>Projects</h1>
-<nav class="btn-group">
+<%= display_header title: "Projects", breadcrumbs: ["Projects"] do %>
   <%= link_to new_project_path, class: 'btn btn-default' do %>
-      <i class="glyphicon glyphicon-plus"></i>Add new project
+    <i class="glyphicon glyphicon-plus"></i>Add new project
   <% end %>
-</nav>
-</header>
+<% end %>
 
 <table class="table queries-list table-bordered table-striped">
   <thead>

--- a/app/views/projects/new.html.erb
+++ b/app/views/projects/new.html.erb
@@ -1,6 +1,5 @@
-<header class="heading-with-actions"/>
-  <h1>New Project</h1>
-</header>
+<%= display_header title: "New project",
+  breadcrumbs: [:projects, "New project"] %>
 
 <%= simple_form_for form, url: projects_path do |f| %>
     <%= f.input :name, input_html: { class: 'form-control' },

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -1,8 +1,8 @@
+<%= display_header title: project.name, breadcrumbs: [:projects, project.name] %>
+
 <%= render partial: 'shared/iframe_proxy_modal' %>
 
 <div class="row tagathon-project">
-  <h1><%= project.name %></h1>
-
   <div class="col-md-3 filter-controls">
     <h3>Filter</h3>
 


### PR DESCRIPTION
This uses the `display_header` helper to generate the title & breadcrumbs for the page so that it's consistent with the other sections in this app.

## Before

![screen shot 2017-08-21 at 17 06 22](https://user-images.githubusercontent.com/233676/29528210-20f31f74-8693-11e7-9467-e15f8c742719.png)
![screen shot 2017-08-21 at 17 06 24](https://user-images.githubusercontent.com/233676/29528209-20f079c2-8693-11e7-9d72-d187e5a5a639.png)
![screen shot 2017-08-21 at 17 06 20](https://user-images.githubusercontent.com/233676/29528208-20eced48-8693-11e7-9aeb-fe1e7964cb3d.png)

## After

![screen shot 2017-08-21 at 17 06 06](https://user-images.githubusercontent.com/233676/29528227-2e0badf2-8693-11e7-97a4-8337f810e4b2.png)
![screen shot 2017-08-21 at 17 06 10](https://user-images.githubusercontent.com/233676/29528229-2e14af06-8693-11e7-9533-07d9fe9318a0.png)
![screen shot 2017-08-21 at 17 06 14](https://user-images.githubusercontent.com/233676/29528228-2e132dd4-8693-11e7-8717-8b64b46aa3b7.png)
