### PR TITLE
Handle missing document information with tagging history

### DIFF
--- a/app/views/tagging_history/index.html.erb
+++ b/app/views/tagging_history/index.html.erb
@@ -21,15 +21,25 @@
       <tr>
         <td><%= time_ago_in_words(link_change[:created_at]) %> ago</td>
         <td>
-          <%= link_to link_change[:source][:title],
-                      tagging_path(content_id: link_change[:source][:content_id]) %>
+          <% if link_change[:source] %>
+            <%= link_to link_change[:source][:title],
+                        tagging_path(content_id: link_change[:source][:content_id]) %>
+          <% else %>
+            An unknown document
+          <% end %>
+
           <% if link_change[:change] == 'remove' %>
             removed from
           <% else %>
             tagged to
           <% end %>
-          <%= link_to link_change[:target][:title],
-                      tagging_history_path(link_change[:target][:content_id]) %>
+
+          <% if link_change[:target] %>
+            <%= link_to link_change[:target][:title],
+                        tagging_history_path(link_change[:target][:content_id]) %>
+          <% else %>
+            an unknown taxon
+          <% end %>
         </td>
         <td>
           <% if link_change[:user_name] %>

--- a/app/views/tagging_history/show.html.erb
+++ b/app/views/tagging_history/show.html.erb
@@ -36,8 +36,12 @@
           </span>
         </td>
         <td>
-          <%= link_to link_change[:source][:title],
-                      tagging_path(content_id: link_change[:source][:content_id]) %>
+          <% if link_change[:source] %>
+            <%= link_to link_change[:source][:title],
+                        tagging_path(content_id: link_change[:source][:content_id]) %>
+          <% else %>
+            An unknown document
+          <% end %>
         </td>
         <td>
           <% if link_change[:user_name] %>

--- a/spec/features/tagging_history_spec.rb
+++ b/spec/features/tagging_history_spec.rb
@@ -64,30 +64,25 @@ RSpec.feature "Tagging History", type: :feature do
   end
 
   def then_i_see_a_list_of_added_link_changes
-    page.all('tbody tr').zip(added_link_changes).each do |tr, link_change|
-      expect(tr).to have_link(
-        link_change['source']['title'],
-        href: tagging_path(link_change['source']['content_id'])
-      )
-      expect(tr).to have_link(
-        link_change['target']['title'],
-        href: tagging_history_path(link_change['target']['content_id'])
-      )
-      expect(tr).to have_text('tagged to')
-      expect(tr).to have_text('Unknown user')
-    end
+    check_index_page_link_changes_table(added_link_changes)
   end
 
   def then_i_see_a_list_of_removed_link_changes
-    page.all('tbody tr').zip(removed_link_changes).each do |tr, link_change|
+    check_index_page_link_changes_table(removed_link_changes)
+  end
+
+  def check_index_page_link_changes_table(link_changes)
+    page.all('tbody tr').zip(link_changes).each do |tr, link_change|
       expect(tr).to have_link(
         link_change['source']['title'],
         href: tagging_path(link_change['source']['content_id'])
       )
+
       expect(tr).to have_link(
         link_change['target']['title'],
         href: tagging_history_path(link_change['target']['content_id'])
       )
+
       expect(tr).to have_text('removed')
       expect(tr).to have_text('Unknown user')
     end


### PR DESCRIPTION
Trello: https://trello.com/c/woqZQI8n/253-display-tagging-history-in-content-tagger