### PR TITLE
Ability to delete a project

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,5 +1,6 @@
 class ProjectsController < ApplicationController
   before_action :ensure_user_can_access_tagathon_tools!
+  before_action :ensure_user_can_administer_taxonomy!, only: %i[confirm_delete destroy]
 
   def index
     render :index, locals: { projects: project_index }
@@ -27,6 +28,15 @@ class ProjectsController < ApplicationController
     end
   end
 
+  def confirm_delete
+    render :confirm_delete, locals: { project: project }
+  end
+
+  def destroy
+    project.destroy!
+    redirect_to projects_path, success: 'You have sucessfully deleted the project'
+  end
+
 private
 
   def taxons
@@ -47,7 +57,11 @@ private
   end
 
   def project
-    @_project ||= Project.find(params[:id])
+    @_project ||= Project.find(project_id)
+  end
+
+  def project_id
+    params[:id] || params[:project_id]
   end
 
   def new_project_params

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,5 +1,5 @@
 class Project < ActiveRecord::Base
-  has_many :content_items, class_name: 'ProjectContentItem'
+  has_many :content_items, class_name: 'ProjectContentItem', dependent: :destroy
 
   def taxons
     @_taxons ||= GovukTaxonomy::Branches.new.taxons_for_branch(taxonomy_branch)

--- a/app/views/projects/confirm_delete.html.erb
+++ b/app/views/projects/confirm_delete.html.erb
@@ -1,0 +1,18 @@
+<header class="heading-with-actions">
+  <h1><%= project.name %></h1>
+</header>
+
+<div class="lead">
+  You are about to <strong>delete</strong> this project - this will remove the
+  project and any participant suggested tags that may still be outstanding,
+  and cannot be undone.
+</div>
+
+<div class="confirmation-box">
+  <%= button_to "Confirm delete",
+    project_path(project),
+    method: :delete,
+    class: 'btn btn-danger add-right-margin' %>
+
+  <%= link_to "Cancel", :back, class: "cancel-link" %>
+</div>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -1,4 +1,8 @@
-<%= display_header title: project.name, breadcrumbs: [:projects, project.name] %>
+<%= display_header title: project.name, breadcrumbs: [:projects, project.name] do %>
+  <% if user_can_administer_taxonomy? %>
+    <%= link_to 'Delete', project_confirm_delete_path(project), class: 'btn btn-danger' %>
+  <% end %>
+<% end %>
 
 <%= render partial: 'shared/iframe_proxy_modal' %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,7 +27,8 @@ Rails.application.routes.draw do
   get '/content/:content_id', to: redirect { |params, _| "/taggings/#{params[:content_id]}" }
   get '/lookup', to: redirect("/taggings/lookup")
 
-  resources :projects, only: %i(index show new create) do
+  resources :projects, except: %i[edit update] do
+    get :confirm_delete
     collection do
       resources :project_content_items, only: [:index]
     end

--- a/spec/features/project_spec.rb
+++ b/spec/features/project_spec.rb
@@ -19,6 +19,14 @@ RSpec.feature "Projects", type: :feature do
     then_i_can_see_my_new_project_in_the_list
   end
 
+  scenario "deleting an existing project" do
+    given_there_is_a_project_with_content_items
+    and_i_am_logged_in_as_a_gds_editor
+    when_i_visit_the_project_page
+    and_i_click_and_confirm_to_delete_the_project
+    then_i_see_the_project_has_been_deleted
+  end
+
   scenario "viewing a project with no bulk-tagging" do
     given_there_is_a_project_with_content_items_but_no_bulk_tagging
     when_i_visit_the_project_page
@@ -120,6 +128,15 @@ RSpec.feature "Projects", type: :feature do
     stub_draft_taxonomy_branch
   end
 
+  def and_i_am_logged_in_as_a_gds_editor
+    login_as create(:user, :gds_editor)
+  end
+
+  def and_i_click_and_confirm_to_delete_the_project
+    click_link "Delete"
+    click_button "Confirm delete"
+  end
+
   def then_i_see_the_content_item_and_its_tag_data
     within('.content-item:first') do
       expect(page).to have_content @content_item.title
@@ -218,6 +235,11 @@ RSpec.feature "Projects", type: :feature do
 
   def then_i_can_see_my_new_project_in_the_list
     expect(page).to have_content 'my_project'
+  end
+
+  def then_i_see_the_project_has_been_deleted
+    expect(page).to have_content 'You have sucessfully deleted the project'
+    expect(page).not_to have_content 'project title'
   end
 
   def then_i_can_see_todo_content_items_for_that_project


### PR DESCRIPTION
Users with the `GDS Editor` permission can delete projects. To be used to clean up test projects before the mini tagathon.

[Trello](https://trello.com/c/eevVDIt9/270-ia-can-delete-a-project-in-tagging-tool)