### PR TITLE
Don't re-initialise select2 on scroll

### DIFF
--- a/app/assets/javascripts/bulk-tagger.js
+++ b/app/assets/javascripts/bulk-tagger.js
@@ -41,8 +41,14 @@
               taxons = $this.data('taxons'),
               options = self.options_for_select2;
 
+          // remove 'disabled' attribute from input element
           $this.prop('disabled', false);
+
+          // populate with previously selected taxons, and initialize select2
           $this.val(taxons).select2(options);
+
+          // remove waypoint
+          this.destroy();
         },
         offset: 'bottom-in-view'
       });


### PR DESCRIPTION
Fixes a bug where a recently-tagged select2 element could be reinitialised by the user scrolling the page. This might cause the appearance of data-loss.