### PR TITLE
Mark a content item as Done

### DIFF
--- a/app/assets/stylesheets/tagathon_project.scss
+++ b/app/assets/stylesheets/tagathon_project.scss
@@ -16,11 +16,15 @@
   }
 
   .content-list {
-    form {
-      margin: 20px 0;
+    .content-item {
       padding: 20px 40px;
+      margin: 20px 0 30px 0;
       border: 1px solid #ccc;
       border-width:1px 0 0 0;
+    }
+
+    form.content-item-form {
+      clear: left;
 
       a {
         font-size: 1.2em;
@@ -34,6 +38,10 @@
         background-color: #ffb6b6;
         transition: background-color 1s;
       }
+    }
+
+    .actions-inline>*{
+      float: left;
     }
   }
 

--- a/app/controllers/project_content_items_controller.rb
+++ b/app/controllers/project_content_items_controller.rb
@@ -3,7 +3,6 @@ class ProjectContentItemsController < ApplicationController
 
   def update
     tag_content
-    content_item.mark_complete
     head :ok
   rescue GdsApi::HTTPClientError
     head :bad_request
@@ -23,6 +22,11 @@ class ProjectContentItemsController < ApplicationController
     content_item.update(flag_params)
     content_item.save
     redirect_to project_path(project)
+  end
+
+  def mark_as_done
+    content_item.done!
+    redirect_back fallback_location: project_path(project)
   end
 
 private

--- a/app/models/project_content_item.rb
+++ b/app/models/project_content_item.rb
@@ -12,7 +12,7 @@ class ProjectContentItem < ActiveRecord::Base
     url.gsub('https://www.gov.uk', '')
   end
 
-  def mark_complete
+  def done!
     update_attributes(done: true)
   end
 

--- a/app/services/projects/bulk_tagger.rb
+++ b/app/services/projects/bulk_tagger.rb
@@ -9,7 +9,6 @@ module Projects
       @content_ids.each do |id|
         content_item = ProjectContentItem.find(id)
         TagContentWorker.perform_async(content_item.content_id, @taxon_content_ids)
-        content_item.mark_complete
       end
     end
 

--- a/app/views/projects/_content_item.html.erb
+++ b/app/views/projects/_content_item.html.erb
@@ -1,5 +1,5 @@
 <div class='content-item'>
-  <%= simple_form_for content_item, url: project_content_item_path(content_item.project, content_item), remote: true, html: { data: { ref: content_item.id }, class: 'js-content-item-form' } do |f| %>
+  <%= simple_form_for content_item, url: project_content_item_path(content_item.project, content_item), remote: true, html: { data: { ref: content_item.id }, class: 'js-content-item-form content-item-form' } do |f| %>
     <%= token_tag %>
     <h4>
       <%= link_to content_item.title, content_item.url, data: {proxy_iframe: 'enabled', modal_url: content_item.proxied_url, toggle: 'modal', target: '#iframe_modal_id'} %>
@@ -9,6 +9,8 @@
       <span class='label label-danger'><%= I18n.t('views.projects.flags.help-needed') %></span>
     <% elsif content_item.missing_topic? %>
       <span class='label label-danger'><%= I18n.t('views.projects.flags.missing-topic') %></span>
+    <% elsif content_item.done? %>
+      <span class='label label-primary'>Done</span>
     <% end %>
 
     <p><%= content_item.description %></p>
@@ -20,9 +22,10 @@
         autocomplete: 'off',
         data: { taxons: content_item.taxons }
       } %>
-
-    <p>
-      <%= link_to text_for_content_flagging_link(content_item), flags_project_content_item_path(content_item.project, content_item) %>
-    </p>
   <% end %>
+
+  <div class='actions actions-inline'>
+    <%= button_to 'Done', mark_done_project_content_item_path(content_item.project, content_item) %>
+    <%= link_to text_for_content_flagging_link(content_item), flags_project_content_item_path(content_item.project, content_item), class: 'add-left-margin' %>
+  </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,7 @@ Rails.application.routes.draw do
     resources :project_content_items, only: [:update], as: 'content_item' do
       get "/flags", on: :member, to: "project_content_items#flags"
       post "/flags", on: :member, to: "project_content_items#update_flags", as: 'update_flags'
+      post "/done", on: :member, to: 'project_content_items#mark_as_done', as: 'mark_done'
     end
     post '/bulk_update', to: 'project_content_items#bulk_update', as: 'bulk_update'
   end

--- a/spec/features/project_spec.rb
+++ b/spec/features/project_spec.rb
@@ -67,6 +67,13 @@ RSpec.feature "Projects", type: :feature do
     then_i_see_the_content_item_and_its_tag_data
   end
 
+  scenario "marking a content item as done" do
+    given_there_is_a_project_with_a_tagged_content_item
+    when_i_visit_the_project_page
+    and_i_mark_the_content_item_as_done
+    then_the_content_item_should_be_marked_as_done
+  end
+
   def given_there_is_a_project_with_content_items
     @project = create :project, :with_content_items
     stub_draft_taxonomy_branch
@@ -196,6 +203,10 @@ RSpec.feature "Projects", type: :feature do
     end
   end
 
+  def and_i_mark_the_content_item_as_done
+    click_button "Done"
+  end
+
   def then_i_can_see_my_new_project_in_the_list
     expect(page).to have_content 'my_project'
   end
@@ -222,5 +233,11 @@ RSpec.feature "Projects", type: :feature do
 
   def then_there_is_no_bulk_tagging_interface
     expect(page).not_to have_selector '.bulk-tagger'
+  end
+
+  def then_the_content_item_should_be_marked_as_done
+    within('.content-item .label') do
+      expect(page).to have_content 'Done'
+    end
   end
 end

--- a/spec/models/project_content_item_spec.rb
+++ b/spec/models/project_content_item_spec.rb
@@ -21,4 +21,13 @@ RSpec.describe ProjectContentItem do
       expect(content_item.proxied_url).to eq("#{proxy_path}/path")
     end
   end
+
+  describe "#done!" do
+    it "updates the content item to 'done' and saves it" do
+      subject = create(:project_content_item, done: false)
+      subject.done!
+      expect(subject.done?).to be true
+      expect(subject.persisted?).to be true
+    end
+  end
 end


### PR DESCRIPTION
Allows the user to represent that they are done tagging this content item.

![mark-as-done](https://user-images.githubusercontent.com/608867/30389569-1cd25f34-98ab-11e7-94cf-f054d35cafa9.gif)

[Trello](https://trello.com/c/FAIzObRG/276-user-can-mark-content-item-as-done)