### PR TITLE
Run gov-lint-ruby as part of default rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,3 +4,5 @@
 require File.expand_path('../config/application', __FILE__)
 
 Rails.application.load_tasks
+
+task(:default).prerequisites << "lint" unless ENV.has_key?("JENKINS_URL")

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,0 +1,4 @@
+desc "Run govuk-lint on files changed since origin/master"
+task "lint" do
+  system "govuk-lint-ruby --diff"
+end


### PR DESCRIPTION
There's been numerous times where I've forgotten to run the govuk lint
task and see CI fail because of it.

When running the default rake task, we should include the lint task and
have it run in a similar way to CI.