### PR TITLE
Add tagged content count to taxon show page

### DIFF
--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -68,6 +68,12 @@
     </div>
   <% end %>
 
+  <h3><%= t('views.taxons.metadata') %></h3>
+
+  <p>
+    Tagged content items: <%= page.tagged.count %>
+  </p>
+
   <h3><%= t('views.taxons.tagged_content') %></h3>
 
   <p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -106,6 +106,7 @@ en:
       visible_to_departmental_editors: 'Visible to departmental editors?'
       visible_to_departmental_editors_hint: 'Affects the visiblity of draft taxonomy root nodes only'
       associated_taxons: Associated taxons
+      metadata: Taxon metadata
     projects:
       flags:
         help-needed: 'Flagged: needs publisher review'

--- a/spec/features/viewing_taxons_spec.rb
+++ b/spec/features/viewing_taxons_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe "Viewing taxons" do
     given_a_taxonomy
     and_the_root_taxon_has_content_tagged_to_it
     when_i_view_the_root_taxon
+    then_i_see_the_count_of_tagged_content
     then_i_see_tagged_content
   end
 
@@ -89,12 +90,20 @@ RSpec.describe "Viewing taxons" do
   def and_the_root_taxon_has_content_tagged_to_it
     stub_request(:get, %r{publishing-api.test.gov.uk/v2/linked/apples})
       .to_return(
-        body: [basic_content_item("Tagged content")].to_json
+        body: [
+          basic_content_item("Green Apples"),
+          basic_content_item("Red Apples"),
+        ].to_json
       )
   end
 
+  def then_i_see_the_count_of_tagged_content
+    expect(page).to have_content("Tagged content items: 2")
+  end
+
   def then_i_see_tagged_content
-    expect(page).to have_content("Tagged content")
+    expect(page).to have_content("Green Apples")
+    expect(page).to have_content("Red Apples")
   end
 
   def when_i_view_the_root_taxon


### PR DESCRIPTION
For https://trello.com/c/17sEgPum/86-show-per-taxon-metrics-in-content-tagger

Adds a metadata section to the show page, including a count of tagged content.

First step in adding more metadata to the show taxon page. Eventually we'll display another count here for tagged content to the taxon's child taxons too.

--------------

## Screenshot

<img width="558" alt="screen shot 2017-11-09 at 16 46 18" src="https://user-images.githubusercontent.com/5112255/32617708-9bb7edca-c56d-11e7-85a5-7037eb891f0e.png">
