### PR TITLE
Add user-organisation to the tagging history page

### DIFF
--- a/app/views/analytics/show.html.erb
+++ b/app/views/analytics/show.html.erb
@@ -20,6 +20,7 @@
         <th>Page</th>
         <th>Guidance?</th>
         <th>User</th>
+        <th>Organisation</th>
       </tr>
     </thead>
 
@@ -34,6 +35,7 @@
             <%= tagging_event['taggable_title'] %></td>
           <td><%= tagging_event.guidance? ? 'Guidance' : 'Other' %></td>
           <td><%= User.find_by(uid: tagging_event['user_uid'])&.name || "A Whitehall User" %></td>
+          <td><%= tagging_event.user_organisation || '' %></td>
         </tr>
       <% end %>
     </tbody>


### PR DESCRIPTION
Add the user-organisation field to the tagging history page.

trello: https://trello.com/c/xzlMHjEj/186-add-organisation-to-tagging-history-page

![image](https://user-images.githubusercontent.com/6050162/29616051-fc78a8b4-8807-11e7-93d4-4ce6b79726b1.png)
