### PR TITLE
Add rake task to export tagging metadata to JSON

### DIFF
--- a/lib/tagged_content_exporter.rb
+++ b/lib/tagged_content_exporter.rb
@@ -1,0 +1,63 @@
+class TaggedContentExporter
+  def self.call
+    transport_taxon_id = "a4038b29-b332-4f13-98b1-1c9709e216bc"
+    content_items = ProjectContentItem.for_taxonomy_branch(transport_taxon_id).done
+
+    content_items = content_items.map do |c|
+      puts c.content_id
+
+      content_item = {}
+      content_item["content_id"] = c.content_id
+      content_item["url"] = c.url.gsub("https://www.gov.uk", "")
+      response = Services.publishing_api.get_links(c.content_id)
+
+      if response.to_h["links"]["taxons"].blank?
+        puts "--FAIL no taxons in links hash"
+        next
+      end
+
+      content_item["taxons"] = response.to_h["links"]["taxons"].map do |taxon_id|
+        puts "--#{taxon_id}"
+
+        params = { source_content_ids: [c.content_id], link_types: ["taxons"] }
+        taxon_change = Services
+          .publishing_api
+          .get_links_changes(params)
+          .to_h["link_changes"]
+          .find { |link| link.dig("target", "content_id") == taxon_id }
+
+        if taxon_change.blank?
+          puts "--FAIL taxon_change is blank"
+          next
+        end
+
+        user = User.find_by(uid: taxon_change.dig("user_uid")) || User.new
+        taxon_hash = Services.publishing_api.get_expanded_links(taxon_id).to_h
+
+        {
+          content_id: taxon_id,
+          depth: self.taxon_depth(taxon_hash),
+          url: taxon_change.dig("target", "base_path"),
+          user_uid: taxon_change.dig("user_uid"),
+          organisation_slug: user.organisation_slug,
+        }
+      end.compact
+
+      content_item
+    end.compact
+
+    content_items
+  end
+
+  def self.taxon_depth(taxon_hash, depth = 0)
+    if taxon_hash.has_key?("links") && taxon_hash["links"].blank?
+      depth
+    else
+      if taxon_hash.has_key? "links"
+        taxon_depth(taxon_hash["links"]["parent_taxons"].first, depth + 1)
+      elsif taxon_hash.has_key? "expanded_links"
+        taxon_depth(taxon_hash["expanded_links"]["parent_taxons"].first, depth + 1)
+      end
+    end
+  end
+end

--- a/lib/tagged_content_exporter.rb
+++ b/lib/tagged_content_exporter.rb
@@ -1,15 +1,8 @@
 class TaggedContentExporter
-  TRANSPORT_TAXON_ID = "a4038b29-b332-4f13-98b1-1c9709e216bc".freeze
   WEBSITE_ROOT = Plek.new.website_root
 
-  def self.call
-    new.content_items_with_taxons.compact
-  end
-
-  def initialize
-    @content_items = ProjectContentItem
-      .for_taxonomy_branch(TRANSPORT_TAXON_ID)
-      .done
+  def initialize(content_items)
+    @content_items = content_items
   end
 
   def content_items_with_taxons

--- a/lib/tagged_content_exporter.rb
+++ b/lib/tagged_content_exporter.rb
@@ -1,63 +1,73 @@
 class TaggedContentExporter
+  TRANSPORT_TAXON_ID = "a4038b29-b332-4f13-98b1-1c9709e216bc".freeze
+  WEBSITE_ROOT = Plek.new.website_root
+
   def self.call
-    transport_taxon_id = "a4038b29-b332-4f13-98b1-1c9709e216bc"
-    content_items = ProjectContentItem.for_taxonomy_branch(transport_taxon_id).done
-
-    content_items = content_items.map do |c|
-      puts c.content_id
-
-      content_item = {}
-      content_item["content_id"] = c.content_id
-      content_item["url"] = c.url.gsub("https://www.gov.uk", "")
-      response = Services.publishing_api.get_links(c.content_id)
-
-      if response.to_h["links"]["taxons"].blank?
-        puts "--FAIL no taxons in links hash"
-        next
-      end
-
-      content_item["taxons"] = response.to_h["links"]["taxons"].map do |taxon_id|
-        puts "--#{taxon_id}"
-
-        params = { source_content_ids: [c.content_id], link_types: ["taxons"] }
-        taxon_change = Services
-          .publishing_api
-          .get_links_changes(params)
-          .to_h["link_changes"]
-          .find { |link| link.dig("target", "content_id") == taxon_id }
-
-        if taxon_change.blank?
-          puts "--FAIL taxon_change is blank"
-          next
-        end
-
-        user = User.find_by(uid: taxon_change.dig("user_uid")) || User.new
-        taxon_hash = Services.publishing_api.get_expanded_links(taxon_id).to_h
-
-        {
-          content_id: taxon_id,
-          depth: self.taxon_depth(taxon_hash),
-          url: taxon_change.dig("target", "base_path"),
-          user_uid: taxon_change.dig("user_uid"),
-          organisation_slug: user.organisation_slug,
-        }
-      end.compact
-
-      content_item
-    end.compact
-
-    content_items
+    new.content_items_with_taxons.compact
   end
 
-  def self.taxon_depth(taxon_hash, depth = 0)
+  def initialize
+    @content_items = ProjectContentItem
+      .for_taxonomy_branch(TRANSPORT_TAXON_ID)
+      .done
+  end
+
+  def content_items_with_taxons
+    @content_items.map do |content_item|
+      {
+        content_id: content_item.content_id,
+        url: content_item.url.gsub(WEBSITE_ROOT, ""),
+        taxons: taxons_for(content_item).compact
+      }
+    end
+  end
+
+private
+
+  def taxons_for(content_item)
+    links = Services.publishing_api.get_links(content_item.content_id).to_h
+    (links.dig("links", "taxons") || []).map do |taxon_id|
+      {
+        content_id: taxon_id
+      }.merge(metadata_for_taxon(taxon_id, content_item.content_id))
+    end
+  end
+
+  def metadata_for_taxon(taxon_id, content_id)
+    metadata = taxon_links_change(taxon_id, content_id)
+
+    user = User.find_by(uid: metadata.dig("user_uid")) || User.new
+
+    {
+      depth: taxon_depth(taxon_id),
+      url: metadata.dig("target", "base_path"),
+      user_uid: metadata.dig("user_uid"),
+      organisation_slug: user.organisation_slug,
+    }
+  end
+
+  def taxon_links_change(taxon_id, content_id)
+    changes = Services
+      .publishing_api
+      .get_links_changes(source_content_ids: [content_id],
+                         link_types: ["taxons"])
+      .to_h["link_changes"]
+
+    changes.find { |link| link.dig("target", "content_id") == taxon_id } || {}
+  end
+
+  def taxon_depth(taxon_id)
+    calculate_taxon_depth(
+      Services.publishing_api.get_expanded_links(taxon_id).to_h
+    )
+  end
+
+  def calculate_taxon_depth(taxon_hash, depth = 0)
     if taxon_hash.has_key?("links") && taxon_hash["links"].blank?
       depth
     else
-      if taxon_hash.has_key? "links"
-        taxon_depth(taxon_hash["links"]["parent_taxons"].first, depth + 1)
-      elsif taxon_hash.has_key? "expanded_links"
-        taxon_depth(taxon_hash["expanded_links"]["parent_taxons"].first, depth + 1)
-      end
+      links = taxon_hash["expanded_links"] || taxon_hash["links"]
+      calculate_taxon_depth(links["parent_taxons"].first, depth + 1)
     end
   end
 end

--- a/lib/tasks/taxonomy/export_tagged_content.rake
+++ b/lib/tasks/taxonomy/export_tagged_content.rake
@@ -1,4 +1,5 @@
 require 'csv'
+require_relative '../../tagged_content_exporter'
 
 namespace :taxonomy do
   desc <<-DESC
@@ -36,5 +37,14 @@ namespace :taxonomy do
     end
 
     puts rows
+  end
+
+  desc "Export tagged content items with taxons and tagging metadata"
+  task export_tagged_content_with_taxons: :environment do
+    content_items = TaggedContentExporter.call
+
+    File.open(Rails.root.join("lib", "data", "tagged_content_items_with_taxon.json"), "w") do |f|
+      f.write(content_items.to_json)
+    end
   end
 end

--- a/lib/tasks/taxonomy/export_tagged_content.rake
+++ b/lib/tasks/taxonomy/export_tagged_content.rake
@@ -41,10 +41,18 @@ namespace :taxonomy do
 
   desc "Export tagged content items with taxons and tagging metadata"
   task export_tagged_content_with_taxons: :environment do
-    content_items = TaggedContentExporter.call
+    transport_taxon_id = "a4038b29-b332-4f13-98b1-1c9709e216bc".freeze
+
+    content_items = ProjectContentItem
+                      .for_taxonomy_branch(transport_taxon_id)
+                      .done
+
+    content_items_with_taxons = TaggedContentExporter
+                                  .new(content_items)
+                                  .content_items_with_taxons
 
     File.open(Rails.root.join("lib", "data", "tagged_content_items_with_taxon.json"), "w") do |f|
-      f.write(content_items.to_json)
+      f.write(content_items_with_taxons.to_json)
     end
   end
 end

--- a/spec/lib/tagged_content_exporter_spec.rb
+++ b/spec/lib/tagged_content_exporter_spec.rb
@@ -1,0 +1,81 @@
+require "rails_helper"
+require_relative "../../lib/tagged_content_exporter"
+
+RSpec.describe TaggedContentExporter do
+  describe "#content_items_with_taxons" do
+    it "returns the content_items" do
+      create(:user,
+             uid: "user-1234",
+             organisation_slug: "department-for-transport")
+
+      project = create(:project, taxonomy_branch: "a4038b29-b332-4f13-98b1-1c9709e216bc")
+
+      create(:project_content_item,
+             done: true,
+             project: project,
+             content_id: "1b99def9-7eaa-4fb4-a0d0-ea76f0c5c370",
+             url: "https://www.test.gov.uk/government/publications/great-western-franchise-2013")
+
+      publishing_api_has_links(
+        content_id: "1b99def9-7eaa-4fb4-a0d0-ea76f0c5c370",
+        links: {
+          taxons: [
+            "taxn-1234"
+          ]
+        }
+      )
+
+      stub_request(:get, "https://publishing-api.test.gov.uk/v2/links/changes?link_types%5B%5D=taxons&source_content_ids%5B%5D=1b99def9-7eaa-4fb4-a0d0-ea76f0c5c370")
+        .to_return(body: {
+          "link_changes" => [
+            {
+              "source" => {
+                "title" => "Great Western rail franchise 2011 and 2012: competition documentation",
+                "base_path" => "/government/publications/great-western-franchise-2013",
+                "content_id" => "1b99def9-7eaa-4fb4-a0d0-ea76f0c5c370"
+              },
+              "target" => {
+                "title" => "Rail procurement documents",
+                "base_path" => "/transport/rail-procurement-documents",
+                "content_id" => "taxn-1234"
+              },
+              "link_type" => "taxons",
+              "change" => "add",
+              "user_uid" => "user-1234",
+            }
+          ]
+        }.to_json)
+
+      publishing_api_has_expanded_links(
+        "content_id" => "taxn-1234",
+        "expanded_links" => {
+          "parent_taxons" => [
+            {
+              "content_id" => "taxn-prnt-9876",
+              "links" => {},
+            }
+          ]
+        }
+      )
+
+      expected_content_items = [
+        {
+          content_id: "1b99def9-7eaa-4fb4-a0d0-ea76f0c5c370",
+          url: "/government/publications/great-western-franchise-2013",
+          taxons: [
+            {
+              content_id: "taxn-1234",
+              depth: 1,
+              url: "/transport/rail-procurement-documents",
+              user_uid: "user-1234",
+              organisation_slug: "department-for-transport",
+            }
+          ],
+        }
+      ]
+
+      content_items = TaggedContentExporter.new.content_items_with_taxons
+      expect(content_items). to eq(expected_content_items)
+    end
+  end
+end

--- a/spec/lib/tagged_content_exporter_spec.rb
+++ b/spec/lib/tagged_content_exporter_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe TaggedContentExporter do
       project = create(:project, taxonomy_branch: "a4038b29-b332-4f13-98b1-1c9709e216bc")
 
       create(:project_content_item,
-             done: true,
              project: project,
              content_id: "1b99def9-7eaa-4fb4-a0d0-ea76f0c5c370",
              url: "https://www.test.gov.uk/government/publications/great-western-franchise-2013")
@@ -74,8 +73,11 @@ RSpec.describe TaggedContentExporter do
         }
       ]
 
-      content_items = TaggedContentExporter.new.content_items_with_taxons
-      expect(content_items). to eq(expected_content_items)
+      expect(
+        TaggedContentExporter
+          .new(ProjectContentItem.all)
+          .content_items_with_taxons
+      ). to eq(expected_content_items)
     end
   end
 end


### PR DESCRIPTION
For https://trello.com/c/cdMOOFtb/14-make-mini-tagathon-data-available-for-analysis

We add a rake task that writes out a JSON file with information about tagged content items for the Transport taxonomy (as tagged in the mini-tagathon). For each content item, we provide the following information:
```
  {
    "url": "/government/publications/great-western-franchise-2013",
    "content_id": "5c7ac403-7631-11e4-a3cb-005056011aef",
    "taxons": [
      {
        "organisation_slug": "department-for-transport",
        "user_uid": "5071c800-b495-012f-73f1-12313c09b582",
        "url": "/transport/rail-procurement-documents",
        "depth": 3,
        "content_id": "bd191af7-cb8b-47d5-bcd5-82e7f95fe96d"
      }
    ],
  }
```

Paired with @tomsabin 🎉 