### PR TITLE
Allow TaxonomySize #max_size to handle empty array

### DIFF
--- a/app/services/taxonomy/taxonomy_size.rb
+++ b/app/services/taxonomy/taxonomy_size.rb
@@ -21,7 +21,7 @@ module Taxonomy
     def max_size
       @_max_size ||= begin
         max_size_in_tree = lambda do |taxon|
-          if taxon[:children].nil?
+          if taxon[:children].blank?
             taxon[:size]
           else
             [

--- a/spec/features/flagging_a_content_item_spec.rb
+++ b/spec/features/flagging_a_content_item_spec.rb
@@ -91,6 +91,7 @@ RSpec.describe "flagging a content item" do
   def and_i_flag_the_first_content_item_as_missing_a_relevant_topic_and_i_suggest_a_new_term
     click_link 'Flag for review'
     choose "There's no relevant topic for this"
+    expect(page).to have_field("Suggest a new topic")
     fill_in "Suggest a new topic", with: "cool new topic"
     click_button "Continue"
     wait_for_ajax

--- a/spec/services/taxonomy/taxonomy_size_spec.rb
+++ b/spec/services/taxonomy/taxonomy_size_spec.rb
@@ -38,6 +38,56 @@ RSpec.describe Taxonomy::TaxonomySize do
     end
   end
 
+  describe '#max_size' do
+    let(:content_item) do
+      double(
+        content_id: 'b92079ac-f1d9-44c8-bc78-772d54377ee2',
+        title: 'title',
+      )
+    end
+
+    it "returns the max size of the tree" do
+      tree = {
+        name: 'title',
+        content_id: 'b92079ac-f1d9-44c8-bc78-772d54377ee2',
+        size: 100,
+        children: [
+          {
+            name: 'foo',
+            content_id: '720f650a-331f-4575-9c56-376d1eaa9ca0',
+            size: 200,
+            children: [
+              {
+                name: 'bar',
+                content_id: 'a544d48b-1e9e-47fb-b427-7a987c658c14',
+                size: 300,
+              }
+            ]
+          }
+        ]
+      }
+
+      size = Taxonomy::TaxonomySize.new(content_item)
+      allow(size).to receive(:nested_tree).and_return(tree)
+
+      expect(size.max_size).to eq(300)
+    end
+
+    it "returns the max size of the tree for no children" do
+      tree = {
+        name: 'title',
+        content_id: 'b92079ac-f1d9-44c8-bc78-772d54377ee2',
+        size: 100,
+        children: [],
+      }
+
+      size = Taxonomy::TaxonomySize.new(content_item)
+      allow(size).to receive(:nested_tree).and_return(tree)
+
+      expect(size.max_size).to eq(100)
+    end
+  end
+
   SEARCH_RESULT_FIXTURE = {
     results: [],
     total: 334_263,


### PR DESCRIPTION
For https://trello.com/c/2aDxBoqF/84-fix-the-corporate-information-list-visualisation-in-content-tagger

It's possible for `TaxonomySize#add_children_recursively` to return
an empty array, as was the case with the Corporate Information list.
Previously this would error as it would eventually try to run the
`max` method on `nil`. Instead the base case should trigger for empty
arrays as well.

We add a test for the `max_size` method to cover this edge case.