### PR TITLE
Permissions

### DIFF
--- a/app/controllers/analytics_controller.rb
+++ b/app/controllers/analytics_controller.rb
@@ -1,4 +1,6 @@
 class AnalyticsController < ApplicationController
+  before_action :ensure_user_can_access_tagathon_tools!
+
   def index
     render :index, locals: { page: Analytics::IndexPage.new }
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,6 +10,14 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
+  def redirect_to_home_page
+    if user_can_administer_taxonomy?
+      redirect_to lookup_taggings_path
+    elsif user_can_access_tagathon_tools?
+      redirect_to projects_path
+    end
+  end
+
 private
 
   helper_method(
@@ -26,15 +34,19 @@ private
            to: :permission_checker
 
   def ensure_user_can_use_application!
-    raise PermissionDeniedException unless user_can_access_application?
+    deny_access_to(:application) unless user_can_access_application?
   end
 
   def ensure_user_can_administer_taxonomy!
-    raise PermissionDeniedException unless user_can_administer_taxonomy?
+    deny_access_to(:feature) unless user_can_administer_taxonomy?
   end
 
   def ensure_user_can_access_tagathon_tools!
-    raise PermissionDeniedException unless user_can_access_tagathon_tools?
+    deny_access_to(:feature) unless user_can_access_tagathon_tools?
+  end
+
+  def deny_access_to(subject)
+    raise PermissionDeniedException, "Sorry, you are not authorised to access this #{subject}."
   end
 
   def permission_checker

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,7 @@ class ApplicationController < ActionController::Base
   include GDS::SSO::ControllerMethods
   before_action :require_signin_permission!
   before_action :set_authenticated_user_header
+  before_action :ensure_user_can_use_application!
 
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
@@ -14,8 +15,31 @@ private
   helper_method(
     :active_navigation_item,
     :website_url,
-    :similar_search_results_url
+    :similar_search_results_url,
+    :user_can_administer_taxonomy?,
+    :user_can_access_tagathon_tools?
   )
+
+  delegate :user_can_access_application?,
+           :user_can_administer_taxonomy?,
+           :user_can_access_tagathon_tools?,
+           to: :permission_checker
+
+  def ensure_user_can_use_application!
+    raise PermissionDeniedException unless user_can_access_application?
+  end
+
+  def ensure_user_can_administer_taxonomy!
+    raise PermissionDeniedException unless user_can_administer_taxonomy?
+  end
+
+  def ensure_user_can_access_tagathon_tools!
+    raise PermissionDeniedException unless user_can_access_tagathon_tools?
+  end
+
+  def permission_checker
+    @permission_checker ||= PermissionChecker.new(current_user)
+  end
 
   def website_url(base_path, draft: false)
     if draft

--- a/app/controllers/bulk_tags_controller.rb
+++ b/app/controllers/bulk_tags_controller.rb
@@ -1,4 +1,6 @@
 class BulkTagsController < ApplicationController
+  before_action :ensure_user_can_administer_taxonomy!
+
   def new
     render :new, locals: {
       search_results: BulkTagging::EmptySearchResponse.new,

--- a/app/controllers/project_content_items_controller.rb
+++ b/app/controllers/project_content_items_controller.rb
@@ -1,4 +1,6 @@
 class ProjectContentItemsController < ApplicationController
+  before_action :ensure_user_can_access_tagathon_tools!
+
   def update
     tag_content
     content_item.mark_complete

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,4 +1,6 @@
 class ProjectsController < ApplicationController
+  before_action :ensure_user_can_access_tagathon_tools!
+
   def index
     render :index, locals: { projects: project_index }
   end

--- a/app/controllers/root_taxons_controller.rb
+++ b/app/controllers/root_taxons_controller.rb
@@ -1,4 +1,6 @@
 class RootTaxonsController < ApplicationController
+  before_action :ensure_user_can_administer_taxonomy!
+
   def index
     render :index, locals: { page: RootTaxonsForm.new }
   end

--- a/app/controllers/tag_migrations_controller.rb
+++ b/app/controllers/tag_migrations_controller.rb
@@ -1,4 +1,6 @@
 class TagMigrationsController < ApplicationController
+  before_action :ensure_user_can_administer_taxonomy!
+
   def index
     render :index, locals: { tag_migrations: presented_tag_migrations }
   end

--- a/app/controllers/tagging_spreadsheets_controller.rb
+++ b/app/controllers/tagging_spreadsheets_controller.rb
@@ -1,4 +1,6 @@
 class TaggingSpreadsheetsController < ApplicationController
+  before_action :ensure_user_can_administer_taxonomy!
+
   def index
     render :index, locals: { page: BulkTagging::IndexPage.new }
   end

--- a/app/controllers/taggings_controller.rb
+++ b/app/controllers/taggings_controller.rb
@@ -1,4 +1,6 @@
 class TaggingsController < ApplicationController
+  before_action :ensure_user_can_administer_taxonomy!
+
   def lookup
     render :lookup, locals: { lookup: ContentLookupForm.new }
   end

--- a/app/controllers/taxon_migrations_controller.rb
+++ b/app/controllers/taxon_migrations_controller.rb
@@ -1,4 +1,6 @@
 class TaxonMigrationsController < ApplicationController
+  before_action :ensure_user_can_administer_taxonomy!
+
   def new
     unless params[:source_content_id]
       redirect_to taxons_path

--- a/app/controllers/taxonomies_controller.rb
+++ b/app/controllers/taxonomies_controller.rb
@@ -1,4 +1,6 @@
 class TaxonomiesController < ApplicationController
+  before_action :ensure_user_can_administer_taxonomy!
+
   def show
     taxon_content_id = params[:content_id]
     taxonomy = Taxonomy::ExpandedTaxonomy.new(taxon_content_id).build

--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -1,4 +1,6 @@
 class TaxonsController < ApplicationController
+  before_action :ensure_user_can_administer_taxonomy!
+
   def index
     render :index, locals: { page: Taxonomy::IndexPage.new(params, "published") }
   end

--- a/app/lib/permission_checker.rb
+++ b/app/lib/permission_checker.rb
@@ -1,0 +1,32 @@
+class PermissionChecker
+  GDS_EDITOR_PERMISSION = "gds_editor".freeze
+  TAGATHON_PARTICIPANT_PERMISSION = "tagathon_participant".freeze
+
+  def initialize(user)
+    @user = user
+  end
+
+  def user_can_access_application?
+    gds_editor? || tagathon_participant?
+  end
+
+  def user_can_administer_taxonomy?
+    gds_editor?
+  end
+
+  def user_can_access_tagathon_tools?
+    gds_editor? || tagathon_participant?
+  end
+
+private
+
+  attr_reader :user
+
+  def gds_editor?
+    user.has_permission?(GDS_EDITOR_PERMISSION)
+  end
+
+  def tagathon_participant?
+    user.has_permission?(TAGATHON_PARTICIPANT_PERMISSION)
+  end
+end

--- a/app/views/analytics/activity.html.erb
+++ b/app/views/analytics/activity.html.erb
@@ -44,11 +44,11 @@
             <% if tagging_event.removed? %>
               <s>
                 <%= link_to tagging_event['taggable_title'], tagging_event['taggable_base_path'] %>
-                removed from  <%= link_to tagging_event.taxon_title, taxon_path(tagging_event.taxon_content_id) %>
+                removed from  <%= link_to tagging_event.taxon_title, taxon_history_path(tagging_event.taxon_content_id) %>
               </s>
             <% else %>
               <%= link_to tagging_event['taggable_title'], tagging_event['taggable_base_path'] %>
-              tagged to  <%= link_to tagging_event.taxon_title, taxon_path(tagging_event.taxon_content_id) %>
+              tagged to  <%= link_to tagging_event.taxon_title, taxon_history_path(tagging_event.taxon_content_id) %>
             <% end %>
           </td>
           <td>

--- a/app/views/analytics/show.html.erb
+++ b/app/views/analytics/show.html.erb
@@ -1,6 +1,8 @@
 <%= display_header title: page.title, breadcrumbs: [:analytics, page.title] do %>
-  <%= link_to I18n.t('views.taxons.view'), taxon_path(page.id),
-    class: 'btn btn-md btn-default' %>
+  <% if user_can_administer_taxonomy? %>
+    <%= link_to I18n.t('views.taxons.view'), taxon_path(page.id),
+      class: 'btn btn-md btn-default' %>
+  <% end %>
 <% end %>
 
 <% content_for :head do %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,25 +5,35 @@
 <% end %>
 
 <% content_for :navbar_items do %>
-  <li class='<%= active_navigation_item == 'taggings' ? 'active' : nil %>'>
-    <%= link_to t('navigation.tagging_content'), lookup_taggings_path %>
-  </li>
+  <% if user_can_administer_taxonomy? %>
+    <li class='<%= active_navigation_item == 'taggings' ? 'active' : nil %>'>
+      <%= link_to t('navigation.tagging_content'), lookup_taggings_path %>
+    </li>
+  <% end %>
 
-  <li class='<%= active_navigation_item.in?(%w[bulk_tags tag_migrations tagging_spreadsheets]) ? 'active' : nil %>'>
-    <%= link_to t('navigation.bulk_tag'), new_bulk_tag_path %>
-  </li>
+  <% if user_can_administer_taxonomy? %>
+    <li class='<%= active_navigation_item.in?(%w[bulk_tags tag_migrations tagging_spreadsheets]) ? 'active' : nil %>'>
+      <%= link_to t('navigation.bulk_tag'), new_bulk_tag_path %>
+    </li>
+  <% end %>
 
-  <li class='<%= active_navigation_item.in?(%w[taxons taxon_migrations]) ? 'active' : nil %>'>
-    <%= link_to t('navigation.taxons'), taxons_path %>
-  </li>
+  <% if user_can_administer_taxonomy? %>
+    <li class='<%= active_navigation_item.in?(%w[taxons taxon_migrations]) ? 'active' : nil %>'>
+      <%= link_to t('navigation.taxons'), taxons_path %>
+    </li>
+  <% end %>
 
-  <li class='<%= active_navigation_item == 'analytics' ? 'active' : nil %>'>
-    <%= link_to t('navigation.analytics'), analytics_path %>
-  </li>
+  <% if user_can_access_tagathon_tools? %>
+    <li class='<%= active_navigation_item == 'analytics' ? 'active' : nil %>'>
+      <%= link_to t('navigation.analytics'), analytics_path %>
+    </li>
+  <% end %>
 
-  <li class='<%= active_navigation_item == 'projects' ? 'active' : nil %>'>
-    <%= link_to t('navigation.projects'), projects_path %>
-  </li>
+  <% if user_can_access_tagathon_tools? %>
+    <li class='<%= active_navigation_item == 'projects' ? 'active' : nil %>'>
+      <%= link_to t('navigation.projects'), projects_path %>
+    </li>
+  <% end %>
 <% end %>
 
 <%= render template: 'layouts/govuk_admin_template' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  root to: 'taggings#lookup'
+  root to: 'application#redirect_to_home_page'
 
   resources :taxons do
     get :confirm_delete

--- a/spec/controllers/root_path_request_spec.rb
+++ b/spec/controllers/root_path_request_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe "Root Path", type: :request do
+  describe "as a GDS Editor" do
+    it "redirects to 'Edit a page'" do
+      login_as create(:user, :gds_editor)
+      get root_path
+      expect(response).to redirect_to lookup_taggings_path
+    end
+  end
+
+  describe "as a tagathon participant" do
+    it "redirects to 'Projects'" do
+      login_as create(:user, :tagathon_participant)
+      get root_path
+      expect(response).to redirect_to projects_path
+    end
+  end
+
+  describe "as an unprivileged user" do
+    it "denies access" do
+      login_as create(:user)
+      get root_path
+      expect(response.code).to eql "403"
+    end
+  end
+end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -1,0 +1,15 @@
+FactoryGirl.define do
+  factory :user do
+    uid { SecureRandom.uuid }
+    name "Sammy Hobson"
+    permissions { ["signin"] }
+
+    trait :gds_editor do
+      permissions { %w(signin gds_editor) }
+    end
+
+    trait :tagathon_participant do
+      permissions { %w(signin tagathon_participant) }
+    end
+  end
+end

--- a/spec/features/navigation_spec.rb
+++ b/spec/features/navigation_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+RSpec.feature "Navigation", type: :feature do
+  scenario "User with no specific permissions" do
+    given_i_am_logged_in_as_a_user_with_no_special_permissions
+    when_i_visit_the_application
+    then_i_will_see_the_permission_denied_page
+  end
+
+  scenario "Tagathon participants can access Projects and Analytics only" do
+    given_i_am_logged_in_as_a_tagathon_participant
+    when_i_visit_the_application
+    then_i_can_only_see_the_tagathon_options_in_the_nav_bar
+  end
+
+  scenario "GDS Editors can access all areas" do
+    given_i_am_logged_in_as_a_gds_editor
+    when_i_visit_the_application
+    then_i_can_see_the_full_set_of_navigation_options
+  end
+
+  def given_i_am_logged_in_as_a_user_with_no_special_permissions
+    login_as create(:user)
+  end
+
+  def given_i_am_logged_in_as_a_tagathon_participant
+    login_as create(:user, :tagathon_participant)
+  end
+
+  def given_i_am_logged_in_as_a_gds_editor
+    login_as create(:user, :gds_editor)
+  end
+
+  def when_i_visit_the_application
+    visit root_path
+  end
+
+  def then_i_will_see_the_permission_denied_page
+    expect(page).to have_text "Sorry, you are not authorised to access this application."
+  end
+
+  def then_i_can_only_see_the_tagathon_options_in_the_nav_bar
+    within "nav .navbar-nav" do
+      expect(page).not_to have_text "Edit a page"
+      expect(page).not_to have_text "Bulk tag"
+      expect(page).not_to have_text "Edit taxonomy"
+      expect(page).to have_text "Analytics"
+      expect(page).to have_text "Projects"
+    end
+  end
+
+  def then_i_can_see_the_full_set_of_navigation_options
+    within "nav .navbar-nav" do
+      expect(page).to have_text "Edit a page"
+      expect(page).to have_text "Bulk tag"
+      expect(page).to have_text "Edit taxonomy"
+      expect(page).to have_text "Analytics"
+      expect(page).to have_text "Projects"
+    end
+  end
+end

--- a/spec/features/tag_importer_spec.rb
+++ b/spec/features/tag_importer_spec.rb
@@ -8,10 +8,7 @@ RSpec.feature "Tag importer", type: :feature do
 
   before do
     Sidekiq::Testing.inline!
-
-    # We need the gds sso test user to be identifiable by uid in this spec to
-    # find the user who added the spreadsheet.
-    User.first.update(uid: "some-value", name: "Barry Allen")
+    @name = User.first.name
   end
 
   scenario "Importing tags" do
@@ -107,7 +104,7 @@ RSpec.feature "Tag importer", type: :feature do
     fill_in I18n.t('tag_import.sheet_url'), with: google_sheet_url(key: SHEET_KEY, gid: SHEET_GID)
     click_button I18n.t('tag_import.upload')
     expect(BulkTagging::TaggingSpreadsheet.count).to eq 1
-    expect(BulkTagging::TaggingSpreadsheet.first.added_by.name).to eq "Barry Allen"
+    expect(BulkTagging::TaggingSpreadsheet.first.added_by.name).to eq @name
   end
 
   def given_tagging_spreadsheet_exists

--- a/spec/lib/permission_checker_spec.rb
+++ b/spec/lib/permission_checker_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe PermissionChecker do
+  subject { described_class.new(user) }
+  let(:user) { instance_double(User, has_permission?: false) }
+
+  context "when the current_user has no special permissions" do
+    it { is_expected.not_to have_permission(:user_can_access_application?) }
+    it { is_expected.not_to have_permission(:user_can_administer_taxonomy?) }
+    it { is_expected.not_to have_permission(:user_can_access_tagathon_tools?) }
+  end
+
+  context "when the user has the Gds Editor permission" do
+    before do
+      allow(user)
+        .to receive(:has_permission?)
+        .with("gds_editor")
+        .and_return(true)
+    end
+
+    it { is_expected.to have_permission(:user_can_access_application?) }
+    it { is_expected.to have_permission(:user_can_administer_taxonomy?) }
+    it { is_expected.to have_permission(:user_can_access_tagathon_tools?) }
+  end
+
+  context "when the user has the Tagathon Participant permission" do
+    before do
+      allow(user)
+        .to receive(:has_permission?)
+        .with("tagathon_participant")
+        .and_return(true)
+    end
+
+    it { is_expected.to have_permission(:user_can_access_application?) }
+    it { is_expected.not_to have_permission(:user_can_administer_taxonomy?) }
+    it { is_expected.to have_permission(:user_can_access_tagathon_tools?) }
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -37,15 +37,6 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = false
   config.infer_spec_type_from_file_location!
 
-  # Authenticate a test user for controllers.
-  config.before(:each, type: :controller) do
-    request.env['warden'] = double(
-      authenticate!: true,
-      authenticated?: true,
-      user: User.new(permissions: ["signin"])
-    )
-  end
-
   config.before(:each) do
     User.create!
     DatabaseCleaner.start

--- a/spec/support/authentication_helpers.rb
+++ b/spec/support/authentication_helpers.rb
@@ -1,0 +1,48 @@
+module AuthenticationControllerHelpers
+  def login_as(user)
+    request.env['warden'] = double(
+      authenticate!: true,
+      authenticated?: true,
+      user: user
+    )
+  end
+
+  def stub_user
+    @stub_user ||= FactoryGirl.create(:user, :gds_editor)
+  end
+
+  def login_as_stub_user
+    login_as stub_user
+  end
+end
+
+module AuthenticationFeatureHelpers
+  def login_as(user)
+    GDS::SSO.test_user = user
+  end
+
+  def stub_user
+    @stub_user ||= FactoryGirl.create(:user, :gds_editor)
+  end
+
+  def login_as_stub_user
+    login_as stub_user
+  end
+end
+
+RSpec.configure do |config|
+  config.include AuthenticationControllerHelpers, type: :controller
+  config.before(:each, type: :controller) do
+    login_as_stub_user
+  end
+
+  config.include AuthenticationFeatureHelpers, type: :feature
+  config.before(:each, type: :feature) do
+    login_as_stub_user
+  end
+
+  config.include AuthenticationFeatureHelpers, type: :request
+  config.before(:each, type: :request) do
+    login_as_stub_user
+  end
+end

--- a/spec/support/permissions_matcher.rb
+++ b/spec/support/permissions_matcher.rb
@@ -1,0 +1,5 @@
+RSpec::Matchers.define :have_permission do |method|
+  match do |permission_checker|
+    permission_checker.send(method)
+  end
+end


### PR DESCRIPTION
Introduces the concept of Permissions into the content-tagger application.

Up until now any user with the default `signin` permission granted by `Signon` could access all the features. With the coming rollout of the tool to non-administrative roles there is a need to restrict certain aspects of the application to only those with the responsibility for making changes to the GOV.UK navigation structure. The `signin` permission will no longer grant access to any of the functionality of content-tagger.

This PR introduces two new roles: GDS Editor, and Tagathon Participant.  The roles have been created in Signon already, however not all users will have been assigned them. This means that there will initially be some disruption when this is deployed, unless we can preemptively assign the correct permissions.

[Trello](https://trello.com/c/jWJa4rEi/176-permissions-in-content-tagger)