### PR TITLE
Prepend 'Imported' to all legacy taxonomies

### DIFF
--- a/app/services/legacy_taxonomy/policy_area_taxonomy.rb
+++ b/app/services/legacy_taxonomy/policy_area_taxonomy.rb
@@ -2,8 +2,8 @@ module LegacyTaxonomy
   class PolicyAreaTaxonomy
     attr_accessor :path_prefix, :root_content_id
 
+    TITLE = 'Imported Policy Areas'.freeze
     BASE_PATH = '/government/topics'.freeze
-    TITLE = 'Policy Areas'.freeze
     ABBREVIATION = "PA".freeze
 
     def initialize(path_prefix)

--- a/app/services/legacy_taxonomy/policy_taxonomy.rb
+++ b/app/services/legacy_taxonomy/policy_taxonomy.rb
@@ -2,7 +2,7 @@ module LegacyTaxonomy
   class PolicyTaxonomy
     attr_reader :path_prefix
 
-    TITLE = 'Policy Areas + Policies'.freeze
+    TITLE = 'Imported Policy Areas + Policies'.freeze
     BASE_PATH = '/government/topics'.freeze
     ABBREVIATION = "P".freeze
 

--- a/lib/tasks/legacy_taxonomy.rake
+++ b/lib/tasks/legacy_taxonomy.rake
@@ -34,7 +34,7 @@ namespace :legacy_taxonomy do
     desc "Generates structure for Topic taxonomy at www.gov.uk/browse"
     task generate_taxons: :environment do
       taxonomy = LegacyTaxonomy::ThreeLevelTaxonomy.new('/imported-topic',
-                                                        title: 'Topics',
+                                                        title: 'Imported Topics',
                                                         type: LegacyTaxonomy::ThreeLevelTaxonomy::TOPIC).to_taxonomy_branch
       LegacyTaxonomy::Yamlizer.new('tmp/topic.yml').write(taxonomy)
     end

--- a/spec/services/legacy_taxonomy/policy_area_taxonomy_spec.rb
+++ b/spec/services/legacy_taxonomy/policy_area_taxonomy_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe LegacyTaxonomy::PolicyAreaTaxonomy do
       end
 
       it 'returns the root browse taxon' do
-        expect(result.title).to eq 'Policy Areas'
-        expect(result.internal_name).to eq 'Policy Areas [PA]'
+        expect(result.title).to eq 'Imported Policy Areas'
+        expect(result.internal_name).to eq 'Imported Policy Areas [PA]'
         expect(result.base_path).to eq '/foo/government/topics'
         expect(result.child_taxons).to be_empty
       end

--- a/spec/services/legacy_taxonomy/policy_taxonomy_spec.rb
+++ b/spec/services/legacy_taxonomy/policy_taxonomy_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe LegacyTaxonomy::PolicyTaxonomy do
       end
 
       it 'returns the root browse taxon' do
-        expect(result.title).to eq 'Policy Areas + Policies'
-        expect(result.internal_name).to eq 'Policy Areas + Policies [P]'
+        expect(result.title).to eq 'Imported Policy Areas + Policies'
+        expect(result.internal_name).to eq 'Imported Policy Areas + Policies [P]'
         expect(result.base_path).to eq '/foo/government/topics'
         expect(result.child_taxons).to be_empty
       end


### PR DESCRIPTION
Previously only the MainstreamBrowse legacy taxonomy had the word 'Imported'
prepended to its title. This commit updates the other legacy taxonomies to
also have the word 'Imported' as part of their title.