### PR TITLE
Add unique constraint on ProjectContentItem content_id

### DIFF
--- a/db/migrate/20171016093424_add_unique_constraint_to_project_content_items_content_id.rb
+++ b/db/migrate/20171016093424_add_unique_constraint_to_project_content_items_content_id.rb
@@ -1,0 +1,14 @@
+class AddUniqueConstraintToProjectContentItemsContentId < ActiveRecord::Migration[5.0]
+  def change
+    # Remove duplicate ProjectContentItem records. These were introduced when
+    # another project was created with content items that were already tagged
+    # in a previous import/project.
+
+    execute <<-SQL
+      DELETE FROM project_content_items
+      WHERE id IN (3896, 3883, 3825, 3773, 3752, 3880, 3909, 3987, 3810, 3927, 1875)
+    SQL
+
+    add_index :project_content_items, :content_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170911152904) do
+ActiveRecord::Schema.define(version: 20171016093424) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -26,6 +26,7 @@ ActiveRecord::Schema.define(version: 20170911152904) do
     t.uuid     "content_id"
     t.integer  "flag"
     t.string   "suggested_tags"
+    t.index ["content_id"], name: "index_project_content_items_on_content_id", unique: true, using: :btree
     t.index ["flag"], name: "index_project_content_items_on_flag", using: :btree
     t.index ["project_id"], name: "index_project_content_items_on_project_id", using: :btree
   end


### PR DESCRIPTION
There should be a one-to-one mapping between the ProjectContentItem
and Content Item. However, we currently have duplicate records in our
database. At this time of writing there are 11 duplicate records; 8
are records with different titles (previous editions) and 3 are plain
duplicates.

---

This has only been ran on integration, please could somebody confirm results on staging.

```
ProjectContentItem.pluck(:content_id).count
# => 4024
ProjectContentItem.pluck(:content_id).uniq.count
# => 4013
```

```
ProjectContentItem.select(:content_id).group(:content_id).having("count(*) > 1").count
#=>
  {
    "df6c80b8-1562-4181-a4a2-9baba863113a"=>2,
    "8705df08-d052-4284-bee7-5f2f0c580885"=>2,
    "cbb1b14d-4133-4f8f-a06e-e0fcc91808dd"=>2,
    "8e270cae-6443-4911-ad57-46c08b99d847"=>2,
    "c0c74a2f-6747-4040-9c02-0d8f549bfc4a"=>2,
    "66a5b1c8-f6f7-4bb9-85cc-c8b142ca8e7a"=>2,
    "ec8cefc1-6efe-4315-97b1-846269464d8e"=>2,
    "1cde49a9-4deb-47e5-bcca-1d2e41a8f9a3"=>2,
    
    "e5b0d75c-d177-40b6-88ad-9dcf91047b6c"=>2,
    "b2f67341-3f8f-44c6-9e5f-ad7714163fe9"=>2,
    "f3ca6fa5-4250-497f-a3e6-30281d76573d"=>2,
  }
```

<details>
  <summary>Code used to find IDs to delete duplicate records</summary>

```ruby
duplicate_content_ids = ProjectContentItem.select(:content_id).group(:content_id).having("count(*) > 1").count.keys

correct_titles_from_search = Services.rummager.search(
  count: 1000,
  start: 0,
  fields: 'content_id,title',
  filter_content_id: duplicate_content_ids
).to_h["results"].map { |hash| hash.slice("content_id", "title") }

content_items_by_content_id = ProjectContentItem.where(content_id: duplicate_content_ids).group_by { |r| r.content_id }

project_content_item_ids_to_delete = []

content_items_by_content_id.each do |content_id, content_items|
  content_item_from_search = correct_titles_from_search.find { |h| h["content_id"] == content_id }
  # Remove record that has the latest title from the "to delete" array
  content_items.delete_if { |r| r.title == content_item_from_search["title"] }
  project_content_item_ids_to_delete += content_items
end

# These 3 weren't deleted because their titles were the same:
[
  "e5b0d75c-d177-40b6-88ad-9dcf91047b6c",
  "b2f67341-3f8f-44c6-9e5f-ad7714163fe9",
  "f3ca6fa5-4250-497f-a3e6-30281d76573d"
]

# Keep the most recent and delete the other one
duplicate_titles = ProjectContentItem.select(:content_id).group(:content_id).having("count(*) > 1").count.keys

duplicate_titles.each do |content_id|
  project_content_item_ids_to_delete += ProjectContentItem.where(content_id: content_id).order(created_at: :desc).offset(1)
end

puts project_content_item_ids_to_delete.pluck(:id).uniq

```

</details>