### PR TITLE
Page of suggested terms

### DIFF
--- a/app/controllers/project_content_items_controller.rb
+++ b/app/controllers/project_content_items_controller.rb
@@ -1,6 +1,11 @@
 class ProjectContentItemsController < ApplicationController
   before_action :ensure_user_can_access_tagathon_tools!
 
+  def index
+    @project_content_items = ProjectContentItemQuery.new(params)
+    @title = index_page_title
+  end
+
   def update
     tag_content
     head :ok
@@ -30,6 +35,12 @@ class ProjectContentItemsController < ApplicationController
   end
 
 private
+
+  def index_page_title
+    response = Services.publishing_api.get_content(params[:taxonomy_branch])
+    taxonomy_title = response.to_h['title']
+    "Content flagged for #{taxonomy_title}"
+  end
 
   def flag_params
     params.require(:project_content_item).permit(:flag, :suggested_tags)

--- a/app/models/project_content_item.rb
+++ b/app/models/project_content_item.rb
@@ -23,4 +23,10 @@ class ProjectContentItem < ActiveRecord::Base
   scope :uncompleted, -> { where(done: false) }
   scope :matching_search, -> (query) { where("title ILIKE ?", "%#{query}%") }
   scope :with_valid_ids, -> { where.not(content_id: nil) }
+
+  scope :for_taxonomy_branch, (lambda do |branch_id|
+    joins(:project).where("projects.taxonomy_branch = ?", branch_id)
+  end)
+
+  scope :flagged_with, -> (flag) { where(flag: flags[flag]) }
 end

--- a/app/queries/project_content_item_query.rb
+++ b/app/queries/project_content_item_query.rb
@@ -1,0 +1,18 @@
+class ProjectContentItemQuery
+  attr_reader :params
+
+  def initialize(params)
+    @params = params.slice(:taxonomy_branch, :flagged)
+  end
+
+  def each(&block)
+    items.each(&block)
+  end
+
+  def items
+    ProjectContentItem
+      .for_taxonomy_branch(params[:taxonomy_branch])
+      .flagged_with(params[:flagged])
+      .order(updated_at: :desc)
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,7 +24,7 @@
   <% end %>
 
   <% if user_can_access_tagathon_tools? %>
-    <li class='<%= active_navigation_item == 'projects' ? 'active' : nil %>'>
+    <li class='<%= active_navigation_item.in?(%w[projects project_content_items]) ? 'active' : nil %>'>
       <%= link_to t('navigation.projects'), projects_path %>
     </li>
   <% end %>

--- a/app/views/project_content_items/index.html.erb
+++ b/app/views/project_content_items/index.html.erb
@@ -1,0 +1,21 @@
+<%= display_header title: @title, breadcrumbs: [:projects, @title] %>
+
+<table class="table queries-list table-bordered table-striped">
+  <thead>
+    <tr class="table-header">
+      <th>Suggested Tag</th>
+      <th>Title</th>
+      <th>Last modified</th>
+    </tr>
+  </thead>
+
+  <tbody>
+  <% @project_content_items.each do |project_content_item| %>
+    <tr>
+      <td><%= project_content_item.suggested_tags %></td>
+      <td><%= link_to project_content_item.title, project_content_item.url %></td>
+      <td><%= project_content_item.updated_at.to_s(:govuk_date) %></td>
+    </tr>
+  <% end %>
+  </tbody>
+</table>

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -9,6 +9,10 @@
     <%= branch_projects.first.taxonomy_branch_title %>
   </h2>
 
+  <p>
+    <%= link_to "View suggested topics", project_content_items_path(taxonomy_branch: taxonomy_branch, flagged: "missing_topic") %>
+  </p>
+
   <table class="table queries-list table-bordered table-striped">
     <thead>
     <tr class="table-header">

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -4,18 +4,24 @@
   <% end %>
 <% end %>
 
-<table class="table queries-list table-bordered table-striped">
-  <thead>
-  <tr class="table-header">
-    <th>Project</th>
-  </tr>
-  </thead>
+<% projects.group_by(&:taxonomy_branch).each do |taxonomy_branch, branch_projects| %>
+  <h2>
+    <%= branch_projects.first.taxonomy_branch_title %>
+  </h2>
 
-  <tbody>
-  <% projects.each do |project| %>
-      <tr>
-        <td><%= link_to project.name, project_path(project) %></td>
-      </tr>
-  <% end %>
-  </tbody>
-</table>
+  <table class="table queries-list table-bordered table-striped">
+    <thead>
+    <tr class="table-header">
+      <th>Project</th>
+    </tr>
+    </thead>
+
+    <tbody>
+    <% branch_projects.each do |project| %>
+        <tr>
+          <td><%= link_to project.name, project_path(project) %></td>
+        </tr>
+    <% end %>
+    </tbody>
+  </table>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,10 @@ Rails.application.routes.draw do
   get '/lookup', to: redirect("/taggings/lookup")
 
   resources :projects, only: %i(index show new create) do
+    collection do
+      resources :project_content_items, only: [:index]
+    end
+
     resources :project_content_items, only: [:update], as: 'content_item' do
       get "/flags", on: :member, to: "project_content_items#flags"
       post "/flags", on: :member, to: "project_content_items#update_flags", as: 'update_flags'

--- a/spec/factories/project_content_item.rb
+++ b/spec/factories/project_content_item.rb
@@ -11,6 +11,7 @@ FactoryGirl.define do
 
     trait :flagged_missing_topic do
       flag { ProjectContentItem.flags['missing_topic'] }
+      suggested_tags 'have you thought about ...?'
     end
   end
 end

--- a/spec/features/reporting_missing_taxons_spec.rb
+++ b/spec/features/reporting_missing_taxons_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe 'Reporting missing taxons to the IA team' do
+  include TaxonomyHelper
+
+  scenario 'IAs can see flagged content items for a branch of the taxonomy' do
+    given_i_am_logged_in_as_a_gds_editor
+    and_there_is_a_draft_branch_of_the_taxonomy
+    and_there_are_content_items_with_suggested_terms
+    when_i_visit_the_projects_page
+    and_i_click_the_see_commented_items_link
+    then_i_can_see_the_suggested_terms
+  end
+
+  def given_i_am_logged_in_as_a_gds_editor
+    login_as create(:user, :gds_editor)
+  end
+
+  def and_there_is_a_draft_branch_of_the_taxonomy
+    stub_draft_taxonomy_branch
+  end
+
+  def and_there_are_content_items_with_suggested_terms
+    p1 = create(:project)
+    p1.content_items << create(:project_content_item, :flagged_missing_topic, title: 'foo')
+    p2 = create(:project)
+    p2.content_items << create(:project_content_item, :flagged_missing_topic, title: 'bar')
+  end
+
+  def when_i_visit_the_projects_page
+    visit '/projects'
+  end
+
+  def and_i_click_the_see_commented_items_link
+    click_link "View suggested topics"
+  end
+
+  def then_i_can_see_the_suggested_terms
+    expect(page).to have_content('foo')
+    expect(page).to have_content('bar')
+  end
+end


### PR DESCRIPTION
Adds a page showing all the suggested terms for a given branch of the taxonomy.

![flagged-content](https://user-images.githubusercontent.com/608867/30587584-9d0f0aec-9d2b-11e7-84f9-ae494d93daf2.gif)


[Trello](https://trello.com/c/yP5vKF2t/214-ia-gets-alerted-if-a-user-reports-no-appropriate-taxon)