### PR TITLE
DRY up the root taxon contstant

### DIFF
--- a/app/forms/root_taxons_form.rb
+++ b/app/forms/root_taxons_form.rb
@@ -1,8 +1,6 @@
 class RootTaxonsForm
   include ActiveModel::Model
 
-  HOMEPAGE_CONTENT_ID = "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a".freeze
-
   attr_accessor :root_taxons
 
   def initialize(attributes = {})
@@ -15,14 +13,16 @@ class RootTaxonsForm
   end
 
   def update
-    Services.publishing_api.patch_links(HOMEPAGE_CONTENT_ID,
-                                        links: { root_taxons: root_taxons.reject(&:empty?) })
+    Services.publishing_api.patch_links(
+      GovukTaxonomy::ROOT_CONTENT_ID,
+      links: { root_taxons: root_taxons.reject(&:empty?) },
+    )
   end
 
 private
 
   def fetch_root_taxons
-    homepage_links = Services.publishing_api.get_links(HOMEPAGE_CONTENT_ID)
+    homepage_links = Services.publishing_api.get_links(GovukTaxonomy::ROOT_CONTENT_ID)
     homepage_links.dig('links', 'root_taxons') || []
   end
 end

--- a/app/models/govuk_taxonomy.rb
+++ b/app/models/govuk_taxonomy.rb
@@ -1,0 +1,3 @@
+module GovukTaxonomy
+  ROOT_CONTENT_ID = "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a".freeze
+end

--- a/app/models/govuk_taxonomy/branches.rb
+++ b/app/models/govuk_taxonomy/branches.rb
@@ -1,7 +1,5 @@
 module GovukTaxonomy
   class Branches
-    HOMEPAGE_CONTENT_ID = "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a".freeze
-
     def branch_name_for_content_id(content_id)
       get_content_item(content_id).dig('title')
     end
@@ -32,7 +30,7 @@ module GovukTaxonomy
     end
 
     def get_root_taxons(with_drafts:)
-      get_expanded_links_hash(HOMEPAGE_CONTENT_ID, with_drafts: with_drafts)
+      get_expanded_links_hash(ROOT_CONTENT_ID, with_drafts: with_drafts)
         .fetch('expanded_links', {})
         .fetch('root_taxons', [])
     end

--- a/spec/controllers/root_taxons_controller_spec.rb
+++ b/spec/controllers/root_taxons_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe RootTaxonsController, type: :controller do
   describe "#index" do
     it "gets root links" do
-      publishing_api_has_links("content_id" => RootTaxonsForm::HOMEPAGE_CONTENT_ID,
+      publishing_api_has_links("content_id" => GovukTaxonomy::ROOT_CONTENT_ID,
                                "links" => { "root_taxons" => [] })
 
       get :index

--- a/spec/features/manage_root_taxons_spec.rb
+++ b/spec/features/manage_root_taxons_spec.rb
@@ -41,10 +41,12 @@ RSpec.feature "Manage Root Taxons" do
   end
 
   def given_that_one_link_is_a_root_taxon
-    links = { "content_id" => "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a",
-              "links" =>
-               { "root_taxons" => @linkable_taxon_hash.first[:content_id] } }
-    publishing_api_has_links(links)
+    publishing_api_has_links(
+      "content_id" => GovukTaxonomy::ROOT_CONTENT_ID,
+      "links" => {
+        "root_taxons" => @linkable_taxon_hash.first[:content_id]
+      }
+    )
   end
 
   def when_i_visit_the_edit_taxonomy_page
@@ -69,7 +71,11 @@ RSpec.feature "Manage Root Taxons" do
   end
 
   def then_the_set_of_root_taxons_is_updated
-    assert_publishing_api_patch_links("f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a", "links" =>
-      { "root_taxons" => @linkable_taxon_hash.map { |t| t[:content_id] } })
+    assert_publishing_api_patch_links(
+      GovukTaxonomy::ROOT_CONTENT_ID,
+      "links" => {
+        "root_taxons" => @linkable_taxon_hash.map { |t| t[:content_id] }
+      }
+    )
   end
 end

--- a/spec/forms/root_taxons_form_spec.rb
+++ b/spec/forms/root_taxons_form_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe RootTaxonsForm do
 
   describe '#taxons_for_select' do
     before :each do
-      publishing_api_has_links("content_id" => RootTaxonsForm::HOMEPAGE_CONTENT_ID,
+      publishing_api_has_links("content_id" => GovukTaxonomy::ROOT_CONTENT_ID,
                                "links" => { "root_taxons" => [""] })
     end
     it 'returns all taxons for the select box' do
@@ -29,12 +29,12 @@ RSpec.describe RootTaxonsForm do
     end
     it 'updates given taxons, ignoring empty strings' do
       RootTaxonsForm.new(root_taxons: ["", "ID-3", "ID-4"]).update
-      assert_publishing_api_patch_links(RootTaxonsForm::HOMEPAGE_CONTENT_ID, "links" =>
+      assert_publishing_api_patch_links(GovukTaxonomy::ROOT_CONTENT_ID, "links" =>
         { "root_taxons" => ["ID-3", "ID-4"] })
     end
     it 'removes all taxons' do
       RootTaxonsForm.new(root_taxons: [""]).update
-      assert_publishing_api_patch_links(RootTaxonsForm::HOMEPAGE_CONTENT_ID, "links" =>
+      assert_publishing_api_patch_links(GovukTaxonomy::ROOT_CONTENT_ID, "links" =>
         { "root_taxons" => [] })
     end
   end

--- a/spec/support/taxonomy_helper.rb
+++ b/spec/support/taxonomy_helper.rb
@@ -12,7 +12,7 @@ module TaxonomyHelper
   end
 
   def stub_draft_taxonomy_branch
-    content_id = GovukTaxonomy::Branches::HOMEPAGE_CONTENT_ID
+    content_id = GovukTaxonomy::ROOT_CONTENT_ID
 
     draft_root_taxons = {
       'root_taxons' => [


### PR DESCRIPTION
The HOMEPAGE_CONTENT_ID taxon was duplicated a bunch of times in different classes. This adds a GovukTaxonomy module with the constant and makes everything use that. I've renamed it ROOT_CONTENT_ID to communicate that it's the root of the taxonomy. We could just as easily use another content item for this.

