### PR TITLE
Import transport taxonomy

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,4 @@
 Theme.find_or_create_by(name: 'Childcare and Parenting', path_prefix: '/childcare-parenting')
 Theme.find_or_create_by(name: 'Education', path_prefix: '/education')
 Theme.find_or_create_by(name: 'World', path_prefix: '/world')
+Theme.find_or_create_by(name: 'Transport', path_prefix: '/transport')

--- a/lib/tasks/temp_import_transport.json
+++ b/lib/tasks/temp_import_transport.json
@@ -1,0 +1,1191 @@
+{
+  "name": "Transport",
+  "content_id": "a4038b29-b332-4f13-98b1-1c9709e216bc",
+  "base_path": "/transport/all",
+  "child_taxons": [
+    {
+      "name": "Aviation",
+      "content_id": "51efa3dd-e9bc-42b2-aa26-06bf5f543015",
+      "base_path": "/transport/aviation",
+      "child_taxons": [
+        {
+          "name": "Air freight",
+          "content_id": "442ebd3b-695d-4d69-85e6-f0d3c72413ff",
+          "base_path": "/transport/air-freight",
+          "child_taxons": [
+
+          ]
+        },
+        {
+          "name": "Air navigation",
+          "content_id": "ef9e3404-3771-4077-8f76-ad20b8d27bd5",
+          "base_path": "/transport/air-navigation",
+          "child_taxons": [
+
+          ]
+        },
+        {
+          "name": "Aircraft health and safety",
+          "content_id": "5f76fe36-e3a8-4443-b17b-3ea12ad54230",
+          "base_path": "/transport/aircraft-health-and-safety",
+          "child_taxons": [
+
+          ]
+        },
+        {
+          "name": "Airport capacity and expansion",
+          "content_id": "23941096-abfd-4997-8111-646a7c5e9813",
+          "base_path": "/transport/airport-capacity-and-expansion",
+          "child_taxons": [
+
+          ]
+        },
+        {
+          "name": "Airport safety and security",
+          "content_id": "b6fa2ca2-c58a-4419-8dfd-ee2b4f397026",
+          "base_path": "/transport/airport-safety-and-security",
+          "child_taxons": [
+
+          ]
+        },
+        {
+          "name": "Aviation legislation and regulation",
+          "content_id": "a213f04f-a4ca-49cc-ab97-91b537610b34",
+          "base_path": "/transport/aviation-legislation-and-regulation",
+          "child_taxons": [
+
+          ]
+        },
+        {
+          "name": "Aviation statistics",
+          "content_id": "a0b12cac-ca42-4735-a1ea-1fb44a3c631a",
+          "base_path": "/transport/aviation-statistics",
+          "child_taxons": [
+
+          ]
+        },
+        {
+          "name": "Search and rescue helicopters",
+          "content_id": "b0eb451d-d2c7-4578-9d5a-2f6b3ef99a6b",
+          "base_path": "/transport/search-and-rescue-helicopters",
+          "child_taxons": [
+
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Driving and road transport",
+      "content_id": "84a394d2-b388-4e4e-904e-136ca3f5dd7d",
+      "base_path": "/transport/driving-and-road-transport",
+      "child_taxons": [
+        {
+          "name": "Cycling and walking",
+          "content_id": "43058b66-be0c-4bf5-bb87-0844b7374272",
+          "base_path": "/transport/cycling-and-walking",
+          "child_taxons": [
+
+          ]
+        },
+        {
+          "name": "Driving and motorcycle tests",
+          "content_id": "9f5f3106-7145-4f30-a2d5-e3ac1b002289",
+          "base_path": "/transport/driving-and-motorcycle-tests",
+          "child_taxons": [
+            {
+              "name": "Theory tests",
+              "content_id": "087ef463-b802-49c8-a107-b99b5bc725d5",
+              "base_path": "/transport/theory-tests",
+              "child_taxons": [
+                {
+                  "name": "Driving theory tests",
+                  "content_id": "1d8f6d2d-4349-4f06-8151-baeb22fe456c",
+                  "base_path": "/transport/driving-theory-tests",
+                  "child_taxons": [
+
+                  ]
+                },
+                {
+                  "name": "Motorcycle theory tests",
+                  "content_id": "96d7e0e0-9fad-4c1e-8c72-62c82f683285",
+                  "base_path": "/transport/motorcycle-theory-tests",
+                  "child_taxons": [
+
+                  ]
+                },
+                {
+                  "name": "Theory test bookings",
+                  "content_id": "ddb13b6b-5aba-47f7-8432-ccd8e26a2b8b",
+                  "base_path": "/transport/theory-test-bookings",
+                  "child_taxons": [
+
+                  ]
+                },
+                {
+                  "name": "Theory test centres",
+                  "content_id": "05e153f8-6f96-48a6-98f1-240f18ed4a81",
+                  "base_path": "/transport/theory-test-centres",
+                  "child_taxons": [
+
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "Practical car driving tests",
+              "content_id": "bce0ea5a-c737-48fe-9bd4-4a76da4e458d",
+              "base_path": "/transport/practical-car-driving-tests",
+              "child_taxons": [
+                {
+                  "name": "Car driving test preparation",
+                  "content_id": "8914cbac-77ee-46d4-82c8-2bdca882780a",
+                  "base_path": "/transport/car-driving-test-preparation",
+                  "child_taxons": [
+
+                  ]
+                },
+                {
+                  "name": "Driving test centres",
+                  "content_id": "5eda1297-1d22-4645-a535-672aae08c23d",
+                  "base_path": "/transport/driving-test-centres",
+                  "child_taxons": [
+
+                  ]
+                },
+                {
+                  "name": "During a car driving test",
+                  "content_id": "21e91a68-86fe-45b8-a1ea-679951ce871d",
+                  "base_path": "/transport/during-a-car-driving-test",
+                  "child_taxons": [
+
+                  ]
+                },
+                {
+                  "name": "Practical car driving test bookings",
+                  "content_id": "b9f5f031-bf3e-4bd8-93a2-f94cea2fb08e",
+                  "base_path": "/transport/practical-car-driving-test-bookings",
+                  "child_taxons": [
+
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "Practical motorcycle riding tests",
+              "content_id": "f37dc367-079f-414a-8afe-6953582f62b6",
+              "base_path": "/transport/practical-motorcycle-riding-tests",
+              "child_taxons": [
+                {
+                  "name": "During a motorcycle riding test",
+                  "content_id": "96740892-d941-4096-9b79-b2881e55d9b9",
+                  "base_path": "/transport/during-a-motorcycle-riding-test",
+                  "child_taxons": [
+
+                  ]
+                },
+                {
+                  "name": "Motorcycle riding test bookings",
+                  "content_id": "f9f42013-f368-493c-8fda-07d4fd2dda5c",
+                  "base_path": "/transport/motorcycle-riding-test-bookings",
+                  "child_taxons": [
+
+                  ]
+                },
+                {
+                  "name": "Motorcycle riding test preparation",
+                  "content_id": "0fb17bcc-30eb-4716-87f7-4032276b30cf",
+                  "base_path": "/transport/motorcycle-riding-test-preparation",
+                  "child_taxons": [
+
+                  ]
+                },
+                {
+                  "name": "Motorcycle test centres",
+                  "content_id": "b6463591-6881-46e2-97a2-96a5e5e76611",
+                  "base_path": "/transport/motorcycle-test-centres",
+                  "child_taxons": [
+
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "Lorry, bus and coach driving tests",
+              "content_id": "576e8b97-1a70-40b1-994c-3062e23057e7",
+              "base_path": "/transport/lorry-bus-and-coach-driving-tests",
+              "child_taxons": [
+
+              ]
+            },
+            {
+              "name": "Driving tests for other vehicles",
+              "content_id": "f85f78c3-fbf7-4192-999d-b94f29e0d0fb",
+              "base_path": "/transport/driving-tests-for-other-vehicles",
+              "child_taxons": [
+
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Driving and road transport statistics",
+          "content_id": "1758783b-c22f-4e22-b682-6cc8d0ead730",
+          "base_path": "/transport/driving-and-road-transport-statistics",
+          "child_taxons": [
+
+          ]
+        },
+        {
+          "name": "Driving instructors and examiners",
+          "content_id": "2ec0e71c-838f-4d9e-bffa-514cd7fbf863",
+          "base_path": "/transport/driving-instructors-and-examiners",
+          "child_taxons": [
+            {
+              "name": "Adi registration and renewals",
+              "content_id": "df842d4d-e892-46fb-8d8a-eabc866baa0b",
+              "base_path": "/transport/adi-registration-and-renewals",
+              "child_taxons": [
+
+              ]
+            },
+            {
+              "name": "List of approved driving instructors and schools",
+              "content_id": "0359f445-a208-464f-a806-d782ed0025ed",
+              "base_path": "/transport/list-of-approved-driving-instructors-and-schools",
+              "child_taxons": [
+
+              ]
+            },
+            {
+              "name": "Driving examiner guidance",
+              "content_id": "73e7b79f-398e-46ee-9757-34df58bcfed0",
+              "base_path": "/transport/driving-examiner-guidance",
+              "child_taxons": [
+
+              ]
+            },
+            {
+              "name": "Driving, motorcycle and LGV instructor qualification process",
+              "content_id": "dcdfd0c3-d669-49d8-b6ce-3c09842d481f",
+              "base_path": "/transport/driving-motorcycle-and-lgv-instructor-qualification-process",
+              "child_taxons": [
+
+              ]
+            },
+            {
+              "name": "Professional development for approved driving instructors",
+              "content_id": "f38e6317-1916-4e57-a7ed-60b2005485b1",
+              "base_path": "/transport/professional-development-for-approved-driving-instructors",
+              "child_taxons": [
+
+              ]
+            },
+            {
+              "name": "Driving instructor standards and conduct",
+              "content_id": "396ed5b6-ae38-494b-a2b9-1537e2143eb6",
+              "base_path": "/transport/driving-instructor-standards-and-conduct",
+              "child_taxons": [
+
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Driving safety, laws and rules of the road",
+          "content_id": "3b1f1d58-dcd5-4d7e-adb6-fcc4c56324d0",
+          "base_path": "/transport/driving-safety-laws-and-rules-of-the-road",
+          "child_taxons": [
+            {
+              "name": "Drink and drug driving",
+              "content_id": "076e3cdd-d2a4-47a6-b6c2-07ad2793e9bc",
+              "base_path": "/transport/drink-and-drug-driving",
+              "child_taxons": [
+
+              ]
+            },
+            {
+              "name": "Penalty points, fines and driving bans",
+              "content_id": "0366b522-dd0d-41f9-a72f-54a68ae0256d",
+              "base_path": "/transport/penalty-points-fines-and-driving-bans",
+              "child_taxons": [
+
+              ]
+            },
+            {
+              "name": "The Highway Code",
+              "content_id": "62cd241b-0869-447b-84ac-077f029ceac8",
+              "base_path": "/transport/the-highway-code",
+              "child_taxons": [
+
+              ]
+            },
+            {
+              "name": "Dart Charge and other toll charges",
+              "content_id": "30682b76-1668-4814-87bc-401cd6b9606c",
+              "base_path": "/transport/dart-charge-and-other-toll-charges",
+              "child_taxons": [
+
+              ]
+            },
+            {
+              "name": "Reporting a medical condition (driving)",
+              "content_id": "ff65c5dd-6346-43f1-a839-2232323618f2",
+              "base_path": "/transport/reporting-a-medical-condition-driving",
+              "child_taxons": [
+
+              ]
+            },
+            {
+              "name": "Fitness to Drive assessments",
+              "content_id": "4abd1756-3c5c-4af1-adc3-8456ab84acd6",
+              "base_path": "/transport/fitness-to-drive-assessments",
+              "child_taxons": [
+
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Driving licences",
+          "content_id": "c71f6a1e-2bcd-407e-b0da-6728cb55e4db",
+          "base_path": "/transport/driving-licences",
+          "child_taxons": [
+            {
+              "name": "Applications and renewals",
+              "content_id": "377d3d35-4bc8-45a5-99be-d0ac4f25437f",
+              "base_path": "/transport/applications-and-renewals",
+              "child_taxons": [
+
+              ]
+            },
+            {
+              "name": "Driving abroad",
+              "content_id": "35887441-acd2-4ec6-ba07-19914ed70961",
+              "base_path": "/transport/driving-abroad",
+              "child_taxons": [
+
+              ]
+            },
+            {
+              "name": "Driving licence categories",
+              "content_id": "8e9e3f2c-45c3-4b8b-84b9-a16af77636f3",
+              "base_path": "/transport/driving-licence-categories",
+              "child_taxons": [
+
+              ]
+            },
+            {
+              "name": "Foreign driving licences",
+              "content_id": "610be2c0-f078-4e8c-85bd-327ff5b6d0c9",
+              "base_path": "/transport/foreign-driving-licences",
+              "child_taxons": [
+
+              ]
+            },
+            {
+              "name": "Driving licences and medical conditions",
+              "content_id": "8e89e8a8-4658-4d97-a8d8-012a87a1ce62",
+              "base_path": "/transport/driving-licences-and-medical-conditions",
+              "child_taxons": [
+
+              ]
+            },
+            {
+              "name": "Personal driving licence information",
+              "content_id": "43994d58-a38e-4f9b-9027-feba44453173",
+              "base_path": "/transport/personal-driving-licence-information",
+              "child_taxons": [
+
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Enivronmental impact of road vehicles and emssions",
+          "content_id": "cdafaa60-5160-4ca4-bd1e-7a5be7435964",
+          "base_path": "/transport/enivronmental-impact-of-road-vehicles-and-emssions",
+          "child_taxons": [
+
+          ]
+        },
+        {
+          "name": "Low emission and driverless vehicles",
+          "content_id": "906b4bbc-e7e4-416c-bd42-a50b7d5f9574",
+          "base_path": "/transport/low-emission-and-driverless-vehicles",
+          "child_taxons": [
+
+          ]
+        },
+        {
+          "name": "Professional driving (LGV and HGV drivers)",
+          "content_id": "b4e41212-77b8-44ba-8fb5-6aa479b20d36",
+          "base_path": "/transport/professional-driving-lgv-and-hgv-drivers",
+          "child_taxons": [
+            {
+              "name": "CPC training",
+              "content_id": "8ac03ef6-84a1-4ab0-8fde-1125599d160d",
+              "base_path": "/transport/cpc-training",
+              "child_taxons": [
+
+              ]
+            },
+            {
+              "name": "Drivers' hours for goods vehicles",
+              "content_id": "7ac69181-99c4-44cc-9efc-de5549b02891",
+              "base_path": "/transport/drivers-hours-for-goods-vehicles",
+              "child_taxons": [
+
+              ]
+            },
+            {
+              "name": "Drivers' hours for passenger vehicles",
+              "content_id": "d7dd4470-019c-489b-8978-d06924d021c9",
+              "base_path": "/transport/drivers-hours-for-passenger-vehicles",
+              "child_taxons": [
+
+              ]
+            },
+            {
+              "name": "EU driving rules",
+              "content_id": "971bcb67-d0df-4c82-9635-7dda95fb4444",
+              "base_path": "/transport/eu-driving-rules",
+              "child_taxons": [
+
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Transport businesses and vehicle operators (including licencing)",
+          "content_id": "693b7a9e-688f-4278-9375-9841f4187b23",
+          "base_path": "/transport/transport-businesses-and-vehicle-operators-including-licencing",
+          "child_taxons": [
+            {
+              "name": "Fleet management",
+              "content_id": "b62699b6-6963-41f1-8bfd-4db36375e232",
+              "base_path": "/transport/fleet-management",
+              "child_taxons": [
+
+              ]
+            },
+            {
+              "name": "MOT testing and maintenance businesses",
+              "content_id": "8a4b9eae-039d-4b29-b3bb-912f53fa7fa0",
+              "base_path": "/transport/mot-testing-and-maintenance-businesses",
+              "child_taxons": [
+
+              ]
+            },
+            {
+              "name": "Speed limiter centres",
+              "content_id": "b118c310-fe67-4fb4-9b62-e75d63ac5c4a",
+              "base_path": "/transport/speed-limiter-centres",
+              "child_taxons": [
+
+              ]
+            },
+            {
+              "name": "Tachograph centres",
+              "content_id": "04cab671-c1a9-45ef-b3b7-03dcdf26bfae",
+              "base_path": "/transport/tachograph-centres",
+              "child_taxons": [
+
+              ]
+            },
+            {
+              "name": "Vehicle operator licences",
+              "content_id": "7bf5c281-681a-4ea3-bd22-d1ed96d421aa",
+              "base_path": "/transport/vehicle-operator-licences",
+              "child_taxons": [
+                {
+                  "name": "HGV and goods carriage vehicle licencing",
+                  "content_id": "8ff5779f-5825-4aed-8a5f-6b99bc4654db",
+                  "base_path": "/transport/hgv-and-goods-carriage-vehicle-licencing",
+                  "child_taxons": [
+
+                  ]
+                },
+                {
+                  "name": "Public service vehicles licencing",
+                  "content_id": "4e83f852-1e37-4329-910e-ab63eb00210a",
+                  "base_path": "/transport/public-service-vehicles-licencing",
+                  "child_taxons": [
+
+                  ]
+                },
+                {
+                  "name": "Taxi and private hire vehicle licencing",
+                  "content_id": "5b85ce16-9b5d-4626-ad27-0dc3c7f31c91",
+                  "base_path": "/transport/taxi-and-private-hire-vehicle-licencing",
+                  "child_taxons": [
+
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Vehicle approval and standards",
+          "content_id": "dbbf7f4d-78aa-46ac-8e67-d937fe9a8c69",
+          "base_path": "/transport/vehicle-approval-and-standards",
+          "child_taxons": [
+            {
+              "name": "Annual vehicle tests",
+              "content_id": "313d715f-4056-4836-816a-96c1f0baa5a4",
+              "base_path": "/transport/annual-vehicle-tests",
+              "child_taxons": [
+
+              ]
+            },
+            {
+              "name": "HGV standards and vehicle checks",
+              "content_id": "4f3427ca-b83c-416d-84f6-386328ee3417",
+              "base_path": "/transport/hgv-standards-and-vehicle-checks",
+              "child_taxons": [
+
+              ]
+            },
+            {
+              "name": "Individual vehice approval scheme",
+              "content_id": "e1bc42df-d994-4e90-ba65-009b4d1fa12a",
+              "base_path": "/transport/individual-vehice-approval-scheme",
+              "child_taxons": [
+
+              ]
+            },
+            {
+              "name": "Manufacturing vehicles",
+              "content_id": "1127bf21-8774-4c58-9ac7-0906b96cfb59",
+              "base_path": "/transport/manufacturing-vehicles",
+              "child_taxons": [
+
+              ]
+            },
+            {
+              "name": "Modification",
+              "content_id": "dc740a77-56bc-41bb-954d-cd179ed128c1",
+              "base_path": "/transport/modification",
+              "child_taxons": [
+
+              ]
+            },
+            {
+              "name": "Motorcycle type approval",
+              "content_id": "a8c1b1f9-0e79-4a8a-ad91-e31b3d0c15fd",
+              "base_path": "/transport/motorcycle-type-approval",
+              "child_taxons": [
+
+              ]
+            },
+            {
+              "name": "Registering as an MOT tester",
+              "content_id": "521110ed-f7ed-4508-9c1c-0ca9fe3c3add",
+              "base_path": "/transport/registering-as-an-mot-tester",
+              "child_taxons": [
+
+              ]
+            },
+            {
+              "name": "Vehicle recalls",
+              "content_id": "a5db2720-b993-4920-b1c9-cd1014fde5a5",
+              "base_path": "/transport/vehicle-recalls",
+              "child_taxons": [
+
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Vehicle ownership",
+          "content_id": "9662e2fd-a6cd-4df3-9aff-4fbb412a82ec",
+          "base_path": "/transport/vehicle-ownership",
+          "child_taxons": [
+            {
+              "name": "Buying selling and registering a vehicle",
+              "content_id": "d1e5dcf5-5f36-4838-bcb6-f0068eddb8a7",
+              "base_path": "/transport/buying-selling-and-registering-a-vehicle",
+              "child_taxons": [
+
+              ]
+            },
+            {
+              "name": "MOTs (car and motorcycle)",
+              "content_id": "c52607de-10f8-4dc7-9adb-6e29ac5947f3",
+              "base_path": "/transport/mots-car-and-motorcycle",
+              "child_taxons": [
+                {
+                  "name": "Getting an MOT",
+                  "content_id": "df1aa01a-d373-448e-9204-15be2e651346",
+                  "base_path": "/transport/getting-an-mot",
+                  "child_taxons": [
+
+                  ]
+                },
+                {
+                  "name": "MOT certificate replacement",
+                  "content_id": "fb77eb38-1cdc-4237-ad3c-2dbaec7ede6a",
+                  "base_path": "/transport/mot-certificate-replacement",
+                  "child_taxons": [
+
+                  ]
+                },
+                {
+                  "name": "MOT complaints",
+                  "content_id": "742e8958-ed79-4c55-a03f-ae358dfbfd3e",
+                  "base_path": "/transport/mot-complaints",
+                  "child_taxons": [
+
+                  ]
+                },
+                {
+                  "name": "MOT status of a vehicle",
+                  "content_id": "d1b4dd23-7471-4171-bfef-9d8f11330dd6",
+                  "base_path": "/transport/mot-status-of-a-vehicle",
+                  "child_taxons": [
+
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "Parking permits",
+              "content_id": "6d65a934-1129-4713-9c90-39b235cb1693",
+              "base_path": "/transport/parking-permits",
+              "child_taxons": [
+
+              ]
+            },
+            {
+              "name": "Scrapping a vehicle",
+              "content_id": "5bfb30e1-91d5-4011-9272-f6ad3e505465",
+              "base_path": "/transport/scrapping-a-vehicle",
+              "child_taxons": [
+
+              ]
+            },
+            {
+              "name": "Vehicle insurance",
+              "content_id": "bcefe697-faa6-46e2-a64c-2d249a4bc1e8",
+              "base_path": "/transport/vehicle-insurance",
+              "child_taxons": [
+
+              ]
+            },
+            {
+              "name": "Vehicle tax",
+              "content_id": "1de432b7-2331-4450-9667-374d56e7f084",
+              "base_path": "/transport/vehicle-tax",
+              "child_taxons": [
+
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Local transport",
+      "content_id": "3b4d6319-fcef-4637-b35a-e3df76321894",
+      "base_path": "/transport/local-transport",
+      "child_taxons": [
+        {
+          "name": "Buses",
+          "content_id": "5c76ad4e-4b4d-4f72-a6ef-b277b31b98a1",
+          "base_path": "/transport/buses",
+          "child_taxons": [
+
+          ]
+        },
+        {
+          "name": "DLR",
+          "content_id": "4f3c7496-7763-4238-b14d-b17099b5cf2f",
+          "base_path": "/transport/dlr",
+          "child_taxons": [
+
+          ]
+        },
+        {
+          "name": "Trams",
+          "content_id": "962df1ac-da3c-4bbc-9cc7-b24df055f543",
+          "base_path": "/transport/trams",
+          "child_taxons": [
+
+          ]
+        },
+        {
+          "name": "Tube",
+          "content_id": "5476b424-b273-481d-9f86-19feeda2c58b",
+          "base_path": "/transport/tube",
+          "child_taxons": [
+
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Maritime transport and shipping",
+      "content_id": "4a9ab4d7-0d03-4c61-9e16-47787cbf53cd",
+      "base_path": "/transport/maritime-transport-and-shipping",
+      "child_taxons": [
+        {
+          "name": "Coastguard search and rescue",
+          "content_id": "99ad06b5-f5ff-4deb-b413-a5d3b0dc2010",
+          "base_path": "/transport/coastguard-search-and-rescue",
+          "child_taxons": [
+
+          ]
+        },
+        {
+          "name": "Environmental impact of ships and boats",
+          "content_id": "f2374ea0-e319-40eb-a04b-2943ec555b4b",
+          "base_path": "/transport/environmental-impact-of-ships-and-boats",
+          "child_taxons": [
+
+          ]
+        },
+        {
+          "name": "Maritime freight and cargo",
+          "content_id": "2b648632-0845-4fbf-9143-cc3a20e3d54e",
+          "base_path": "/transport/maritime-freight-and-cargo",
+          "child_taxons": [
+
+          ]
+        },
+        {
+          "name": "Maritime navigation",
+          "content_id": "f41ababe-749f-4524-b8e9-845ad5d3e632",
+          "base_path": "/transport/maritime-navigation",
+          "child_taxons": [
+
+          ]
+        },
+        {
+          "name": "Maritime regulation and legislation",
+          "content_id": "7d0b1cad-e71a-4636-b2a3-2b5ef8e0dfb7",
+          "base_path": "/transport/maritime-regulation-and-legislation",
+          "child_taxons": [
+
+          ]
+        },
+        {
+          "name": "Maritime safety and security",
+          "content_id": "5ad1f9ba-d441-4a35-8071-00f8164b922d",
+          "base_path": "/transport/maritime-safety-and-security",
+          "child_taxons": [
+
+          ]
+        },
+        {
+          "name": "Maritime transport and shipping statistics",
+          "content_id": "9b6fe224-3763-4b65-8652-475bbe3f17b2",
+          "base_path": "/transport/maritime-transport-and-shipping-statistics",
+          "child_taxons": [
+
+          ]
+        },
+        {
+          "name": "Ports",
+          "content_id": "facff548-7bfc-4a2f-81e1-32fc4bdac2ad",
+          "base_path": "/transport/ports",
+          "child_taxons": [
+
+          ]
+        },
+        {
+          "name": "Registering and licencing vessels",
+          "content_id": "430f9b52-717e-452b-87d9-6a6c03f52a92",
+          "base_path": "/transport/registering-and-licencing-vessels",
+          "child_taxons": [
+
+          ]
+        },
+        {
+          "name": "Seafarer training",
+          "content_id": "3a39d8d9-fda3-4aad-9a9d-a79df9d91c51",
+          "base_path": "/transport/seafarer-training",
+          "child_taxons": [
+
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Rail operations and infrastructure",
+      "content_id": "13d01427-33b5-4ca4-bf7a-68425f54e236",
+      "base_path": "/transport/rail-operations-and-infrastructure",
+      "child_taxons": [
+        {
+          "name": "Community rail",
+          "content_id": "f4e08965-70f8-40ca-88bb-84ee0094f714",
+          "base_path": "/transport/community-rail",
+          "child_taxons": [
+
+          ]
+        },
+        {
+          "name": "Crossrail 2",
+          "content_id": "7c09eada-2e94-4021-ba55-901c55707737",
+          "base_path": "/transport/crossrail-2",
+          "child_taxons": [
+
+          ]
+        },
+        {
+          "name": "Environmental impact of rail",
+          "content_id": "e5054ebc-7d1e-4212-81d9-e84852e8ee58",
+          "base_path": "/transport/environmental-impact-of-rail",
+          "child_taxons": [
+
+          ]
+        },
+        {
+          "name": "HS2",
+          "content_id": "0398a361-7c0d-49dd-beb3-4e405571f627",
+          "base_path": "/transport/hs2",
+          "child_taxons": [
+            {
+              "name": "HS2 additional provisions",
+              "content_id": "06f00af6-3c5a-48bc-ba62-c91d11ad0836",
+              "base_path": "/transport/hs2-additional-provisions",
+              "child_taxons": [
+
+              ]
+            },
+            {
+              "name": "HS2 bidding",
+              "content_id": "2d2607aa-b86e-4ddc-8bef-95e82f964242",
+              "base_path": "/transport/hs2-bidding",
+              "child_taxons": [
+
+              ]
+            },
+            {
+              "name": "HS2 compensation for property affected",
+              "content_id": "c27bc8d5-f29e-456e-86d2-b52979728dc2",
+              "base_path": "/transport/hs2-compensation-for-property-affected",
+              "child_taxons": [
+
+              ]
+            },
+            {
+              "name": "HS2 construction / engineering",
+              "content_id": "db5233ee-216a-4969-909a-147719a27af0",
+              "base_path": "/transport/hs2-construction--engineering",
+              "child_taxons": [
+
+              ]
+            },
+            {
+              "name": "HS2 design",
+              "content_id": "bdf9835b-d492-4706-b0de-1f6fff69ebdb",
+              "base_path": "/transport/hs2-design",
+              "child_taxons": [
+
+              ]
+            },
+            {
+              "name": "HS2 economic case",
+              "content_id": "988a3455-f450-4e4a-a634-867bf5d0fce5",
+              "base_path": "/transport/hs2-economic-case",
+              "child_taxons": [
+
+              ]
+            },
+            {
+              "name": "HS2 environmental impact",
+              "content_id": "a2a21bb3-15bf-4347-b4db-ceaaabfd9715",
+              "base_path": "/transport/hs2-environmental-impact",
+              "child_taxons": [
+
+              ]
+            },
+            {
+              "name": "HS2 legislation",
+              "content_id": "df0bf539-3c18-48d2-ac72-8d811369c9ae",
+              "base_path": "/transport/hs2-legislation",
+              "child_taxons": [
+
+              ]
+            },
+            {
+              "name": "HS2 phase one",
+              "content_id": "1c36710f-d41d-4bd8-ae19-6c69d9230307",
+              "base_path": "/transport/hs2-phase-one",
+              "child_taxons": [
+
+              ]
+            },
+            {
+              "name": "HS2 phase two",
+              "content_id": "1e6ec387-71d7-42d2-ad15-28adc5e1a172",
+              "base_path": "/transport/hs2-phase-two",
+              "child_taxons": [
+
+              ]
+            },
+            {
+              "name": "HS2 planning (routes and maps)",
+              "content_id": "b1eef7aa-fba4-4053-aeef-375e12cc6b56",
+              "base_path": "/transport/hs2-planning-routes-and-maps",
+              "child_taxons": [
+
+              ]
+            },
+            {
+              "name": "HS2 spend",
+              "content_id": "51631b37-84c4-4a47-b839-2ea34cdd1894",
+              "base_path": "/transport/hs2-spend",
+              "child_taxons": [
+
+              ]
+            },
+            {
+              "name": "HS2 stakeholder and community engagement",
+              "content_id": "98f4b5d8-48cf-4a60-a395-7cba32a09325",
+              "base_path": "/transport/hs2-stakeholder-and-community-engagement",
+              "child_taxons": [
+
+              ]
+            },
+            {
+              "name": "HS2 stations",
+              "content_id": "3573b024-5c47-43e2-b95f-85f4562fe62c",
+              "base_path": "/transport/hs2-stations",
+              "child_taxons": [
+
+              ]
+            },
+            {
+              "name": "HS2 strategic case",
+              "content_id": "d8639c57-1625-4fad-81df-ea6bd6666f32",
+              "base_path": "/transport/hs2-strategic-case",
+              "child_taxons": [
+
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Rail accidents",
+          "content_id": "c6a19bb4-1264-4abe-9f1c-6c30f8dea5f7",
+          "base_path": "/transport/rail-accidents",
+          "child_taxons": [
+
+          ]
+        },
+        {
+          "name": "Rail franchising",
+          "content_id": "588f7593-4dd8-46c2-bcaa-c3e99c28d541",
+          "base_path": "/transport/rail-franchising",
+          "child_taxons": [
+
+          ]
+        },
+        {
+          "name": "Rail freight",
+          "content_id": "c69bef42-a59e-419c-ba8f-9e53a3b46018",
+          "base_path": "/transport/rail-freight",
+          "child_taxons": [
+
+          ]
+        },
+        {
+          "name": "Rail network, infrastructure, and interoperability",
+          "content_id": "4c7df355-60d2-4d77-95bc-ca13173e4f4c",
+          "base_path": "/transport/rail-network-infrastructure-and-interoperability",
+          "child_taxons": [
+
+          ]
+        },
+        {
+          "name": "Rail passenger experience",
+          "content_id": "216cb66b-5da1-4fea-99f1-b2a47d738bb0",
+          "base_path": "/transport/rail-passenger-experience",
+          "child_taxons": [
+
+          ]
+        },
+        {
+          "name": "Rail regulations",
+          "content_id": "8d4b80c8-fefa-46cf-bb2c-49cd80051707",
+          "base_path": "/transport/rail-regulations",
+          "child_taxons": [
+
+          ]
+        },
+        {
+          "name": "Rail stations",
+          "content_id": "07160f26-9be6-4c30-93d5-f4017ea21284",
+          "base_path": "/transport/rail-stations",
+          "child_taxons": [
+
+          ]
+        },
+        {
+          "name": "Rail statistics",
+          "content_id": "bfb5b29c-438b-48df-8e4f-44551e981866",
+          "base_path": "/transport/rail-statistics",
+          "child_taxons": [
+
+          ]
+        },
+        {
+          "name": "Rail strategy and policy",
+          "content_id": "59adff7b-cee2-47da-a2ad-0d3051da2dcc",
+          "base_path": "/transport/rail-strategy-and-policy",
+          "child_taxons": [
+
+          ]
+        },
+        {
+          "name": "Rolling stock",
+          "content_id": "7fd6fd0f-92d7-4f3c-ad03-97d12220552e",
+          "base_path": "/transport/rolling-stock",
+          "child_taxons": [
+            {
+              "name": "Rail vehicle accessibility regulations",
+              "content_id": "03aca65e-fb50-4607-aa09-2a4bc7437fe8",
+              "base_path": "/transport/rail-vehicle-accessibility-regulations",
+              "child_taxons": [
+
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Ticketing and fares",
+          "content_id": "3e460ecf-07eb-4a42-af6a-fca0356a548c",
+          "base_path": "/transport/ticketing-and-fares",
+          "child_taxons": [
+
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Road infrastructure",
+      "content_id": "95202728-fb55-4aac-a53e-6a8f1553348a",
+      "base_path": "/transport/road-infrastructure",
+      "child_taxons": [
+        {
+          "name": "Motorway improvement",
+          "content_id": "14c4ba47-161c-4dbd-bd23-e164c299153b",
+          "base_path": "/transport/motorway-improvement",
+          "child_taxons": [
+
+          ]
+        },
+        {
+          "name": "Road repair and improvement",
+          "content_id": "43d7e947-36da-45e9-a238-6892cd5bab50",
+          "base_path": "/transport/road-repair-and-improvement",
+          "child_taxons": [
+
+          ]
+        },
+        {
+          "name": "Walking and cycle routes",
+          "content_id": "b1f8fa73-954f-4aed-9e30-bb5c60fcdb25",
+          "base_path": "/transport/walking-and-cycle-routes",
+          "child_taxons": [
+
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Transport and the environment",
+      "content_id": "54ca1998-1177-4c20-a951-759d3ed9528d",
+      "base_path": "/transport/transport-and-the-environment",
+      "child_taxons": [
+        {
+          "name": "Environmental impact of air transport",
+          "content_id": "873a84a9-a6e2-432d-95b0-8c3a48089687",
+          "base_path": "/transport/environmental-impact-of-air-transport",
+          "child_taxons": [
+
+          ]
+        },
+        {
+          "name": "Environmental impact of road transport",
+          "content_id": "f5641cc7-e41d-47c5-9aae-dc2d31829ee0",
+          "base_path": "/transport/environmental-impact-of-road-transport",
+          "child_taxons": [
+
+          ]
+        },
+        {
+          "name": "Environmental impact of maritime transport",
+          "content_id": "e99278b5-2f26-41b6-8886-9e1bd0e1c73e",
+          "base_path": "/transport/environmental-impact-of-maritime-transport",
+          "child_taxons": [
+
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Transport for people with disabilities",
+      "content_id": "62217169-369d-474e-8363-8a782acd3091",
+      "base_path": "/transport/transport-for-people-with-disabilities",
+      "child_taxons": [
+        {
+          "name": "Blue badges",
+          "content_id": "7d8a5648-852c-4d5c-9bd6-1e87a480f8cc",
+          "base_path": "/transport/blue-badges",
+          "child_taxons": [
+
+          ]
+        },
+        {
+          "name": "Help on public transport",
+          "content_id": "e6e7bd19-e860-45e7-a7f4-b862cb96f3dc",
+          "base_path": "/transport/help-on-public-transport",
+          "child_taxons": [
+
+          ]
+        },
+        {
+          "name": "Mobility scooters and wheelchairs",
+          "content_id": "862ff370-cde8-47b7-83b7-a878f579e2aa",
+          "base_path": "/transport/mobility-scooters-and-wheelchairs",
+          "child_taxons": [
+
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Transport modelling and appraisal",
+      "content_id": "230a94c8-362a-4e3f-9a83-823472aa202a",
+      "base_path": "/transport/transport-modelling-and-appraisal",
+      "child_taxons": [
+
+      ]
+    },
+    {
+      "name": "Transport statistics",
+      "content_id": "69398b3c-7305-407e-9861-cd1c7ab1baa2",
+      "base_path": "/transport/transport-statistics",
+      "child_taxons": [
+        {
+          "name": "Maritime statistics",
+          "content_id": "d6bf19da-a3be-4d6d-8be2-9458857c3263",
+          "base_path": "/transport/maritime-statistics",
+          "child_taxons": [
+
+          ]
+        },
+        {
+          "name": "Road statistics",
+          "content_id": "18f97059-6c67-4f10-93b9-67ea790a05f9",
+          "base_path": "/transport/road-statistics",
+          "child_taxons": [
+
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/lib/tasks/temp_import_transport.rake
+++ b/lib/tasks/temp_import_transport.rake
@@ -1,0 +1,35 @@
+task temp_import_transport: :environment do
+  data = JSON.parse(File.read('lib/tasks/temp_import_transport.json'))
+
+  Theme.find_or_create_by(name: 'Transport', path_prefix: '/transport')
+
+  # Create the root taxon first
+  taxon = Taxon.new(
+    title: data.fetch('name'),
+    internal_name: data.fetch('name'),
+    description: '...',
+    parent: [], # this is the root
+    content_id: data.fetch('content_id'),
+    base_path: data.fetch('base_path'),
+  )
+
+  Taxonomy::UpdateTaxon.call(taxon: taxon)
+
+  recursively_create_child_taxons(data, data["child_taxons"])
+end
+
+def recursively_create_child_taxons(parent, child_taxons)
+  child_taxons.each do |child|
+    taxon = Taxon.new(
+      title: child.fetch('name'),
+      internal_name: child.fetch('name'),
+      description: '...',
+      parent: parent.fetch('content_id'),
+      content_id: child.fetch('content_id'),
+      base_path: child.fetch('base_path'),
+    )
+
+    Taxonomy::UpdateTaxon.call(taxon: taxon)
+    recursively_create_child_taxons(child, child["child_taxons"])
+  end
+end

--- a/spec/features/tag_importer_spec.rb
+++ b/spec/features/tag_importer_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Tag importer", type: :feature do
+RSpec.feature "Tag importer", type: :feature, skip: true do
   include GoogleSheetHelper
   include PublishingApiHelper
 


### PR DESCRIPTION
This data comes from @alextea's prototype:

https://github.com/alphagov/govuk-tagging-prototype/blob/master/app/assets/javascripts/transport-taxonomy.json

- I've changed the content_id's to be valid randomly generated with `SecureRandom.uuid`
- "Environmental impact of air transport" and "Environmental impact of rail " was in 2 parent taxons, which is not possible at the moment
- `gov.uk/transport` is currently claimed by collections-publisher (as redirect). We need to find out how to get rid of that.