### PR TITLE
Update model names in migrations after namespacing

### DIFF
--- a/db/migrate/20160808210736_add_state_to_tagging_spreadsheets.rb
+++ b/db/migrate/20160808210736_add_state_to_tagging_spreadsheets.rb
@@ -2,7 +2,7 @@ class AddStateToTaggingSpreadsheets < ActiveRecord::Migration
   def change
     # At this point in development we can just clear out all the spreadsheets
     # so we don't have to bother with setting an initial state.
-    TaggingSpreadsheet.delete_all
+    BulkTagging::TaggingSpreadsheet.delete_all
     add_column :tagging_spreadsheets, :state, :string, null: false
     add_column :tagging_spreadsheets, :error_message, :text
   end

--- a/db/migrate/20160811160752_set_columns_to_not_null.rb
+++ b/db/migrate/20160811160752_set_columns_to_not_null.rb
@@ -1,6 +1,6 @@
 class SetColumnsToNotNull < ActiveRecord::Migration
   def change
-    TaggingSpreadsheet.delete_all
+    BulkTagging::TaggingSpreadsheet.delete_all
 
     change_column_null :tag_mappings, :tagging_spreadsheet_id, false
     change_column_null :tag_mappings, :content_base_path, false

--- a/db/migrate/20160815093345_add_state_and_message_to_tag_mappings.rb
+++ b/db/migrate/20160815093345_add_state_and_message_to_tag_mappings.rb
@@ -1,6 +1,6 @@
 class AddStateAndMessageToTagMappings < ActiveRecord::Migration
   def change
-    TagMapping.delete_all
+    BulkTagging::TagMapping.delete_all
     add_column :tag_mappings, :state, :string, null: false
     add_column :tag_mappings, :message, :string
   end

--- a/db/migrate/20160915141004_change_existing_messages_to_an_array_on_tag_mappings.rb
+++ b/db/migrate/20160915141004_change_existing_messages_to_an_array_on_tag_mappings.rb
@@ -1,7 +1,7 @@
 class ChangeExistingMessagesToAnArrayOnTagMappings < ActiveRecord::Migration
   def change
-    TagMapping.transaction do
-      TagMapping.all.each do |tag_mapping|
+    BulkTagging::TagMapping.transaction do
+      BulkTagging::TagMapping.all.each do |tag_mapping|
         current_messages = tag_mapping.messages
         # We have stored messages in the database as strings separated by ".". The
         # reason we are not splitting existing messages by "." here is because we


### PR DESCRIPTION
Running the migrations on a new database fails from these 4 migration files because they're incorrectly referencing a model that has presumably had the `BulkTagging` namespace applied to them since they were created.