### PR TITLE
Display suggested topic in 'flagged' filter view

### DIFF
--- a/app/views/projects/_content_item.html.erb
+++ b/app/views/projects/_content_item.html.erb
@@ -1,17 +1,19 @@
 <div class='content-item'>
   <%= simple_form_for content_item, url: project_content_item_path(content_item.project, content_item), remote: true, html: { data: { ref: content_item.id }, class: 'js-content-item-form content-item-form' } do |f| %>
     <%= token_tag %>
-    <h4>
-      <%= link_to content_item.title, content_item.url, data: {proxy_iframe: 'enabled', modal_url: content_item.proxied_url, toggle: 'modal', target: '#iframe_modal_id'} %>
-    </h4>
 
     <% if content_item.needs_help? %>
       <span class='label label-danger'><%= I18n.t('views.projects.flags.help-needed') %></span>
     <% elsif content_item.missing_topic? %>
       <span class='label label-danger'><%= I18n.t('views.projects.flags.missing-topic') %></span>
+      Suggested topic: <%= content_item.suggested_tags %>
     <% elsif content_item.done? %>
       <span class='label label-primary'>Done</span>
     <% end %>
+
+    <h4>
+      <%= link_to content_item.title, content_item.url, data: {proxy_iframe: 'enabled', modal_url: content_item.proxied_url, toggle: 'modal', target: '#iframe_modal_id'} %>
+    </h4>
 
     <p><%= content_item.description %></p>
     <%= f.input :taxons,

--- a/spec/features/flagging_a_content_item_spec.rb
+++ b/spec/features/flagging_a_content_item_spec.rb
@@ -15,8 +15,9 @@ RSpec.describe "flagging a content item" do
     given_there_is_a_project_with_a_content_item
     when_i_visit_the_project_page
     and_i_flag_the_first_content_item_as_missing_a_relevant_topic_and_i_suggest_a_new_term
-    then_them_content_item_should_be_flagged_as_missing_topic
-    and_there_should_be_an_associated_suggestion
+    and_i_apply_the_flagged_filter
+    then_the_content_item_should_be_flagged_as_missing_topic
+    and_the_suggested_topic_should_be_displayed
   end
 
   scenario "flagged content is labelled in table view" do
@@ -68,7 +69,7 @@ RSpec.describe "flagging a content item" do
 
   def and_i_apply_the_flagged_filter
     choose "Flagged"
-    click_button "Apply"
+    click_button "Apply filter"
   end
 
   def then_the_content_item_should_be_flagged_as_needs_help
@@ -87,12 +88,12 @@ RSpec.describe "flagging a content item" do
     click_button "Done"
   end
 
-  def then_them_content_item_should_be_flagged_as_missing_topic
-    expect(Project.first.content_items.first.missing_topic?).to be true
+  def then_the_content_item_should_be_flagged_as_missing_topic
+    expect(page).to have_content "Flagged: needs IA review"
   end
 
-  def and_there_should_be_an_associated_suggestion
-    expect(Project.first.content_items.first.suggested_tags).to eql "cool new topic"
+  def and_the_suggested_topic_should_be_displayed
+    expect(page).to have_content "Suggested topic: cool new topic"
   end
 
   def then_the_flagged_content_items_should_be_labelled_correctly


### PR DESCRIPTION
When users have flagged content items with a suggested topic, they are
not able to see their input after submitting the form. We now expose
this information in the 'flagged' filter view so that they can be
reminded of the suggested topic.

[Trello](https://trello.com/c/P0HJpWng/39-show-suggested-topic-in-flagged-view)