### PR TITLE
Display taxon path in typeahead

### DIFF
--- a/app/assets/javascripts/bulk-tagger.js
+++ b/app/assets/javascripts/bulk-tagger.js
@@ -137,9 +137,12 @@
     taxons_for_select2: function(taxons) {
       var self = this;
       return Object.keys(taxons).reduce(function(acc, taxon_id) {
+        var ancestors = self.taxon_ancestors(taxon_id, taxons);
+        ancestors.shift(); // lose the first ancestor, it's common to all taxons
+
         acc.push({
           "id": taxon_id,
-          "text": self.taxon_ancestors(taxon_id, taxons).join(' > ')
+          "text": ancestors.join(' > ')
         });
         return acc;
       }, []);

--- a/app/assets/javascripts/bulk-tagger.js
+++ b/app/assets/javascripts/bulk-tagger.js
@@ -164,13 +164,14 @@
 
     // Green flash of success
     mark_form_as_successfully_updated: function($form, taxons) {
-      taxons = typeof taxons !== 'undefined' ? taxons : [];
       $form.removeClass(this.form_error_class);
       $form.effect("highlight", { color: this.color_of_success }, 1000);
 
-      $select2 = $form.find('.select2');
-      $select2.data('taxons', taxons);
-      this.update_select2_with_new_taxons($select);
+      if(typeof taxons !== 'undefined') {
+        var $select2 = $form.find('.select2');
+        $select2.data('taxons', taxons);
+        this.update_select2_with_new_taxons($select2);
+      }
     },
 
     update_select2_with_new_taxons: function($select2) {

--- a/app/assets/javascripts/bulk-tagger.js
+++ b/app/assets/javascripts/bulk-tagger.js
@@ -18,7 +18,8 @@
     this.options_for_select2 = {
       allowClear: true,
       multiple: true,
-      data: this.taxons_for_select2(taxons)
+      data: this.taxons_for_select2(taxons),
+      formatSelection: this.format_selected_taxon
     }
   };
 
@@ -48,6 +49,9 @@
           self.mark_form_as_failed_to_update($(this));
         }
       );
+
+      // Contains all the content-item tagging forms
+      var $content_item_forms = $element.find(self.selectors.content_item_forms);
 
       // Aligns the content-item selection checkboxes
       $content_item_forms.each(function(index, form) {
@@ -131,13 +135,31 @@
      * }]
     **/
     taxons_for_select2: function(taxons) {
+      var self = this;
       return Object.keys(taxons).reduce(function(acc, taxon_id) {
         acc.push({
           "id": taxon_id,
-          "text": taxons[taxon_id]
+          "text": self.taxon_ancestors(taxon_id, taxons).join(' > ')
         });
         return acc;
       }, []);
+    },
+
+    // Returns the ancestors array of taxon names
+    taxon_ancestors: function(taxon_id, taxons) {
+      var taxon = taxons[taxon_id];
+
+      if(taxon.parent_id !== null) {
+        return this.taxon_ancestors(taxon.parent_id, taxons).concat(taxon.name);
+      }
+      else {
+        return [taxon.name];
+      }
+    },
+
+    // renders the selected tag
+    format_selected_taxon: function(data) {
+      return data.text.split(' > ').pop();
     },
 
     // Green flash of success
@@ -148,7 +170,7 @@
 
       $select2 = $form.find('.select2');
       $select2.data('taxons', taxons);
-      self.update_select2_with_new_taxons($select);
+      this.update_select2_with_new_taxons($select);
     },
 
     update_select2_with_new_taxons: function($select2) {

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -8,7 +8,7 @@ class ProjectsController < ApplicationController
   def show
     render :show, locals: { project: project,
                             bulk_search: searcher,
-                            taxons: taxons_json,
+                            taxons: taxons,
                             content_items: content_items }
   end
 
@@ -35,11 +35,17 @@ private
     @_content_items ||= Projects::PrepareContentItems.call(searcher.project_content_items_to_display)
   end
 
-  def taxons_json
+  def taxons
     project
       .taxons
-      .reduce({}) { |acc, taxon| acc.merge(taxon.content_id => taxon.name) }
-      .to_json
+      .reduce({}) do |acc, taxon|
+        acc.merge(
+          taxon.content_id => {
+            name: taxon.name,
+            parent_id: taxon.parent_node.try(:content_id)
+          }
+        )
+      end
   end
 
   def project_index

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -49,7 +49,7 @@
 </div>
 
 <script>
-  var bulkTagger = new GOVUKAdmin.Modules.BulkTagger(<%= taxons.to_s.html_safe %>);
+  var bulkTagger = new GOVUKAdmin.Modules.BulkTagger(<%= taxons.to_json.html_safe %>);
   bulkTagger.start_individual_taggers($('.tagathon-project'));
 
   <% if project.bulk_tagging_enabled? %>


### PR DESCRIPTION
Allows the user to typeahead search through the entire taxonomy tree when selecting tags for an item of content in the Project tagger view.

![typeahead](https://user-images.githubusercontent.com/608867/30163285-53c4b99a-93d0-11e7-9b08-5b2f2093e8d3.gif)

[Trello](https://trello.com/c/GwcQBQu5/249-display-taxon-path-in-typeahead-results)