### PR TITLE
Set bulk publishing for taxonomy publisher

### DIFF
--- a/app/workers/legacy_taxonomy/taxonomy_publisher.rb
+++ b/app/workers/legacy_taxonomy/taxonomy_publisher.rb
@@ -28,7 +28,8 @@ module LegacyTaxonomy
 
     def taxon_for_publishing_api(taxon)
       taxon_attrs = taxon.hash_for_publishing_api
-      Taxonomy::BuildTaxonPayload.call(taxon: Taxon.new(taxon_attrs))
+      payload = Taxonomy::BuildTaxonPayload.call(taxon: Taxon.new(taxon_attrs))
+      payload.merge(bulk_publishing: true)
     end
   end
 end


### PR DESCRIPTION
Since we'll be running this in production, we should make sure that we do not block other users of the publishing api (as it might take several hours). By setting `bulk_publishing` to `true` the publihsing api should send this to the low priority queue.

See https://github.com/alphagov/publishing-api/blob/8b5972debd7a5b71de9d8d71bd8e78cbf843dc78/app/commands/v2/put_content.rb#L171