### PR TITLE
Only link to the taxonomy visualisation from the index

### DIFF
--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -5,8 +5,8 @@
 <% end %>
 
 <% projects.group_by(&:taxonomy_branch).each do |taxonomy_branch, branch_projects| %>
-  <%= link_to "Show",
-              branch_path(taxonomy_branch, viz: :list),
+  <%= link_to "Show #{branch_projects.first.taxonomy_branch_title.downcase} taxonomy",
+              branch_path(branch_projects.first.taxonomy_branch, viz: :list),
               class: %w(btn btn-default pull-right) %>
   <h2>
     <%= branch_projects.first.taxonomy_branch_title %>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -9,12 +9,6 @@
 
 <div class="row tagathon-project">
   <div class="col-md-3 filter-controls">
-    <%= link_to "Show #{project.taxonomy_branch_title.downcase} taxonomy",
-                branch_path(project.taxonomy_branch, viz: :list),
-                class: 'btn btn-default btn-lg',
-                target: '_blank'
-    %>
-
     <h3>Filter</h3>
 
     <form method="GET">


### PR DESCRIPTION
Not the projects show page, to avoid the possibility of users
scrolling around the page to get at it.

Trello: https://trello.com/c/dEpDiGDI/295-allow-tagathon-participants-to-access-list-view-for-a-taxonomy-branch