### PR TITLE
Add missing startup script

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+bundle install
+bundle exec rails s -p 3116


### PR DESCRIPTION
Other Rails applications in GOV.UK have a startup script. It makes it easier to start the application standalone in development if you don't have to lookup or remember the port number every time.