### PR TITLE
Include internal_name in search parameters for RemoteTaxons

### DIFF
--- a/app/models/remote_taxons.rb
+++ b/app/models/remote_taxons.rb
@@ -21,6 +21,7 @@ private
         document_type: 'taxon',
         order: '-public_updated_at',
         q: query || '',
+        search_in: %i[title base_path details.internal_name],
         page: page || 1,
         per_page: per_page || 50,
         states: states || [],

--- a/spec/support/publishing_api_helper.rb
+++ b/spec/support/publishing_api_helper.rb
@@ -44,6 +44,7 @@ module PublishingApiHelper
       page: 1,
       per_page: 50,
       q: '',
+      search_in: %i[title base_path details.internal_name],
       states: ["published"],
     }
 
@@ -70,6 +71,7 @@ module PublishingApiHelper
       page: 1,
       per_page: 50,
       q: '',
+      search_in: %i[title base_path details.internal_name],
       states: ["unpublished"],
     }
 


### PR DESCRIPTION
We are in the process of importing the legacy taxonomies into ContentTagger and it's useful to filter taxons by their internal name as well as the defaults (base_path and title).
This has already been set up for [bulk tagging search](https://github.com/alphagov/content-tagger/commit/0fc00de0a4e51ab9b61cd9c382cc8fa7993b3f5d)