### PR TITLE
Set bulk publishing for patch links for legacy taxonomy import

### DIFF
--- a/app/workers/legacy_taxonomy/tag_content.rb
+++ b/app/workers/legacy_taxonomy/tag_content.rb
@@ -8,7 +8,10 @@ module LegacyTaxonomy
       taxons = links.dig('links', 'taxons') || []
       taxons << taxon_content_id
 
-      Client::PublishingApi.patch_links(taggable_content_id, links: { taxons: taxons.uniq }, previous_version: previous_version)
+      Client::PublishingApi.patch_links(taggable_content_id,
+                                        links: { taxons: taxons.uniq },
+                                        previous_version: previous_version,
+                                        bulk_publishing: true)
     rescue GdsApi::HTTPNotFound
       puts "404 Taggable Not Found"
     end

--- a/app/workers/legacy_taxonomy/taxonomy_publisher.rb
+++ b/app/workers/legacy_taxonomy/taxonomy_publisher.rb
@@ -10,7 +10,9 @@ module LegacyTaxonomy
       Client::PublishingApi.publish(content_id) if publish
 
       if parent_taxon_id
-        Client::PublishingApi.patch_links(content_id, links: { parent_taxons: [parent_taxon_id] })
+        Client::PublishingApi.patch_links(content_id,
+                                          links: { parent_taxons: [parent_taxon_id] },
+                                          bulk_publishing: true)
       end
 
       taxon_data.tagged_pages
@@ -28,8 +30,7 @@ module LegacyTaxonomy
 
     def taxon_for_publishing_api(taxon)
       taxon_attrs = taxon.hash_for_publishing_api
-      payload = Taxonomy::BuildTaxonPayload.call(taxon: Taxon.new(taxon_attrs))
-      payload.merge(bulk_publishing: true)
+      Taxonomy::BuildTaxonPayload.call(taxon: Taxon.new(taxon_attrs))
     end
   end
 end


### PR DESCRIPTION
Effectively reverts https://github.com/alphagov/content-tagger/pull/508

The previous PR didn't actually work as intended. It would fail since
the schema for Taxons don't allow the property `bulk_publishing`.

Also it's actually the patch links calls that need the `bulk_publishing`
attr to be set to `true` as they form the largest part of the requests. There
would only be a few hundred 'put-content' calls vs hundreds of thousands of
'patch-links' calls