### PR TITLE
Enable legacy taxonomy import for Policies

### DIFF
--- a/app/services/legacy_taxonomy/policy_taxonomy.rb
+++ b/app/services/legacy_taxonomy/policy_taxonomy.rb
@@ -40,12 +40,13 @@ module LegacyTaxonomy
       policies = Client::Whitehall.policies_for_policy_area(policy_area_slug)
       policies.map do |policy_id|
         policy_content_item = Client::PublishingApi.client.get_content(policy_id)
-        policy_slug = policy_content_item.dig('details', 'filter', 'policies')
+        policy_slug = policy_content_item.to_h["base_path"].split("/").last
+        path_slug = "#{BASE_PATH}/#{policy_area_slug}/#{policy_slug}"
         TaxonData.new(
           title: policy_content_item['title'],
           internal_name: "#{policy_content_item['title']} [#{ABBREVIATION}]",
           description: policy_content_item['description'],
-          path_slug: policy_content_item['base_path'],
+          path_slug: path_slug,
           path_prefix: path_prefix,
           legacy_content_id: policy_id,
           tagged_pages: Client::SearchApi.content_tagged_to_policy(policy_slug)

--- a/app/services/legacy_taxonomy/policy_taxonomy.rb
+++ b/app/services/legacy_taxonomy/policy_taxonomy.rb
@@ -4,6 +4,7 @@ module LegacyTaxonomy
 
     TITLE = 'Policy Areas + Policies'.freeze
     BASE_PATH = '/government/topics'.freeze
+    ABBREVIATION = "P".freeze
 
     def initialize(path_prefix)
       @path_prefix = path_prefix
@@ -12,6 +13,7 @@ module LegacyTaxonomy
     def to_taxonomy_branch
       @taxon = TaxonData.new(
         title: TITLE,
+        internal_name: "#{TITLE} [#{ABBREVIATION}]",
         description: TITLE + ' Taxonomy',
         path_slug: BASE_PATH,
         path_prefix: path_prefix,
@@ -24,6 +26,7 @@ module LegacyTaxonomy
       areas.map do |policy_area|
         TaxonData.new(
           title: policy_area['title'],
+          internal_name: "#{policy_area['title']} [#{ABBREVIATION}]",
           description: policy_area['description'],
           path_slug: policy_area['link'],
           path_prefix: path_prefix,
@@ -40,6 +43,7 @@ module LegacyTaxonomy
         policy_slug = policy_content_item.dig('details', 'filter', 'policies')
         TaxonData.new(
           title: policy_content_item['title'],
+          internal_name: "#{policy_content_item['title']} [#{ABBREVIATION}]",
           description: policy_content_item['description'],
           path_slug: policy_content_item['base_path'],
           path_prefix: path_prefix,

--- a/lib/tasks/legacy_taxonomy.rake
+++ b/lib/tasks/legacy_taxonomy.rake
@@ -54,7 +54,7 @@ namespace :legacy_taxonomy do
       LegacyTaxonomy::Yamlizer.new('tmp/policy_area.yml').write(taxonomy)
     end
 
-    desc "Send the Topic taxonomy to the publishing platform"
+    desc "Send the Policy Area taxonomy to the publishing platform"
     task publish_taxons: :environment do
       Theme.find_or_create_by(name: 'Policy Area', path_prefix: '/imported-policy-areas')
       taxonomy_branch = LegacyTaxonomy::Yamlizer.new('tmp/policy_area.yml').as_yaml
@@ -65,8 +65,15 @@ namespace :legacy_taxonomy do
   namespace :policy do
     desc "Generates structure for Policy Areas => Policy"
     task generate_taxons: :environment do
-      taxonomy = LegacyTaxonomy::PolicyTaxonomy.new('/baz').to_taxonomy_branch
+      taxonomy = LegacyTaxonomy::PolicyTaxonomy.new('/imported-policies').to_taxonomy_branch
       File.write('tmp/policy.yml', YAML.dump(taxonomy))
+    end
+
+    desc "Send the 'Policy Area and Policies' taxonomy to the publishing platform"
+    task publish_taxons: :environment do
+      Theme.find_or_create_by(name: 'Policy Area and Policy', path_prefix: '/imported-policies')
+      taxonomy_branch = LegacyTaxonomy::Yamlizer.new('tmp/policy.yml').as_yaml
+      LegacyTaxonomy::TaxonomyPublisher.perform_async(taxonomy_branch)
     end
   end
 

--- a/spec/services/legacy_taxonomy/policy_area_taxonomy_spec.rb
+++ b/spec/services/legacy_taxonomy/policy_area_taxonomy_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe LegacyTaxonomy::PolicyAreaTaxonomy do
 
     context 'there is only one root, no children' do
       before do
-        stub_publishing_api_top_level_topic
         stub_policy_areas([])
       end
 
@@ -50,7 +49,7 @@ RSpec.describe LegacyTaxonomy::PolicyAreaTaxonomy do
         stub_documents(example_policy_area, [example_attached_document])
       end
 
-      it 'returns the child taxon' do
+      it 'returns the tagged pages' do
         child_taxon = result.child_taxons.first
         expect(child_taxon.tagged_pages).to eq([example_attached_document])
       end

--- a/spec/services/legacy_taxonomy/policy_taxonomy_spec.rb
+++ b/spec/services/legacy_taxonomy/policy_taxonomy_spec.rb
@@ -1,0 +1,162 @@
+require 'rails_helper'
+
+RSpec.describe LegacyTaxonomy::PolicyTaxonomy do
+  describe "#to_taxonomy_branch" do
+    let(:result) do
+      described_class.new('/foo').to_taxonomy_branch
+    end
+
+    before :each do
+      stub_publishing_api_top_level_topic
+    end
+
+    context 'there is only one root, no children' do
+      before do
+        stub_policy_areas([])
+      end
+
+      it 'returns the root browse taxon' do
+        expect(result.title).to eq 'Policy Areas + Policies'
+        expect(result.internal_name).to eq 'Policy Areas + Policies [P]'
+        expect(result.base_path).to eq '/foo/government/topics'
+        expect(result.child_taxons).to be_empty
+      end
+    end
+
+    context 'there is a child taxon' do
+      before do
+        stub_policy_areas([example_policy_area])
+        stub_legacy_content_id(example_policy_area, ['id'])
+        stub_policies_from_whitehall(example_policy_area, [])
+      end
+
+      it 'returns the child taxon' do
+        child_taxon = result.child_taxons.first
+        expect(child_taxon.title).to eq(example_policy_area['title'])
+        expect(child_taxon.internal_name).to eq("#{example_policy_area['title']} [P]")
+        expect(child_taxon.description).to eq(example_policy_area['description'])
+        expect(child_taxon.path_slug).to eq(example_policy_area['link'])
+        expect(child_taxon.path_prefix).to eq('/foo')
+        expect(child_taxon.legacy_content_id).to eq(['id'])
+        expect(child_taxon.tagged_pages).to eq([])
+      end
+    end
+
+    context 'there is a policy related to the policy area' do
+      before do
+        stub_policy_areas([example_policy_area])
+        stub_legacy_content_id(example_policy_area, ['id'])
+        stub_policies_from_whitehall(example_policy_area, [example_policy["content_id"]])
+        publishing_api_has_item(example_policy)
+        stub_documents_tagged_to_policy(example_policy, [])
+      end
+
+      it 'returns the policy as child taxon' do
+        child_taxon = result.child_taxons.first.child_taxons.first
+
+        expect(child_taxon.title).to eq(example_policy['title'])
+        expect(child_taxon.internal_name).to eq("#{example_policy['title']} [P]")
+        expect(child_taxon.description).to eq(example_policy['description'])
+        expect(child_taxon.path_slug).to eq(example_policy['base_path'])
+        expect(child_taxon.path_prefix).to eq('/foo')
+        expect(child_taxon.legacy_content_id).to eq(example_policy['content_id'])
+      end
+
+      context 'there are no tagged pages' do
+        it 'does not return any tagged pages' do
+          child_taxon = result.child_taxons.first.child_taxons.first
+          expect(child_taxon.tagged_pages).to eq([])
+        end
+      end
+
+      context 'there are tagged pages' do
+        before do
+          stub_documents_tagged_to_policy(example_policy, [example_attached_document])
+        end
+
+        it 'returns the tagged pages' do
+          child_taxon = result.child_taxons.first.child_taxons.first
+          expect(child_taxon.tagged_pages).to eq([example_attached_document])
+        end
+      end
+    end
+
+    ####################
+    #  HELPER METHODS  #
+    ####################
+
+    def stub_publishing_api_top_level_topic
+      allow(LegacyTaxonomy::Client::PublishingApi)
+        .to receive(:content_id_for_base_path)
+        .with('/government/topics')
+        .and_return root_browse_page_content_id
+    end
+
+    def stub_policy_areas(list)
+      allow(LegacyTaxonomy::Client::SearchApi)
+        .to receive(:policy_areas)
+        .and_return list
+    end
+
+    def stub_legacy_content_id(policy_area, content_id)
+      allow(LegacyTaxonomy::Client::PublishingApi)
+        .to receive(:content_id_for_base_path)
+        .with(policy_area['link'])
+        .and_return content_id
+    end
+
+    def stub_policies_from_whitehall(policy_area, list)
+      allow(LegacyTaxonomy::Client::Whitehall)
+        .to receive(:policies_for_policy_area)
+        .with(policy_area['slug'])
+        .and_return list
+    end
+
+    def stub_documents_tagged_to_policy(policy, list)
+      allow(LegacyTaxonomy::Client::SearchApi)
+        .to receive(:content_tagged_to_policy)
+        .with(policy['details']['filter']['policies'])
+        .and_return list
+    end
+
+    def root_browse_page_content_id
+      'foo-bar-baz'
+    end
+
+    def example_policy_area
+      {
+        "format" => "topic",
+        "title" => "Arts and Culture",
+        "slug" => "arts-culture",
+        "description" => "Arts and Culture enrich the soul.",
+        "link" => "/government/topics/arts-culture",
+        "index" => "government",
+        "es_score" => nil,
+        "_id" => "/government/topics/arts-culture",
+        "elasticsearch_type" => "edition",
+        "document_type" => "edition",
+      }
+    end
+
+    def example_policy
+      {
+        "content_id" => "aaaa-bbbb",
+        "title" => "Library services",
+        "description" => "All things related to borrowing books",
+        "base_path" => "library-services",
+        "details" => {
+          "filter" => {
+            "policies" => "library-services",
+          }
+        }
+      }
+    end
+
+    def example_attached_document
+      {
+        "content_id" => "f4428540-a13d-45d2-877f-283bef8d96c5",
+        "link" => "/government/news/sad-death-of-mhra-non-executive-director-professor-barrington-furr"
+      }
+    end
+  end
+end


### PR DESCRIPTION
For https://trello.com/c/rZychwKa/126-enable-import-of-policies-as-legacy-taxonomy

Relies on https://github.com/alphagov/whitehall/pull/3521 to be deployed before this will work, otherwise it requires Signon permissions