### PR TITLE
Show text feedback when saving tags for a content item

### DIFF
--- a/app/assets/javascripts/bulk-tagger.js
+++ b/app/assets/javascripts/bulk-tagger.js
@@ -112,14 +112,27 @@
       $content_item_forms.on(
         'ajax:success',
         function() {
+          display_response_state($(this), "Saved");
           self.mark_form_as_successfully_updated($(this));
         }
       ).on(
         'ajax:error',
         function() {
+          display_response_state($(this), "Failed to save");
           self.mark_form_as_failed_to_update($(this));
         }
       );
+
+      function display_response_state($formEl, message) {
+        $formEl.siblings(".js-save-state")
+          .text(message)
+          .delay(700)
+          .animate({ opacity: 0 }, 300, 'linear', function() {
+            var $textEl = $(this)
+            $textEl.html("&nbsp;");
+            $textEl.css({ opacity: 1 })
+          });
+      }
     },
 
     /**

--- a/app/assets/stylesheets/tagathon_project.scss
+++ b/app/assets/stylesheets/tagathon_project.scss
@@ -33,7 +33,7 @@
       }
 
       .project_content_item_taxons {
-        margin: 20px 0;
+        margin: 20px 0 0;
       }
 
       &.error-saving {

--- a/app/views/projects/_content_item.html.erb
+++ b/app/views/projects/_content_item.html.erb
@@ -25,6 +25,9 @@
   <% end %>
 
   <% unless content_item.done? %>
+    <p class='js-save-state'>
+      &nbsp;
+    </p>
     <div class='actions actions-inline'>
       <%= button_to 'Done', mark_done_project_content_item_path(content_item.project, content_item), class: 'btn btn-primary' %>
       <% unless content_item.flag? %>


### PR DESCRIPTION
We found that the visual colour flash when saving tags caused some confusion on whether the item was updated. Now, as well as the colour flash, we also display "Saved" or "Failed to save" in the interface.

## Save successful

![](https://media.giphy.com/media/3ov9k9TPfBN2arzLsA/giphy.gif)

## Save failed

![](https://media.giphy.com/media/l378pbelwNn2xOi0U/giphy.gif)

[Trello](https://trello.com/c/NHABw8Sf/275-show-text-feedback-when-saving-tags-for-a-content-item)