### PR TITLE
Add comment field for need help option

### DIFF
--- a/app/assets/stylesheets/tagathon_project.scss
+++ b/app/assets/stylesheets/tagathon_project.scss
@@ -89,3 +89,11 @@
     padding: 5px 0 10px 15px;
   }
 }
+
+.flagged-for-needs-help {
+  display: flex;
+
+  .needs-help-comment {
+    padding-left: 5px;
+  }
+}

--- a/app/assets/stylesheets/tagathon_project.scss
+++ b/app/assets/stylesheets/tagathon_project.scss
@@ -90,10 +90,10 @@
   }
 }
 
-.flagged-for-needs-help {
+.danger-label-with-text {
   display: flex;
 
-  .needs-help-comment {
+  .additional-text {
     padding-left: 5px;
   }
 }

--- a/app/controllers/project_content_items_controller.rb
+++ b/app/controllers/project_content_items_controller.rb
@@ -54,7 +54,7 @@ private
   end
 
   def flag_params
-    params.require(:project_content_item).permit(:flag, :suggested_tags)
+    params.require(:project_content_item).permit(:flag, :suggested_tags, :need_help_comment)
   end
 
   def bulk_params

--- a/app/views/project_content_items/_flags.html.erb
+++ b/app/views/project_content_items/_flags.html.erb
@@ -9,9 +9,14 @@
     <div class="modal-body flag-for-review">
       <div class='radio'>
         <label>
-          <%= f.radio_button :flag, "needs_help", required: true %>
+          <%= f.radio_button :flag, "needs_help", required: true, data: { target: 'need-help-comment' } %>
           I need help tagging this
         </label>
+      </div>
+
+      <div id='need-help-comment' class='form-group add-top-margin add-left-border'>
+        <%= f.label :need_help_comment, "Comment (optional)" %>
+        <%= f.text_field :need_help_comment, class: 'form-control input-md-4' %>
       </div>
 
       <div class='radio'>

--- a/app/views/projects/_content_item.html.erb
+++ b/app/views/projects/_content_item.html.erb
@@ -3,7 +3,15 @@
     <%= token_tag %>
 
     <% if content_item.needs_help? %>
-      <span class='label label-danger'><%= I18n.t('views.projects.flags.help-needed') %></span>
+      <div class='flagged-for-needs-help'>
+        <div>
+          <span class='label label-danger'><%= I18n.t('views.projects.flags.help-needed') %></span>
+        </div>
+
+        <% if content_item.need_help_comment.present? %>
+            <span class="needs-help-comment">Comment: <%= content_item.need_help_comment %></span>
+        <% end %>
+      </div>
     <% elsif content_item.missing_topic? %>
       <span class='label label-danger'><%= I18n.t('views.projects.flags.missing-topic') %></span>
       Suggested topic: <%= content_item.suggested_tags %>
@@ -16,6 +24,7 @@
     </h4>
 
     <p><%= content_item.description %></p>
+
     <%= f.input :taxons,
       placeholder: 'Choose one...',
       label: false,

--- a/app/views/projects/_content_item.html.erb
+++ b/app/views/projects/_content_item.html.erb
@@ -3,18 +3,17 @@
     <%= token_tag %>
 
     <% if content_item.needs_help? %>
-      <div class='flagged-for-needs-help'>
-        <div>
-          <span class='label label-danger'><%= I18n.t('views.projects.flags.help-needed') %></span>
-        </div>
-
-        <% if content_item.need_help_comment.present? %>
-            <span class="needs-help-comment">Comment: <%= content_item.need_help_comment %></span>
-        <% end %>
-      </div>
+      <%= render partial: "danger_label_with_text", locals: {
+        label_text: I18n.t('views.projects.flags.help-needed'),
+        additional_text_label: "Comment",
+        additional_text: content_item.need_help_comment,
+      } %>
     <% elsif content_item.missing_topic? %>
-      <span class='label label-danger'><%= I18n.t('views.projects.flags.missing-topic') %></span>
-      Suggested topic: <%= content_item.suggested_tags %>
+      <%= render partial: "danger_label_with_text", locals: {
+        label_text: I18n.t('views.projects.flags.missing-topic'),
+        additional_text_label: "Suggested topic",
+        additional_text: content_item.suggested_tags,
+      } %>
     <% elsif content_item.done? %>
       <span class='label label-primary'>Done</span>
     <% end %>

--- a/app/views/projects/_danger_label_with_text.html.erb
+++ b/app/views/projects/_danger_label_with_text.html.erb
@@ -1,0 +1,9 @@
+<div class='danger-label-with-text'>
+  <div>
+    <span class='label label-danger'><%= label_text %></span>
+  </div>
+
+  <% if additional_text.present? %>
+      <span class="additional-text"><%= additional_text_label %>: <%= additional_text %></span>
+  <% end %>
+</div>

--- a/db/migrate/20171013133107_add_need_help_comment_to_project_content_item.rb
+++ b/db/migrate/20171013133107_add_need_help_comment_to_project_content_item.rb
@@ -1,0 +1,5 @@
+class AddNeedHelpCommentToProjectContentItem < ActiveRecord::Migration[5.0]
+  def change
+    add_column :project_content_items, :need_help_comment, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -19,13 +19,14 @@ ActiveRecord::Schema.define(version: 20171016093424) do
     t.string   "url"
     t.string   "title"
     t.string   "description"
-    t.datetime "created_at",                     null: false
-    t.datetime "updated_at",                     null: false
+    t.datetime "created_at",                        null: false
+    t.datetime "updated_at",                        null: false
     t.integer  "project_id"
-    t.boolean  "done",           default: false
+    t.boolean  "done",              default: false
     t.uuid     "content_id"
     t.integer  "flag"
     t.string   "suggested_tags"
+    t.text     "need_help_comment"
     t.index ["content_id"], name: "index_project_content_items_on_content_id", unique: true, using: :btree
     t.index ["flag"], name: "index_project_content_items_on_flag", using: :btree
     t.index ["project_id"], name: "index_project_content_items_on_project_id", using: :btree

--- a/spec/features/flagging_a_content_item_spec.rb
+++ b/spec/features/flagging_a_content_item_spec.rb
@@ -8,7 +8,11 @@ RSpec.describe "flagging a content item" do
     given_there_is_a_project_with_a_content_item
     when_i_visit_the_project_page
     and_i_flag_the_first_content_item_as_i_need_help
+    and_i_enter_a_comment_to_explain_why_i_need_help
+    and_i_submit_my_flag_for_review_choice
+    and_i_apply_the_flagged_filter
     then_the_content_item_should_be_flagged_as_needs_help
+    and_the_need_help_comment_should_be_displayed
   end
 
   scenario "flagging a content item and suggesting a new term", js: true do
@@ -63,6 +67,14 @@ RSpec.describe "flagging a content item" do
   def and_i_flag_the_first_content_item_as_i_need_help
     click_link 'Flag for review'
     choose "I need help tagging this"
+  end
+
+  def and_i_enter_a_comment_to_explain_why_i_need_help
+    expect(page).to have_field("Comment (optional)")
+    fill_in "Comment (optional)", with: "I don't know what I'm doing"
+  end
+
+  def and_i_submit_my_flag_for_review_choice
     click_button "Continue"
     wait_for_ajax
   end
@@ -73,7 +85,7 @@ RSpec.describe "flagging a content item" do
   end
 
   def then_the_content_item_should_be_flagged_as_needs_help
-    expect(Project.first.content_items.first.needs_help?).to be true
+    expect(page).to have_content "Flagged: needs publisher review"
   end
 
   def and_i_flag_the_first_content_item_as_missing_a_relevant_topic_and_i_suggest_a_new_term
@@ -103,5 +115,9 @@ RSpec.describe "flagging a content item" do
 
   def then_the_content_item_should_no_longer_be_flagged
     expect(page).not_to have_content 'Flagged: needs publisher review'
+  end
+
+  def and_the_need_help_comment_should_be_displayed
+    expect(page).to have_content "Comment: I don't know what I'm doing"
   end
 end


### PR DESCRIPTION
For https://trello.com/c/CJRdMIYn/40-allow-text-comments-to-be-left-when-a-user-needs-help-tagging-this-and-display-this-comment-in-flagged-view

See screenshots below

------------------------------------------------------

## Before
<img width="545" alt="screen shot 2017-10-13 at 15 40 50" src="https://user-images.githubusercontent.com/5112255/31551675-2e8cf1aa-b02d-11e7-8381-43264fd47bd4.png">

<img width="713" alt="screen shot 2017-10-13 at 15 42 27" src="https://user-images.githubusercontent.com/5112255/31551672-2e270a34-b02d-11e7-8c7c-1e5dd400ba81.png">


## After

![screen shot 2017-10-16 at 14 50 43](https://user-images.githubusercontent.com/5112255/31615575-e124fdb6-b281-11e7-9bd6-2f6473e0facd.png)

### Short comment

![screen shot 2017-10-16 at 12 22 56](https://user-images.githubusercontent.com/5112255/31609607-cdb22ec6-b26c-11e7-8715-f0254394112e.png)

### Longer comment

![screen shot 2017-10-16 at 12 22 40](https://user-images.githubusercontent.com/5112255/31609608-cdc715e8-b26c-11e7-92cd-ccef77f9a11e.png)
