### PR TITLE
Include current tags in tagathon tool

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'uglifier', '~> 3.2'
 gem 'unicorn', '~> 5.0.0'
 
 # GDS managed dependencies
-gem 'gds-api-adapters', '~> 47.6'
+gem 'gds-api-adapters', '~> 47.9'
 gem 'gds-sso', '~> 13.2'
 gem 'govuk_admin_template', '~> 5.0'
 gem 'govuk_sidekiq', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,7 +86,7 @@ GEM
       railties (>= 3.0.0)
     faraday (0.11.0)
       multipart-post (>= 1.2, < 3)
-    gds-api-adapters (47.7.0)
+    gds-api-adapters (47.9.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -356,7 +356,7 @@ DEPENDENCIES
   chartkick
   database_cleaner
   factory_girl_rails
-  gds-api-adapters (~> 47.6)
+  gds-api-adapters (~> 47.9)
   gds-sso (~> 13.2)
   govuk-content-schema-test-helpers
   govuk-lint

--- a/app/assets/javascripts/bulk-tagger.js
+++ b/app/assets/javascripts/bulk-tagger.js
@@ -27,7 +27,11 @@
       var self = this;
 
       // Initialise tag input selects
-      $element.find(self.selectors.tag_input_element).select2(self.options_for_select2);
+      $element.find(self.selectors.tag_input_element)
+        .select2(self.options_for_select2)
+        .each(function(index, el) {
+          self.update_select2_with_new_taxons($(el));
+        });
 
       // Contains all the content-item tagging forms
       var $content_item_forms = $element.find(self.selectors.content_item_forms);
@@ -130,9 +134,14 @@
       $form.removeClass(this.form_error_class);
       $form.effect("highlight", { color: this.color_of_success }, 1000);
 
-      if(taxons.length > 0) {
-        $form.find('.select2').select2('val', taxons);
-      }
+      $select2 = $form.find('.select2');
+      $select2.data('taxons', taxons);
+      self.update_select2_with_new_taxons($select);
+    },
+
+    update_select2_with_new_taxons: function($select2) {
+      var taxons = $select2.data('taxons');
+      $select2.select2('val', taxons);
     },
 
     // Red background of failure

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -7,8 +7,9 @@ class ProjectsController < ApplicationController
 
   def show
     render :show, locals: { project: project,
-                            bulk_search: Projects::BulkSearch.new(project, params),
-                            taxons: taxons_json }
+                            bulk_search: searcher,
+                            taxons: taxons_json,
+                            content_items: content_items }
   end
 
   def new
@@ -25,6 +26,14 @@ class ProjectsController < ApplicationController
   end
 
 private
+
+  def searcher
+    @_search ||= Projects::BulkSearch.new(project, params)
+  end
+
+  def content_items
+    @_content_items ||= Projects::PrepareContentItems.call(searcher.project_content_items_to_display)
+  end
 
   def taxons_json
     project

--- a/app/models/project_content_item.rb
+++ b/app/models/project_content_item.rb
@@ -1,13 +1,10 @@
 class ProjectContentItem < ActiveRecord::Base
   belongs_to :project
 
+  attr_accessor :taxons
+
   def base_path
     url.gsub('https://www.gov.uk', '')
-  end
-
-  # taxons don't exist
-  def taxons
-    []
   end
 
   def mark_complete

--- a/app/services/projects/bulk_search.rb
+++ b/app/services/projects/bulk_search.rb
@@ -22,7 +22,7 @@ module Projects
     end
 
     def project_content_items_to_display
-      @_project_content_items_to_display = begin
+      @_project_content_items_to_display ||= begin
         items = project.content_items.with_valid_ids
 
         if selected_state != TAGGED_STATE_ALL

--- a/app/services/projects/prepare_content_items.rb
+++ b/app/services/projects/prepare_content_items.rb
@@ -1,0 +1,33 @@
+module Projects
+  class PrepareContentItems
+    def self.call(content_items)
+      new(content_items).call
+    end
+
+    def initialize(content_items)
+      @content_items = content_items
+    end
+
+    def call
+      content_items.each do |content_item|
+        content_item.taxons = taxons_for(content_item)
+      end
+    end
+
+  private
+
+    attr_reader :content_items
+
+    def taxons_for(content_item)
+      content_tags.dig(content_item.content_id, 'links', 'taxons') || []
+    end
+
+    def content_tags
+      @_tags ||= Services.publishing_api.get_links_for_content_ids(content_ids)
+    end
+
+    def content_ids
+      @_content_ids ||= content_items.map(&:content_id)
+    end
+  end
+end

--- a/app/views/projects/_content_item.html.erb
+++ b/app/views/projects/_content_item.html.erb
@@ -5,6 +5,10 @@
     <%= f.input :taxons,
       placeholder: 'Choose one...',
       label: false,
-      input_html: { class: [:select2, :tagging_project, :js_bulk_tagger_input], autocomplete: 'off' } %>
+      input_html: {
+        class: [:select2, :tagging_project, :js_bulk_tagger_input],
+        autocomplete: 'off',
+        data: { taxons: content_item.taxons }
+      } %>
   <% end %>
 </div>

--- a/app/views/projects/_item_tagging.html.erb
+++ b/app/views/projects/_item_tagging.html.erb
@@ -17,7 +17,7 @@
 
     <div class='bulk-selectors'>
       <%= f.input_field :content_items,
-        collection: project_content_items_to_display,
+        collection: content_items,
         as: :check_boxes,
         include_hidden: false,
         class: 'content-selector js-content-selector'
@@ -29,5 +29,5 @@
 </div>
 
 <div class='content-list'>
-  <%= render partial: 'content_item', collection: project_content_items_to_display %>
+  <%= render partial: 'content_item', collection: content_items %>
 </div>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -34,8 +34,8 @@
   </div>
 
   <div class="col-md-9">
-    <% if bulk_search.project_content_items_to_display.any? %>
-      <%= render 'item_tagging', project: project, project_content_items_to_display: bulk_search.project_content_items_to_display %>
+    <% if content_items.any? %>
+      <%= render 'item_tagging', project: project, content_items: content_items %>
     <% else %>
       <p class="no-content">No pages found!</p>
     <% end %>

--- a/spec/support/publishing_api_helper.rb
+++ b/spec/support/publishing_api_helper.rb
@@ -1,4 +1,18 @@
 module PublishingApiHelper
+  def stub_empty_bulk_taxons_lookup
+    url = Plek.current.find('publishing-api') + "/v2/links/by-content-id"
+    stub_request(:post, url).to_return(body: {}.to_json)
+  end
+
+  def stub_bulk_taxons_lookup(content_ids, taxons)
+    url = Plek.current.find('publishing-api') + "/v2/links/by-content-id"
+    body = { content_ids: content_ids }
+    response_hash = content_ids.each_with_object({}) do |content_id, obj|
+      obj[content_id] = { "links" => { "taxons" => taxons } }
+    end
+    stub_request(:post, url).with(body: body).to_return(body: response_hash.to_json)
+  end
+
   def stub_requests_for_show_page(taxon)
     content_id = taxon.fetch("content_id")
 


### PR DESCRIPTION
Uses the new `/v2/links/by-content-id` endpoint in `publishing-api` to augment the page with previously assigned tags. This endpoint is capable of supplying links for up to 1000 content items at a time.

[Trello](https://trello.com/c/H3BqIPWc/190-current-tags-are-visible-in-the-bulk-tagging-tool)