### PR TITLE
Improve displaying tagging progress

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -4,7 +4,8 @@ class ProjectsController < ApplicationController
 
   def index
     render :index, locals: {
-      percentage_by_organisation: percentage_by_organisation,
+      percentage_by_organisation: tagging_progress_query.try(:percentage_tagged),
+      total_counts: tagging_progress_query.try(:total_counts),
       projects: project_index
     }
   end
@@ -73,10 +74,10 @@ private
       .permit(:name, :remote_url, :taxonomy_branch, :bulk_tagging_enabled)
   end
 
-  def percentage_by_organisation
+  def tagging_progress_query
     return if params[:progress_for_organisations].blank?
 
     organisations = params[:progress_for_organisations].tr(' ', '').split(',')
-    TaggingProgressByOrganisationsQuery.new(organisations).percentage_tagged
+    @_tagging_query ||= TaggingProgressByOrganisationsQuery.new(organisations)
   end
 end

--- a/app/queries/tagging_progress_by_organisations_query.rb
+++ b/app/queries/tagging_progress_by_organisations_query.rb
@@ -4,12 +4,12 @@ class TaggingProgressByOrganisationsQuery
   end
 
   def percentage_tagged
-    content_item_counts_grouped_by_organisation.transform_values do |results|
+    @_tagged_counts ||= content_item_counts_grouped_by_organisation.transform_values do |results|
       total_count, tagged_count = results.map { |obj| obj["documents"] }
-
       {
-        percentage: (Float(tagged_count) / Float(total_count)) * 100,
-        total: total_count
+        percentage: percentage(tagged_count, total_count),
+        total: total_count,
+        tagged: tagged_count
       }
     end
   end
@@ -17,6 +17,11 @@ class TaggingProgressByOrganisationsQuery
 private
 
   attr_reader :organisations
+
+  def percentage(tagged_count, total_count)
+    return 0.0 if total_count.zero?
+    (Float(tagged_count) / Float(total_count)) * 100
+  end
 
   def content_item_counts_grouped_by_organisation
     (Array(total_content_count) + Array(tagged_content_count))

--- a/app/queries/tagging_progress_by_organisations_query.rb
+++ b/app/queries/tagging_progress_by_organisations_query.rb
@@ -14,6 +14,17 @@ class TaggingProgressByOrganisationsQuery
     end
   end
 
+  def total_counts
+    return {} if percentage_tagged.empty?
+    total_count = percentage_tagged.values.map { |v| v[:total] }.sum
+    tagged_count = percentage_tagged.values.map { |v| v[:tagged] }.sum
+    {
+      percentage: percentage(tagged_count, total_count),
+      total: total_count,
+      tagged: tagged_count
+    }
+  end
+
 private
 
   attr_reader :organisations

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -67,6 +67,14 @@
         <th>Percentage</th>
       </tr>
     </thead>
+    <tfoot>
+    <tr>
+      <th>Totals</th>
+      <td><%= total_counts[:total] %></td>
+      <td><%= total_counts[:tagged] %></td>
+      <td><%= number_to_percentage(total_counts[:percentage], precision: 2) %></td>
+    </tr>
+    </tfoot>
     <tbody>
       <% percentage_by_organisation.each do |organisation, progress| %>
       <tr>

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -57,25 +57,29 @@
 
 </form>
 
-<% if percentage_by_organisation.present? %>
+<% if percentage_by_organisation.present?%>
   <table class="table queries-list table-bordered table-striped" id="tagging-progress">
     <thead>
       <tr class="table-header">
         <th>Organisation</th>
-        <th>Progress</th>
+        <th>Content Published</th>
+        <th>Content tagged</th>
+        <th>Percentage</th>
       </tr>
     </thead>
-
     <tbody>
       <% percentage_by_organisation.each do |organisation, progress| %>
       <tr>
         <td><%= organisation %></td>
         <td>
-          <% if progress[:total] == 0 %>
-            0 documents
-          <% else %>
-            <%= number_to_percentage(progress[:percentage], precision: 2) %> of <%= progress[:total] %> documents</td>
-          <% end %>
+          <%= progress[:total] %>
+        </td>
+        <td>
+          <%= progress[:tagged] %>
+        </td>
+        <td>
+          <%= number_to_percentage(progress[:percentage], precision: 2) %>
+        </td>
       </tr>
       <% end %>
     </tbody>

--- a/spec/features/project_spec.rb
+++ b/spec/features/project_spec.rb
@@ -295,10 +295,10 @@ RSpec.feature "Projects", type: :feature do
 
   def then_the_tagging_progress_for_the_organisations_will_be_shown
     within "table#tagging-progress" do
-      expect(page).to have_content "department-for-transport 18.34% of 5844 documents"
-      expect(page).to have_content "high-speed-two-limited 98.80% of 753 documents"
-      expect(page).to have_content "home-office 0.00% of 7475 documents"
-      expect(page).to have_content "maritime-and-coastguard-agency 0 documents"
+      expect(page).to have_content "department-for-transport 5844 1072 18.34%"
+      expect(page).to have_content "high-speed-two-limited 753 744 98.80%"
+      expect(page).to have_content "home-office 7475 0 0.00%"
+      expect(page).to have_content "maritime-and-coastguard-agency 0 0 0.00%"
     end
   end
 

--- a/spec/features/project_spec.rb
+++ b/spec/features/project_spec.rb
@@ -299,6 +299,7 @@ RSpec.feature "Projects", type: :feature do
       expect(page).to have_content "high-speed-two-limited 753 744 98.80%"
       expect(page).to have_content "home-office 7475 0 0.00%"
       expect(page).to have_content "maritime-and-coastguard-agency 0 0 0.00%"
+      expect(page).to have_content "Totals 14072 1816 12.91%"
     end
   end
 

--- a/spec/queries/tagging_progress_by_organisations_query_spec.rb
+++ b/spec/queries/tagging_progress_by_organisations_query_spec.rb
@@ -1,0 +1,117 @@
+require 'rails_helper'
+
+RSpec.describe TaggingProgressByOrganisationsQuery do
+  let(:name) do
+    ['department-for-transport', 'high-speed-two-limited']
+  end
+
+  describe '#percentage_tagged' do
+    it 'returns an empty table when nothing is returned' do
+      stub_rummager_totals(rummager_empty)
+      stub_rummager_untagged(rummager_empty)
+      expect(TaggingProgressByOrganisationsQuery.new(organisations).percentage_tagged).to be_empty
+    end
+
+    it 'returns zeros when there are no documents' do
+      stub_rummager_totals(rummager_zeros)
+      stub_rummager_untagged(rummager_zeros)
+      expect(TaggingProgressByOrganisationsQuery.new(organisations).percentage_tagged)
+        .to eq('department-for-transport' => { percentage: 0.0, total: 0, tagged: 0 },
+               'high-speed-two-limited' => { percentage: 0.0, total: 0, tagged: 0 })
+    end
+
+    it 'returns correct values' do
+      stub_rummager_totals(rummager_totals)
+      stub_rummager_untagged(rummager_untagged)
+      expect(TaggingProgressByOrganisationsQuery.new(organisations).percentage_tagged)
+        .to eq('department-for-transport' => { percentage: 25.0, total: 20, tagged: 5 },
+               'high-speed-two-limited' => { percentage: 56.25, total: 80, tagged: 45 })
+    end
+  end
+
+  # HELPERS #
+  def stub_rummager_untagged(return_hash)
+    allow(Services.rummager).to receive(:search).with(hash_including(reject_taxons: '_MISSING')).and_return return_hash
+  end
+
+  def stub_rummager_totals(return_hash)
+    allow(Services.rummager).to receive(:search).with(hash_excluding(reject_taxons: '_MISSING')).and_return return_hash
+  end
+
+  def organisations
+    ['department-for-transport', 'high-speed-two-limited']
+  end
+
+  def rummager_empty
+    { "results" => [],
+      "total" => 100,
+      "start" => 0,
+      "aggregates" => {
+        "primary_publishing_organisation" => {
+          "options" => [],
+          "documents_with_no_value" => 80,
+          "total_options" => 10,
+          "missing_options" => 10,
+          "scope" => "all_filters"
+        }
+      },
+      "suggested_queries" => [] }
+  end
+
+  def rummager_totals
+    { "results" => [],
+      "total" => 100,
+      "start" => 0,
+      "aggregates" => {
+        "primary_publishing_organisation" => {
+          "options" => [
+            { "value" => { "slug" => "department-for-transport" }, "documents" => 20 },
+            { "value" => { "slug" => "high-speed-two-limited" }, "documents" => 80 }
+          ],
+          "documents_with_no_value" => 0,
+          "total_options" => 2,
+          "missing_options" => 2,
+          "scope" => "all_filters"
+        }
+      },
+      "suggested_queries" => [] }
+  end
+
+  def rummager_untagged
+    { "results" => [],
+      "total" => 50,
+      "start" => 0,
+      "aggregates" => {
+        "primary_publishing_organisation" => {
+          "options" => [
+            { "value" => { "slug" => "department-for-transport" }, "documents" => 5 },
+            { "value" => { "slug" => "high-speed-two-limited" }, "documents" => 45 }
+          ],
+          "documents_with_no_value" => 0,
+          "total_options" => 2,
+          "missing_options" => 2,
+          "scope" => "all_filters"
+        }
+      },
+      "suggested_queries" => [] }
+  end
+
+  def rummager_zeros
+    { "results" => [],
+      "total" => 50,
+      "start" => 0,
+      "aggregates" => {
+        "primary_publishing_organisation" => {
+          "options" => [
+            { "value" => { "slug" => "department-for-transport" }, "documents" => 0 },
+            { "value" => { "slug" => "high-speed-two-limited" }, "documents" => 0 }
+          ],
+          "documents_with_no_value" => 0,
+          "total_options" => 2,
+          "missing_options" => 2,
+          "scope" => "all_filters"
+        }
+      },
+      "suggested_queries" => [] }
+  end
+end

--- a/spec/queries/tagging_progress_by_organisations_query_spec.rb
+++ b/spec/queries/tagging_progress_by_organisations_query_spec.rb
@@ -29,6 +29,27 @@ RSpec.describe TaggingProgressByOrganisationsQuery do
     end
   end
 
+  describe '#total_counts' do
+    it 'returns an empty hash when nothing is returned' do
+      stub_rummager_totals(rummager_empty)
+      stub_rummager_untagged(rummager_empty)
+      expect(TaggingProgressByOrganisationsQuery.new(organisations).total_counts).to be_empty
+    end
+
+    it 'returns zeros when there are no documents' do
+      stub_rummager_totals(rummager_zeros)
+      stub_rummager_untagged(rummager_zeros)
+      expect(TaggingProgressByOrganisationsQuery.new(organisations).total_counts).to eq(percentage: 0.0, total: 0, tagged: 0)
+    end
+
+    it 'returns correct totals' do
+      stub_rummager_totals(rummager_totals)
+      stub_rummager_untagged(rummager_untagged)
+      expect(TaggingProgressByOrganisationsQuery.new(organisations).total_counts)
+        .to eq(percentage: 50.0, total: 100, tagged: 50)
+    end
+  end
+
   # HELPERS #
   def stub_rummager_untagged(return_hash)
     allow(Services.rummager).to receive(:search).with(hash_including(reject_taxons: '_MISSING')).and_return return_hash


### PR DESCRIPTION
Trello: https://trello.com/c/jGR1DRzp/129-improvements-to-showing-departmental-tagging-progress-in-content-tagger

In the project page, the absolute number of document tagged per department is now show together with a row detailing totals.

![image](https://user-images.githubusercontent.com/6050162/32609068-42a1218c-c556-11e7-8519-5c88e082e05d.png)