### PR TITLE
Hide bulk tagger

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -53,6 +53,6 @@ private
   def new_project_params
     params
       .fetch(:new_project_form)
-      .permit(:name, :remote_url, :taxonomy_branch)
+      .permit(:name, :remote_url, :taxonomy_branch, :bulk_tagging_enabled)
   end
 end

--- a/app/forms/new_project_form.rb
+++ b/app/forms/new_project_form.rb
@@ -1,7 +1,8 @@
 class NewProjectForm
   include ActiveModel::Model
 
-  attr_accessor :name, :remote_url, :taxonomy_branch
+  attr_accessor :name, :remote_url, :taxonomy_branch, :bulk_tagging_enabled
+  alias bulk_tagging_enabled? bulk_tagging_enabled
 
   UUID_REGEX = %r([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})
 
@@ -18,7 +19,12 @@ class NewProjectForm
   def create
     return false unless valid?
     csv = RemoteCsv.new(remote_url)
-    ProjectBuilder.call(name, taxonomy_branch, csv.to_enum)
+    ProjectBuilder.call(
+      name: name,
+      taxonomy_branch_content_id: taxonomy_branch,
+      content_item_attributes_enum: csv.to_enum,
+      bulk_tagging_enabled: bulk_tagging_enabled
+    )
   rescue URI::InvalidURIError,
          ActiveRecord::RecordInvalid,
          Errno::ECONNREFUSED,

--- a/app/lib/project_builder.rb
+++ b/app/lib/project_builder.rb
@@ -1,8 +1,8 @@
 class ProjectBuilder
-  def self.call(project_name, taxonomy_branch_content_id, content_item_attributes_enum)
+  def self.call(name:, taxonomy_branch_content_id:, content_item_attributes_enum:, bulk_tagging_enabled:)
     project = ProjectContentItem.transaction do
       Project
-        .create!(name: project_name, taxonomy_branch: taxonomy_branch_content_id)
+        .create!(name: name, taxonomy_branch: taxonomy_branch_content_id, bulk_tagging_enabled: bulk_tagging_enabled)
         .tap do |project|
           content_item_attributes_enum.each do |content_item_attributes|
             ProjectContentItem.create!(

--- a/app/views/projects/_bulk_tagging.html.erb
+++ b/app/views/projects/_bulk_tagging.html.erb
@@ -27,7 +27,3 @@
     <%= f.submit 'Apply' %>
   <% end %>
 </div>
-
-<div class='content-list'>
-  <%= render partial: 'content_item', collection: content_items %>
-</div>

--- a/app/views/projects/new.html.erb
+++ b/app/views/projects/new.html.erb
@@ -16,6 +16,12 @@
                     label: 'Spreadsheet URL',
                     hint: 'Spreadsheet URL with the contents of the project. Required columns: url, title and description.' %>
 
+        <%= f.input :bulk_tagging_enabled, input_html: { class: 'form-control' },
+                    label: 'Bulk tagging',
+                    hint: 'Enable the bulk tagging interface for this project?',
+                    as: :boolean,
+                    checked_value: true %>
+
         <%= f.submit 'New Project', class: "btn btn-lg btn-success" %>
     <% end %>
   </div>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -35,14 +35,23 @@
 
   <div class="col-md-9">
     <% if content_items.any? %>
-      <%= render 'item_tagging', project: project, content_items: content_items %>
+      <% if project.bulk_tagging_enabled? %>
+        <%= render partial: "bulk_tagging", locals: local_assigns %>
+      <% end %>
+
+      <div class='content-list'>
+        <%= render partial: 'content_item', collection: content_items %>
+      </div>
     <% else %>
       <p class="no-content">No pages found!</p>
     <% end %>
   </div>
 </div>
 
-<script>
-  var bulkTagger = new GOVUKAdmin.Modules.BulkTagger(<%= taxons.to_s.html_safe %>);
-  bulkTagger.start($('.tagathon-project'));
-</script>
+<% if project.bulk_tagging_enabled? %>
+  <script>
+    var bulkTagger = new GOVUKAdmin.Modules.BulkTagger(<%= taxons.to_s.html_safe %>);
+    bulkTagger.start($('.tagathon-project'));
+  </script>
+<% end %>
+

--- a/db/migrate/20170905094243_add_bulk_tagging_enabled_flag_to_projects.rb
+++ b/db/migrate/20170905094243_add_bulk_tagging_enabled_flag_to_projects.rb
@@ -1,0 +1,5 @@
+class AddBulkTaggingEnabledFlagToProjects < ActiveRecord::Migration[5.0]
+  def change
+    add_column :projects, :bulk_tagging_enabled, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170818101559) do
+ActiveRecord::Schema.define(version: 20170905094243) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -29,9 +29,10 @@ ActiveRecord::Schema.define(version: 20170818101559) do
 
   create_table "projects", force: :cascade do |t|
     t.string   "name"
-    t.datetime "created_at",      null: false
-    t.datetime "updated_at",      null: false
+    t.datetime "created_at",                           null: false
+    t.datetime "updated_at",                           null: false
     t.uuid     "taxonomy_branch"
+    t.boolean  "bulk_tagging_enabled", default: false
   end
 
   create_table "tag_mappings", force: :cascade do |t|

--- a/spec/factories/project.rb
+++ b/spec/factories/project.rb
@@ -5,12 +5,18 @@ FactoryGirl.define do
     # TaxonomyHelper.valid_taxon_uuid
     taxonomy_branch 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
 
+    bulk_tagging_enabled true
+
     trait :with_content_items do
       content_items { build_list :project_content_item, 3 }
     end
 
     trait :with_content_item do
       content_items { build_list :project_content_item, 1 }
+    end
+
+    trait :with_bulk_tagging_disabled do
+      bulk_tagging_enabled false
     end
   end
 end

--- a/spec/lib/project_builder_spec.rb
+++ b/spec/lib/project_builder_spec.rb
@@ -5,20 +5,40 @@ RSpec.describe ProjectBuilder do
     allow(LookupContentIdWorker).to receive(:perform_async)
   end
 
+  let(:project_name) { 'project_name' }
+  let(:taxonomy_branch_content_id) { SecureRandom.uuid }
+  let(:content_item_attributes_enum) { [] }
+  let(:bulk_tagging_enabled) { false }
+
+  def build_project(
+    name: project_name,
+    branch: taxonomy_branch_content_id,
+    content_items: content_item_attributes_enum,
+    bulk_tagging: bulk_tagging_enabled
+  )
+
+    ProjectBuilder.call(
+      name: name,
+      taxonomy_branch_content_id: branch,
+      content_item_attributes_enum: content_items,
+      bulk_tagging_enabled: bulk_tagging
+    )
+  end
+
   it 'creates a new project' do
-    expect { ProjectBuilder.call('project', '', []) }
+    expect { build_project }
       .to change { Project.count }
             .by(1)
   end
 
   it 'creates two new content items' do
-    expect { ProjectBuilder.call('project', '', [{ title: 'one' }, { title: 'two' }]) }
+    expect { build_project(content_items: [{ title: 'one' }, { title: 'two' }]) }
       .to change { ProjectContentItem.count }
             .by(2)
   end
 
   it 'queues a request to lookup the content_id' do
-    ProjectBuilder.call('project', '', [{ id: 1 }])
+    build_project(content_items: [{ id: 1 }])
 
     expect(LookupContentIdWorker)
       .to have_received(:perform_async)


### PR DESCRIPTION
Provides an option on the New Project screen, to enable the bulk-tagging UI.

Bulk-tagging is disabled by default for existing projects, and for new projects unless it is explicitly enabled.

[Trello](https://trello.com/c/ZzG433q5/220-hide-bulk-tagging-and-checkboxes)