### PR TITLE
Redesign the management of root taxons

### DIFF
--- a/app/controllers/root_taxons_controller.rb
+++ b/app/controllers/root_taxons_controller.rb
@@ -1,17 +1,17 @@
 class RootTaxonsController < ApplicationController
   before_action :ensure_user_can_administer_taxonomy!
 
-  def index
-    render :index, locals: { page: RootTaxonsForm.new }
-  end
-
   def show
     @content_item = ContentItem.find!(params[:id])
   end
 
-  def update
+  def edit_all
+    render :edit_all, locals: { form: RootTaxonsForm.new }
+  end
+
+  def update_all
     RootTaxonsForm.new(root_taxons_params).update
-    redirect_to taxons_path
+    redirect_to edit_all_root_taxons_path
   end
 
 private

--- a/app/views/root_taxons/edit_all.html.erb
+++ b/app/views/root_taxons/edit_all.html.erb
@@ -1,0 +1,11 @@
+<%= display_header title: t('navigation.edit_root_taxons'),
+                   breadcrumbs: [:root_taxons, t('navigation.edit_root_taxons')] %>
+
+<%= simple_form_for form, url: update_all_root_taxons_path, method: :put do |f| %>
+  <%= f.input :root_taxons,
+              collection: form.taxons_for_select,
+              placeholder: "Choose root taxons...",
+              input_html: { multiple: true, class: :select2 } %>
+
+  <%= f.submit "Save & publish", class: "btn btn-lg btn-success submit-button" %>
+<% end %>

--- a/app/views/root_taxons/index.html.erb
+++ b/app/views/root_taxons/index.html.erb
@@ -1,19 +1,29 @@
-<%= display_header title: t('navigation.manage_root_taxons'),
-                   breadcrumbs: [t('navigation.manage_root_taxons')] %>
+<%= display_header title: t('navigation.root_taxons'),
+                   breadcrumbs: [t('navigation.root_taxons')] do %>
 
-<div class="lead">
-  Add or remove root taxons.
-</div>
-
-
-<%= simple_form_for page, url: root_taxons_path, method: :put do |f| %>
-
-
-    <%= f.input :root_taxons,
-                collection: page.taxons_for_select,
-                placeholder: "Choose root taxons...",
-                input_html: { multiple: true, class: :select2 } %>
-
-    <%= f.submit "Save & publish", class: "btn btn-lg btn-success submit-button" %>
-
+  <a href="<%= edit_all_root_taxons_path %>"
+     class="btn btn-default btn-lg pull-right"
+     role="button">
+    Edit root taxons
+  </a>
 <% end %>
+
+<table class="table queries-list table-bordered table-striped">
+  <thead>
+    <tr class="table-header">
+      <th>Title</th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% GovukTaxonomy::Branches.new.all.each do |taxon| %>
+      <tr>
+        <td>
+          <a href="<%= root_taxon_path(taxon['content_id']) %>">
+             <%= taxon['title'] %>
+          </a>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/root_taxons/show.html.erb
+++ b/app/views/root_taxons/show.html.erb
@@ -6,7 +6,7 @@
   <% if root_taxon['content_id'] == @content_item.content_id %>
     <strong><%= root_taxon['title'] %></strong>
   <% else %>
-    <%= link_to root_taxon['title'], { id: root_taxon['content_id'] } %>
+    <%= link_to root_taxon['title'], root_taxon_path(root_taxon['content_id']) %>
   <% end %>
 <% end %>
 </p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,7 +1,8 @@
 en:
   navigation:
     bulk_tag: 'Bulk tag'
-    manage_root_taxons: 'Manage root taxons'
+    root_taxons: 'Root taxons'
+    edit_root_taxons: 'Edit root taxons'
     projects: 'Projects'
     tagging_content: Edit a page
     tagging_title: Which page do you want to edit?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,8 +53,12 @@ Rails.application.routes.draw do
 
   resources :taxonomies, only: %i(show), param: :content_id
 
-  resources :root_taxons, only: [:index, :show]
-  resource :root_taxons, only: [:update]
+  resources :root_taxons, only: [:index, :show] do
+    collection do
+      get 'edit_all'
+      put 'update_all'
+    end
+  end
 
   if Rails.env.development?
     mount GovukAdminTemplate::Engine, at: '/style-guide'

--- a/spec/controllers/root_taxons_controller_spec.rb
+++ b/spec/controllers/root_taxons_controller_spec.rb
@@ -12,12 +12,12 @@ RSpec.describe RootTaxonsController, type: :controller do
     end
   end
 
-  describe "#update" do
-    it "redirects to the taxons index page" do
+  describe "#update_all" do
+    it "redirects to the edit all taxons page" do
       stub_any_publishing_api_patch_links
-      put :update, params: { 'root_taxons_form' => { root_taxons: ["", "ID-1", "ID-2"] } }
+      put :update_all, params: { 'root_taxons_form' => { root_taxons: ["", "ID-1", "ID-2"] } }
 
-      expect(response).to redirect_to(taxons_path)
+      expect(response).to redirect_to(edit_all_root_taxons_path)
     end
   end
 end

--- a/spec/features/manage_root_taxons_spec.rb
+++ b/spec/features/manage_root_taxons_spec.rb
@@ -4,39 +4,50 @@ RSpec.feature "Manage Root Taxons" do
   include PublishingApiHelper
   include ContentItemHelper
 
-  scenario "Add a root taxon" do
-    given_there_are_taxons
-    given_there_are_links
-    given_that_one_link_is_a_root_taxon
-    when_i_visit_the_edit_taxonomy_page
-    and_i_click_the_add_root_taxon_button
-    then_i_see_the_current_root_taxons
-  end
-
   scenario "Update the list of root taxons" do
-    given_there_are_taxons
-    given_there_are_links
+    given_that_there_are_two_taxons
+    given_that_one_taxon_is_a_root_taxon
     given_that_one_link_is_a_root_taxon
     when_i_visit_the_edit_taxonomy_page
-    and_i_click_the_add_root_taxon_button
+    and_i_click_the_manage_root_taxons_button
+    and_i_click_the_edit_root_taxons_button
     and_i_add_a_new_taxon
     when_i_click_save
     then_the_set_of_root_taxons_is_updated
   end
 
-  def given_there_are_taxons
+  def given_that_there_are_two_taxons
+    @linkable_taxon_hash = FactoryGirl.build_list(:linkable_taxon_hash, 2)
     publishing_api_has_taxons(
       [],
       page: 1,
       states: ["published"]
     )
-  end
-
-  def given_there_are_links
-    @linkable_taxon_hash = FactoryGirl.build_list(:linkable_taxon_hash, 2)
     publishing_api_has_linkables(
       @linkable_taxon_hash,
       document_type: 'taxon'
+    )
+  end
+
+  def given_that_one_taxon_is_a_root_taxon
+    publishing_api_has_expanded_links(
+      content_id: GovukTaxonomy::ROOT_CONTENT_ID,
+      expanded_links: {
+        root_taxons: [
+          {
+            content_id: @linkable_taxon_hash.first[:content_id]
+          }
+        ],
+      }
+    )
+    publishing_api_has_expanded_links(
+      {
+        content_id: GovukTaxonomy::ROOT_CONTENT_ID,
+        expanded_links: {
+          root_taxons: [],
+        }
+      },
+      with_drafts: false
     )
   end
 
@@ -53,8 +64,12 @@ RSpec.feature "Manage Root Taxons" do
     visit taxons_path
   end
 
-  def and_i_click_the_add_root_taxon_button
+  def and_i_click_the_manage_root_taxons_button
     click_link "Manage root taxons"
+  end
+
+  def and_i_click_the_edit_root_taxons_button
+    click_link "Edit root taxons"
   end
 
   def then_i_see_the_current_root_taxons


### PR DESCRIPTION
https://trello.com/c/AHfdTD94/188-create-visualisations-to-show-how-much-is-tagged-to-where

Move the previous index page for root taxons to be an explicit edit
page, and change the index page to a show page with a table. This show
page is now used to link out to the pages for the individual root
taxons.

This will allow users to navigate to the show pages for root taxons.

![root-taxons-1](https://user-images.githubusercontent.com/1130010/30115185-da4fabd8-9311-11e7-898c-694702ed6b1f.png)
![root-taxons-2](https://user-images.githubusercontent.com/1130010/30115186-da4fa278-9311-11e7-97e9-8a845894cbc3.png)
