### PR TITLE
Rename BulkTagger to TaxonTagger to avoid confusion

### DIFF
--- a/app/assets/javascripts/taxon-tagger.js
+++ b/app/assets/javascripts/taxon-tagger.js
@@ -2,7 +2,7 @@
   "use strict";
 
   // Constructor
-  Modules.BulkTagger = function(taxons) {
+  Modules.TaxonTagger = function(taxons) {
     this.selectors = {
       tag_input_element: '.js_bulk_tagger_input',
       bulk_tagger_form: '.js-bulk-tagger-form',
@@ -24,7 +24,7 @@
     }
   };
 
-  Modules.BulkTagger.prototype = {
+  Modules.TaxonTagger.prototype = {
 
     /*
      * Initializes each content-item tagging form with Select2 and auto-save.

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -54,10 +54,10 @@
 </div>
 
 <script>
-  var bulkTagger = new GOVUKAdmin.Modules.BulkTagger(<%= taxons.to_json.html_safe %>);
-  bulkTagger.start_individual_taggers($('.tagathon-project'));
+  var taxonTagger = new GOVUKAdmin.Modules.TaxonTagger(<%= taxons.to_json.html_safe %>);
+  taxonTagger.start_individual_taggers($('.tagathon-project'));
 
   <% if project.bulk_tagging_enabled? %>
-    bulkTagger.start_bulk_tagger($('.tagathon-project'));
+    taxonTagger.start_bulk_tagger($('.tagathon-project'));
   <% end %>
 </script>


### PR DESCRIPTION
We should avoid using the BulkTagger module name when it is not
directly tied to the "bulk tagger" interface that is hidden by default.