### PR TITLE
Set flags for content

### DIFF
--- a/app/assets/stylesheets/tagathon_project.scss
+++ b/app/assets/stylesheets/tagathon_project.scss
@@ -58,3 +58,10 @@
     }
   }
 }
+
+.flag-for-review {
+  .add-left-border {
+    border-left: 5px solid #ccc;
+    padding: 5px 0 10px 15px;
+  }
+}

--- a/app/controllers/project_content_items_controller.rb
+++ b/app/controllers/project_content_items_controller.rb
@@ -15,7 +15,21 @@ class ProjectContentItemsController < ApplicationController
     render json: tagger.result
   end
 
+  def flags
+    render :flags, locals: { project: project, content_item: content_item }
+  end
+
+  def update_flags
+    content_item.update(flag_params)
+    content_item.save
+    redirect_to project_path(project)
+  end
+
 private
+
+  def flag_params
+    params.require(:project_content_item).permit(:flag, :suggested_tags)
+  end
 
   def bulk_params
     params

--- a/app/models/project_content_item.rb
+++ b/app/models/project_content_item.rb
@@ -1,6 +1,11 @@
 class ProjectContentItem < ActiveRecord::Base
   belongs_to :project
 
+  enum flag: {
+    needs_help: 1,
+    missing_topic: 2,
+  }
+
   attr_accessor :taxons
 
   def base_path

--- a/app/views/project_content_items/flags.html.erb
+++ b/app/views/project_content_items/flags.html.erb
@@ -1,0 +1,32 @@
+<div class='row flag-for-review'>
+  <h1>Flag '<%= content_item.title %>' for review</h1>
+
+  <%= form_for content_item, url: update_flags_project_content_item_path(project, content_item), method: :post, html: { class: 'col-md-6', data: { module: 'radio-toggle' } } do |f| %>
+
+    <div class='radio'>
+      <label>
+        <%= f.radio_button :flag, "needs_help" %>
+        I need help tagging this
+      </label>
+    </div>
+
+    <div class='radio-toggle'>
+      <div class='radio'>
+        <label>
+          <%= f.radio_button :flag, "missing_topic", data: { target: 'suggested-tags' } %>
+          There's no relevant topic for this
+        </label>
+      </div>
+
+      <div id='suggested-tags' class='form-group add-top-margin add-left-border'>
+        <%= f.label :suggested_tags, "Suggest a new topic" %>
+        <%= f.text_field :suggested_tags, class: 'form-control input-md-4' %>
+      </div>
+    </div>
+
+    <div class='add-top-margin'>
+      <%= f.submit "Continue", class: 'btn btn-success add-right-margin' %>
+      <%= link_to "Cancel", :back %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/projects/_content_item.html.erb
+++ b/app/views/projects/_content_item.html.erb
@@ -11,5 +11,7 @@
         autocomplete: 'off',
         data: { taxons: content_item.taxons }
       } %>
+
+    <p><%= link_to "Flag for review", flags_project_content_item_path(content_item.project, content_item) %></p>
   <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,7 +28,10 @@ Rails.application.routes.draw do
   get '/lookup', to: redirect("/taggings/lookup")
 
   resources :projects, only: %i(index show new create) do
-    resources :project_content_items, only: [:update], as: 'content_item'
+    resources :project_content_items, only: [:update], as: 'content_item' do
+      get "/flags", on: :member, to: "project_content_items#flags"
+      post "/flags", on: :member, to: "project_content_items#update_flags", as: 'update_flags'
+    end
     post '/bulk_update', to: 'project_content_items#bulk_update', as: 'bulk_update'
   end
 

--- a/db/migrate/20170911152904_add_flags_to_content_item.rb
+++ b/db/migrate/20170911152904_add_flags_to_content_item.rb
@@ -1,0 +1,8 @@
+class AddFlagsToContentItem < ActiveRecord::Migration[5.0]
+  def change
+    add_column :project_content_items, :flag, :integer
+    add_column :project_content_items, :suggested_tags, :string
+
+    add_index :project_content_items, :flag
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170906153022) do
+ActiveRecord::Schema.define(version: 20170911152904) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -19,11 +19,14 @@ ActiveRecord::Schema.define(version: 20170906153022) do
     t.string   "url"
     t.string   "title"
     t.string   "description"
-    t.datetime "created_at",                  null: false
-    t.datetime "updated_at",                  null: false
+    t.datetime "created_at",                     null: false
+    t.datetime "updated_at",                     null: false
     t.integer  "project_id"
-    t.boolean  "done",        default: false
+    t.boolean  "done",           default: false
     t.uuid     "content_id"
+    t.integer  "flag"
+    t.string   "suggested_tags"
+    t.index ["flag"], name: "index_project_content_items_on_flag", using: :btree
     t.index ["project_id"], name: "index_project_content_items_on_project_id", using: :btree
   end
 

--- a/spec/features/flagging_a_content_item_spec.rb
+++ b/spec/features/flagging_a_content_item_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.describe "flagging a content item" do
+  include TaxonomyHelper
+  include PublishingApiHelper
+
+  scenario "flagging a content_item as 'I need help'" do
+    given_there_is_a_project_with_a_content_item
+    when_i_visit_the_project_page
+    and_i_flag_the_first_content_item_as_i_need_help
+    then_the_content_item_should_be_flagged_as_needs_help
+  end
+
+  scenario "flagging a content item and suggesting a new term" do
+    given_there_is_a_project_with_a_content_item
+    when_i_visit_the_project_page
+    and_i_flag_the_first_content_item_as_missing_a_relevant_topic_and_i_suggest_a_new_term
+    then_them_content_item_should_be_flagged_as_missing_topic
+    and_there_should_be_an_associated_suggestion
+  end
+
+  def given_there_is_a_project_with_a_content_item
+    create(:project, :with_content_item)
+    stub_empty_bulk_taxons_lookup
+    stub_draft_taxonomy_branch
+  end
+
+  def when_i_visit_the_project_page
+    visit project_path(Project.first)
+  end
+
+  def and_i_flag_the_first_content_item_as_i_need_help
+    click_link 'Flag for review'
+    choose "I need help tagging this"
+    click_button "Continue"
+  end
+
+  def then_the_content_item_should_be_flagged_as_needs_help
+    expect(Project.first.content_items.first.needs_help?).to be true
+  end
+
+  def and_i_flag_the_first_content_item_as_missing_a_relevant_topic_and_i_suggest_a_new_term
+    click_link 'Flag for review'
+    choose "There's no relevant topic for this"
+    fill_in "Suggest a new topic", with: "cool new topic"
+    click_button "Continue"
+  end
+
+  def then_them_content_item_should_be_flagged_as_missing_topic
+    expect(Project.first.content_items.first.missing_topic?).to be true
+  end
+
+  def and_there_should_be_an_associated_suggestion
+    expect(Project.first.content_items.first.suggested_tags).to eql "cool new topic"
+  end
+end


### PR DESCRIPTION
First in a the series of changes that introduce the concept of Flagging to the Tagathon application.

Flagging is implemented as orthogonal to the 'doneness' of an item of content.

![image](https://user-images.githubusercontent.com/608867/30336138-25dac406-97dc-11e7-8099-d8b199fc63d8.png)

![image](https://user-images.githubusercontent.com/608867/30372145-d6079c58-9874-11e7-9314-9e6c13d6928f.png)


![image](https://user-images.githubusercontent.com/608867/30372170-e5385bb8-9874-11e7-85ef-4ba663041ea5.png)



[Trello](https://trello.com/c/FWCp5ShV/274-set-flags-for-content)