### PR TITLE
Recalculate waypoint trigger points after modifiying DOM

### DIFF
--- a/app/assets/javascripts/bulk-tagger.js
+++ b/app/assets/javascripts/bulk-tagger.js
@@ -83,6 +83,7 @@
         function() {
           $(this).parents('.content-item').fadeOut('fast', function() {
             $(this).remove();
+            Waypoint.refreshAll();
           });
         }
       ).on(

--- a/app/views/project_content_items/update_flags.js.erb
+++ b/app/views/project_content_items/update_flags.js.erb
@@ -1,4 +1,5 @@
 $('#flags-modal').modal('toggle');
 $('.content-item form[data-ref="<%= content_item.id %>"]').parent('.content-item').fadeOut('slow', function() {
   $(this).remove();
+  Waypoint.refreshAll();
 });


### PR DESCRIPTION
We are initialising the select2 boxes using the Waypoints library,
however, this library works solely on scroll events.

In a normal workflow, our users do not scroll down the page, but
instead mark the content as "Done" or "Flagged". These actions will
remove the elements from the page (which then brings the element below
up into view) while never triggering a scroll event.

We resolve this by refreshing the Waypoint library when changes to the
DOM have completed.