### PR TITLE
Add abbreviation to internal name for legacy taxonomies

### DIFF
--- a/app/services/legacy_taxonomy/policy_area_taxonomy.rb
+++ b/app/services/legacy_taxonomy/policy_area_taxonomy.rb
@@ -4,6 +4,7 @@ module LegacyTaxonomy
 
     BASE_PATH = '/government/topics'.freeze
     TITLE = 'Policy Areas'.freeze
+    ABBREVIATION = "PA".freeze
 
     def initialize(path_prefix)
       @path_prefix = path_prefix
@@ -13,6 +14,7 @@ module LegacyTaxonomy
     def to_taxonomy_branch
       @taxon = TaxonData.new(
         title: TITLE,
+        internal_name: "#{TITLE} [#{ABBREVIATION}]",
         description: TITLE + ' Taxonomy',
         legacy_content_id: root_content_id,
         path_slug: BASE_PATH,
@@ -30,6 +32,7 @@ module LegacyTaxonomy
       policy_areas.map do |policy_area|
         TaxonData.new(
           title: policy_area['title'],
+          internal_name: "#{policy_area['title']} [#{ABBREVIATION}]",
           description: policy_area['description'],
           path_slug: policy_area['link'],
           path_prefix: path_prefix,

--- a/app/services/legacy_taxonomy/taxon_data.rb
+++ b/app/services/legacy_taxonomy/taxon_data.rb
@@ -2,6 +2,7 @@ module LegacyTaxonomy
   class TaxonData
     attr_accessor(
       :title,
+      :internal_name,
       :description,
       :legacy_content_id,
       :path_slug,
@@ -33,6 +34,7 @@ module LegacyTaxonomy
     def hash_for_publishing_api
       {
         title: title,
+        internal_name: internal_name,
         description: description,
         path_slug: path_slug,
         path_prefix: path_prefix,

--- a/app/services/legacy_taxonomy/three_level_taxonomy.rb
+++ b/app/services/legacy_taxonomy/three_level_taxonomy.rb
@@ -6,14 +6,16 @@ module LegacyTaxonomy
       base_path: '/browse',
       first_level_key: 'top_level_browse_pages',
       second_level_key: 'second_level_browse_pages',
-      link_type: 'mainstream_browse_pages'
+      link_type: 'mainstream_browse_pages',
+      abbreviation: "M",
     }.freeze
 
     TOPIC = {
       base_path: '/topic',
       first_level_key: 'children',
       second_level_key: 'children',
-      link_type: 'topics'
+      link_type: 'topics',
+      abbreviation: "T",
     }.freeze
 
     def initialize(path_prefix, type:, title:)
@@ -23,6 +25,7 @@ module LegacyTaxonomy
       @first_level_key = type[:first_level_key]
       @second_level_key = type[:second_level_key]
       @link_type = type[:link_type]
+      @abbreviation = type[:abbreviation]
     end
 
     def to_taxonomy_branch
@@ -30,6 +33,7 @@ module LegacyTaxonomy
 
       TaxonData.new(
         title: @title,
+        internal_name: "#{@title} [#{@abbreviation}]",
         description: '',
         legacy_content_id: root_content_id,
         path_slug: @base_path,
@@ -58,6 +62,7 @@ module LegacyTaxonomy
         .map do |browse_page|
           TaxonData.new(
             title: browse_page['title'],
+            internal_name: "#{browse_page['title']} [#{@abbreviation}]",
             description: browse_page['description'],
             legacy_content_id: browse_page['content_id'],
             path_slug: browse_page['base_path'],
@@ -75,6 +80,7 @@ module LegacyTaxonomy
           content_id = browse_page['content_id']
           TaxonData.new(
             title: browse_page['title'],
+            internal_name: "#{browse_page['title']} [#{@abbreviation}]",
             description: browse_page['description'],
             legacy_content_id: content_id,
             path_slug: base_path,
@@ -91,6 +97,7 @@ module LegacyTaxonomy
           path_slug = parent_taxon.path_slug + '/' + group['name'].parameterize
           TaxonData.new(
             title: group['name'],
+            internal_name: "#{group['name']} [#{@abbreviation}]",
             description: group['name'],
             path_slug: path_slug,
             path_prefix: path_prefix,

--- a/spec/services/legacy_taxonomy/client/policy_area_taxonomy_spec.rb
+++ b/spec/services/legacy_taxonomy/client/policy_area_taxonomy_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe LegacyTaxonomy::PolicyAreaTaxonomy do
 
       it 'returns the root browse taxon' do
         expect(result.title).to eq 'Policy Areas'
+        expect(result.internal_name).to eq 'Policy Areas [PA]'
         expect(result.base_path).to eq '/foo/government/topics'
         expect(result.child_taxons).to be_empty
       end
@@ -33,6 +34,7 @@ RSpec.describe LegacyTaxonomy::PolicyAreaTaxonomy do
       it 'returns the child taxon' do
         child_taxon = result.child_taxons.first
         expect(child_taxon.title).to eq(example_policy_area['title'])
+        expect(child_taxon.internal_name).to eq("#{example_policy_area['title']} [PA]")
         expect(child_taxon.description).to eq(example_policy_area['description'])
         expect(child_taxon.path_slug).to eq(example_policy_area['link'])
         expect(child_taxon.path_prefix).to eq('/foo')

--- a/spec/services/legacy_taxonomy/three_level_taxonomy_spec.rb
+++ b/spec/services/legacy_taxonomy/three_level_taxonomy_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe LegacyTaxonomy::ThreeLevelTaxonomy do
 
       it 'returns the root browse taxon' do
         expect(result.title).to eq 'taxonomy title'
+        expect(result.internal_name).to eq 'taxonomy title [M]'
         expect(result.base_path).to eq '/foo/browse'
         expect(result.child_taxons).to be_empty
       end
@@ -35,6 +36,7 @@ RSpec.describe LegacyTaxonomy::ThreeLevelTaxonomy do
         child_taxon = result.child_taxons.first
         expect(child_taxon.child_taxons).to be_empty
         expect(child_taxon.title).to eq "foo"
+        expect(child_taxon.internal_name).to eq "foo [M]"
         expect(child_taxon.description).to eq "bar"
         expect(child_taxon.base_path).to eq "/foo/path"
       end
@@ -55,6 +57,8 @@ RSpec.describe LegacyTaxonomy::ThreeLevelTaxonomy do
         expect(result.child_taxons.first.child_taxons).to be_an Array
         child_taxon = result.child_taxons.first.child_taxons.first
         expect(child_taxon.child_taxons).to be_empty
+        expect(child_taxon.title).to eq("baz")
+        expect(child_taxon.internal_name).to eq("baz [M]")
         expect(child_taxon.content_id).to eq subtaxon['content_id']
         expect(child_taxon.tagged_pages).to eq %w(page_content_id)
       end
@@ -74,6 +78,7 @@ RSpec.describe LegacyTaxonomy::ThreeLevelTaxonomy do
       it "has third level taxons" do
         l3_taxon = result.child_taxons.first.child_taxons.first.child_taxons.first
         expect(l3_taxon.title).to eq 'groupo_uno'
+        expect(l3_taxon.internal_name).to eq 'groupo_uno [M]'
         expect(l3_taxon.tagged_pages).to eq [
           {
             'link' => '/path-of-group-contents',
@@ -176,7 +181,7 @@ RSpec.describe LegacyTaxonomy::ThreeLevelTaxonomy do
 
   def subtaxon
     {
-      'title' => 'foo',
+      'title' => 'baz',
       'description' => 'bar',
       'content_id' => 'sub_taxon',
       'base_path' => '/subpath'


### PR DESCRIPTION
For https://trello.com/c/LgoqJ2zI/125-append-abbreviation-to-legacy-taxonomies-in-content-tagger

This PR adds an abbreviation to the internal name of a taxon imported from a legacy taxonomy, based on the type of taxonomy.

M for Mainstream
T for Topics
PA for Policy Areas

We don't add anything to Policies at this point, since we still need to figure out whether importing these into ContentTagger would be useful.