### PR TITLE
Make 'suggested tags' field optional

### DIFF
--- a/app/queries/flagged_content_query.rb
+++ b/app/queries/flagged_content_query.rb
@@ -10,6 +10,20 @@ class FlaggedContentQuery
   end
 
   def items
+    if params[:flagged] == "missing_topic"
+      project_content_items_with_suggested_tags_only
+    else
+      project_content_items
+    end
+  end
+
+private
+
+  def project_content_items_with_suggested_tags_only
+    project_content_items.select { |c| c.suggested_tags.present? }
+  end
+
+  def project_content_items
     ProjectContentItem
       .for_taxonomy_branch(params[:taxonomy_branch])
       .flagged_with(params[:flagged])

--- a/app/views/project_content_items/_flags.html.erb
+++ b/app/views/project_content_items/_flags.html.erb
@@ -27,7 +27,7 @@
       </div>
 
       <div id='suggested-tags' class='form-group add-top-margin add-left-border'>
-        <%= f.label :suggested_tags, "Suggest a new topic" %>
+        <%= f.label :suggested_tags, "Suggest a new topic (optional)" %>
         <%= f.text_field :suggested_tags, class: 'form-control input-md-4' %>
       </div>
     </div>

--- a/app/views/project_content_items/flags.js.erb
+++ b/app/views/project_content_items/flags.js.erb
@@ -2,12 +2,3 @@ $('#flags-modal').html("<%= escape_javascript(render partial: 'flags', locals: l
 
 var radioToggle = new GOVUKAdmin.Modules.RadioToggle;
 radioToggle.start($('#flags-modal'));
-
-$('#flags-modal input[type=radio]').change(function() {
-  var $input = $('#flags-modal input[type=text]#project_content_item_suggested_tags');
-  if(this.value == 'missing_topic') {
-    $input.attr('required', true);
-  } else {
-    $input.attr('required', false);
-  }
-});

--- a/spec/queries/flagged_content_query_spec.rb
+++ b/spec/queries/flagged_content_query_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+RSpec.describe FlaggedContentQuery do
+  describe '#items' do
+    let(:project) { create(:project) }
+    let!(:item_needs_help) do
+      create(:project_content_item,
+             :flagged_needs_help,
+             project: project)
+    end
+    let!(:item_missing_topic) do
+      create(:project_content_item,
+             :flagged_missing_topic,
+             project: project,
+             suggested_tags: "Better Taxon Suggestion")
+    end
+    let!(:item_missing_topic_with_missing_suggested_tag) do
+      create(:project_content_item,
+             :flagged_missing_topic,
+             project: project,
+             suggested_tags: "")
+    end
+
+    context "when querying for content items flagged with needs help" do
+      it "returns the flagged content items" do
+        params = {
+          flagged: "needs_help",
+          taxonomy_branch: project.taxonomy_branch,
+        }
+
+        expect(FlaggedContentQuery.new(params).items).to include(item_needs_help)
+      end
+    end
+
+    context "when querying for content items flagged with missing topic" do
+      it "returns the flagged content items with suggested tags" do
+        params = {
+          flagged: "missing_topic",
+          taxonomy_branch: project.taxonomy_branch,
+        }
+
+        expect(FlaggedContentQuery.new(params).items).to include(item_missing_topic)
+      end
+
+      it "does not return content items with missing suggested tags" do
+        params = {
+          flagged: "missing_topic",
+          taxonomy_branch: project.taxonomy_branch,
+        }
+
+        expect(FlaggedContentQuery.new(params).items).to_not include(item_missing_topic_with_missing_suggested_tag)
+      end
+    end
+  end
+end


### PR DESCRIPTION
For https://trello.com/c/4nQoaMMe/60-tag-suggestions-are-no-longer-mandatory-if-a-tagger-says-there-is-no-suitable-topic

Makes the 'suggested tags' field when flagging a ProjectContentItem as 'there's not relevant topic' optional. This was enforced via JavaScript so we just remove the relevant lines.

We also don't want flagged ContentItems that have no suggested taxons to
show up on the index page. This commit updates the FlaggedContentQuery
class to not return those content items. We still need to return all
content items that are flagged with "needs_help".

Since this makes the FlaggedContentQuery more complex, we add a test
that documents this behaviour.