### PR TITLE
Stop retries of LookupContentIdWorker

### DIFF
--- a/app/workers/lookup_content_id_worker.rb
+++ b/app/workers/lookup_content_id_worker.rb
@@ -5,5 +5,8 @@ class LookupContentIdWorker
     content_item = ProjectContentItem.find(project_content_item_id)
     id = Services.publishing_api.lookup_content_id(base_path: content_item.base_path)
     content_item.update_attribute(:content_id, id)
+  rescue ActiveRecord::RecordNotFound => ex
+    # This is to prevent a lot of retries when a project is deleted before instances of this worker are finished.
+    logger.info ex.message
   end
 end

--- a/spec/workers/lookup_content_id_worker_spec.rb
+++ b/spec/workers/lookup_content_id_worker_spec.rb
@@ -29,5 +29,9 @@ RSpec.describe LookupContentIdWorker do
       content_item.reload
       expect(content_item.content_id).to eql content_item_id
     end
+
+    it "does not raise an error if the content item cannot be found" do
+      expect { LookupContentIdWorker.new.perform(123) }.to_not raise_error
+    end
   end
 end


### PR DESCRIPTION
Stop Sidekiq spawning lots of retries when a project is deleted before related instances of LookupContentIdWorker have completed.

Trello: https://trello.com/c/MBjydZOp/64-dont-retry-lookupcontentidworker-if-the-projectcontentitem-cannot-be-found
