### PR TITLE
Establish order on projects index page

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -53,7 +53,7 @@ private
   end
 
   def project_index
-    @_project_index = Project.all
+    @_project_index = Project.all.order(:taxonomy_branch, :name)
   end
 
   def project


### PR DESCRIPTION
It was observed that the order of projects displayed on the index page
is seemingly random, and was re-shuffled when an update was made to a
project content item.

In this commit, we have defined the order in which projects should be
displayed: We are grouping by taxanomy_branch and displaying it's
title, but we do not have access to the title in the database, only the
taxanomy_branch UUID. This is used to define the order of the grouping,
and then order individual projects by names.