### PR TITLE
Add uncurated content items to legacy taxonomy

### DIFF
--- a/app/services/legacy_taxonomy/client/publishing_api.rb
+++ b/app/services/legacy_taxonomy/client/publishing_api.rb
@@ -14,6 +14,11 @@ module LegacyTaxonomy
           SecureRandom.uuid
         end
 
+        def get_linked_items(content_id, link_type)
+          linked_items = client.get_linked_items(content_id, link_type: link_type, fields: %i[base_path content_id])
+          linked_items.map { |item| { 'link' => item['base_path'], 'content_id' => item['content_id'] } }
+        end
+
         def content_id_for_base_path(base_path)
           client.lookup_content_id(base_path: base_path)
         end

--- a/lib/tasks/legacy_taxonomy.rake
+++ b/lib/tasks/legacy_taxonomy.rake
@@ -18,9 +18,7 @@ namespace :legacy_taxonomy do
     task generate_taxons: :environment do
       taxonomy = LegacyTaxonomy::ThreeLevelTaxonomy.new('/imported-browse',
                                                         title: 'Imported Mainstream Browse',
-                                                        first_level_key: 'top_level_browse_pages',
-                                                        second_level_key: 'second_level_browse_pages',
-                                                        base_path: '/browse').to_taxonomy_branch
+                                                        type: LegacyTaxonomy::ThreeLevelTaxonomy::MAINSTREAM).to_taxonomy_branch
       LegacyTaxonomy::Yamlizer.new('tmp/msbp.yml').write(taxonomy)
     end
 
@@ -36,10 +34,8 @@ namespace :legacy_taxonomy do
     desc "Generates structure for Topic taxonomy at www.gov.uk/browse"
     task generate_taxons: :environment do
       taxonomy = LegacyTaxonomy::ThreeLevelTaxonomy.new('/imported-topic',
-                                                        base_path: '/topic',
-                                                        first_level_key: 'children',
-                                                        second_level_key: 'children',
-                                                        title: 'Imported Topic').to_taxonomy_branch
+                                                        title: 'Topics',
+                                                        type: LegacyTaxonomy::ThreeLevelTaxonomy::TOPIC).to_taxonomy_branch
       LegacyTaxonomy::Yamlizer.new('tmp/topic.yml').write(taxonomy)
     end
 

--- a/spec/services/legacy_taxonomy/client/publishing_api_spec.rb
+++ b/spec/services/legacy_taxonomy/client/publishing_api_spec.rb
@@ -3,6 +3,12 @@ require 'rails_helper'
 RSpec.describe LegacyTaxonomy::Client::PublishingApi do
   subject { described_class }
 
+  it "gets linked items" do
+    stub_request(:get, "https://publishing-api.test.gov.uk/v2/linked/content_id?fields%5B%5D=base_path&fields%5B%5D=content_id&link_type=link_type")
+      .to_return(status: 200, body: [{ 'base_path' => 'path/to/content', 'content_id' => 'content_id' }].to_json)
+    expect(subject.get_linked_items('content_id', 'link_type')).to eq([{ 'link' => 'path/to/content', 'content_id' => 'content_id' }])
+  end
+
   describe "proxies to a publishing api client" do
     let(:mock_client) { instance_double(GdsApi::PublishingApiV2) }
 


### PR DESCRIPTION
A number of links associated with a 2nd level taxon show up in collections publisher as 'Uncurated Items'. These have now been included in the pages tagged to the 2nd level taxon.

Trello: https://trello.com/c/4FAdOmiI/24-revisit-the-legacy-taxonomy-work-done-at-the-beginning-of-q2