### PR TITLE
Export data

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -41,6 +41,9 @@ Metrics/ModuleLength:
 Metrics/PerceivedComplexity:
   Enabled: true
 
+Metrics/BlockLength:
+  Enabled: false
+
 # Rails cops, disabled by default in govuk-lint.
 
 ActionFilter:

--- a/app/lib/services.rb
+++ b/app/lib/services.rb
@@ -1,5 +1,6 @@
 require 'gds_api/publishing_api_v2'
 require 'gds_api/rummager'
+require 'gds_api/content_store'
 
 module Services
   def self.publishing_api
@@ -8,6 +9,10 @@ module Services
       disable_cache: true,
       bearer_token: ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example',
     )
+  end
+
+  def self.content_store
+    @content_store ||= GdsApi::ContentStore.new(Plek.current.find("draft-content-store"))
   end
 
   def self.statsd

--- a/app/services/data_export/content_export.rb
+++ b/app/services/data_export/content_export.rb
@@ -1,0 +1,106 @@
+module DataExport
+  class ContentExport
+    CONTENT_BASE_FIELDS = %w[base_path content_id document_type first_published_at locale publishing_app title description details].freeze
+    CONTENT_TAXON_FIELDS = %w[title content_id].freeze
+    CONTENT_PPO_FIELDS = %w[title].freeze
+    BLACKLIST_DOCUMENT_TYPES = %w[
+      staff_update
+      coming_soon
+      travel_advice
+      html_publication
+      manual_section
+      hmrc_manual_section
+      contact
+      completed_transaction
+      aaib_report
+      raib_report
+      maib_report
+      service_standard_report
+      employment_tribunal_decision
+      tax_tribunal_decision
+      utaac_decision
+      dfid_research_output
+      asylum_support_decision
+      employment_appeal_tribunal_decision
+      cma_case
+      need
+      working_group
+      organisation
+      person
+      worldwide_organisation
+      world_location
+      topical_event
+      policy_area
+      field_of_operation
+      ministerial_role
+      topical_event_about_page
+      finder_email_signup
+      mainstream_browse_page
+      topic
+      homepage
+      licence_finder
+      search
+      taxon
+      travel_advice_index
+      business_support_finder
+      finder
+      about
+      about_our_services
+      personal_information_charter
+      equality_and_diversity
+      our_governance
+      services_and_information
+      our_energy_use
+      corporate_report
+      social_media_use
+      access_and_opening
+      membership
+      publication_scheme
+      media_enquiries
+      complaints_procedure
+      help_page
+      service_manual_homepage
+      service_manual_service_toolkit
+      service_manual_service_standard
+      service_manual_guide
+      service_manual_topic
+    ].freeze
+
+    def content_links_enum(window = 1000, size = Float::INFINITY)
+      Enumerator.new do |yielder|
+        (0..size).step(window).each do |index|
+          results = Services.rummager.search(start: index.to_i,
+                                             count: window,
+                                             reject_content_store_document_type: BLACKLIST_DOCUMENT_TYPES,
+                                             fields: ['link']).to_h.fetch('results', [])
+          results.each do |result|
+            yielder << result['link']
+          end
+          if results.count < window
+            break
+          end
+        end
+      end
+    end
+
+    def get_content(base_path, base_fields: CONTENT_BASE_FIELDS, taxon_fields: CONTENT_TAXON_FIELDS, ppo_fields: CONTENT_PPO_FIELDS)
+      hash = get_content_hash(base_path)
+      base = hash.slice(*base_fields)
+      taxons = hash.dig('links', 'taxons')
+      ppo = hash.dig('links', 'primary_publishing_organisation')
+      base.tap do |result|
+        result['taxons'] = taxons.map { |t| t.slice(*taxon_fields) } if taxons.present?
+        result['primary_publishing_organisation'] = ppo.first.slice(*ppo_fields) if ppo.present?
+      end
+    rescue GdsApi::ContentStore::ItemNotFound
+      Rails.logger.warn("Cannot find content item '#{base_path}' in the content store")
+      {}
+    end
+
+  private
+
+    def get_content_hash(path)
+      Services.content_store.content_item(path).to_h
+    end
+  end
+end

--- a/app/services/data_export/taxon_export.rb
+++ b/app/services/data_export/taxon_export.rb
@@ -1,0 +1,30 @@
+module DataExport
+  class TaxonExport
+    TAXON_FIELDS = %w[content_id base_path title].freeze
+
+    def root_taxons
+      taxons = get_content_hash('/').dig('links', 'root_taxons') || []
+      taxons.map { |taxon| taxon.slice(*TAXON_FIELDS) }
+    end
+
+    def child_taxons(base_path)
+      root_content_hash = get_content_hash(base_path)
+      taxons = root_content_hash.dig('links', 'child_taxons') || []
+      recursive_child_taxons(taxons, root_content_hash['content_id'])
+    end
+
+  private
+
+    def recursive_child_taxons(taxons, parent_content_id)
+      results = taxons.map { |taxon| taxon.slice(*TAXON_FIELDS).merge('parent_content_id' => parent_content_id) }
+      results + taxons.flat_map do |taxon|
+        child_taxons = taxon.dig('links', 'child_taxons') || []
+        recursive_child_taxons(child_taxons, taxon['content_id'])
+      end
+    end
+
+    def get_content_hash(path)
+      Services.content_store.content_item(path).to_h
+    end
+  end
+end

--- a/lib/tasks/export_data.rake
+++ b/lib/tasks/export_data.rake
@@ -1,0 +1,14 @@
+namespace :export_data do
+  namespace :taxons do
+    desc "Export all taxons to file"
+    task export: :environment do
+      exporter = DataExport::TaxonExport.new
+      root_taxons = exporter.root_taxons
+      result = root_taxons + root_taxons.flat_map { |t| exporter.child_taxons(t['base_path']) }
+
+      open('tmp/taxons.json', 'w') do |f|
+        f << JSON.dump(result)
+      end
+    end
+  end
+end

--- a/lib/tasks/export_data.rake
+++ b/lib/tasks/export_data.rake
@@ -11,4 +11,24 @@ namespace :export_data do
       end
     end
   end
+
+  namespace :content do
+    desc "Export all content items to file"
+    task export: :environment do
+      exporter = DataExport::ContentExport.new
+      enum = exporter.content_links_enum.lazy.map { |link| exporter.get_content(link) }
+      head = enum.first
+      tail = enum.drop(1)
+      File.open('tmp/content.json', 'w') do |f|
+        f << "[ "
+        f << JSON.dump(head) if head.present?
+        tail.each_with_index do |taxon, index|
+          f << ",\n"
+          f << JSON.dump(taxon)
+          puts "Documents exported: #{index}" if (index % 1000).zero?
+        end
+        f << "]\n"
+      end
+    end
+  end
 end

--- a/spec/services/data_export/content_export_spec.rb
+++ b/spec/services/data_export/content_export_spec.rb
@@ -1,0 +1,107 @@
+require 'rails_helper'
+
+module DataExport
+  RSpec.describe ContentExport do
+    describe '#get_content' do
+      it 'returns empty hash if there is no content for the base path' do
+        expect(Services.content_store).to receive(:content_item).with('/base_path').and_raise GdsApi::ContentStore::ItemNotFound.new(404)
+        expect(ContentExport.new.get_content('/base_path')).to eq({})
+      end
+      it 'returns simple content' do
+        expect(Services.content_store).to receive(:content_item).with('/base_path').and_return content_no_taxon
+        expect(ContentExport.new.get_content('/base_path', base_fields: %w[base_path content_id]))
+          .to eq("base_path" => "/base_path", "content_id" => "d282d35a-2bd2-4e14-a7a6-a04e6b10520f")
+      end
+      it 'returns taxons' do
+        expect(Services.content_store).to receive(:content_item).with('/base_path').and_return content_with_taxons
+        expect(ContentExport.new.get_content('/base_path', taxon_fields: %w[content_id])['taxons'])
+          .to eq([{ "content_id" => "237b2e72-c465-42fe-9293-8b6af21713c0" },
+                  { "content_id" => "8da62d85-47c0-42df-94c4-eaaeac329671" }])
+      end
+      it 'returns the primary publishing organistations' do
+        expect(Services.content_store).to receive(:content_item).with('/base_path').and_return content_with_ppo
+        expect(ContentExport.new.get_content('/base_path', ppo_fields: %w[title])['primary_publishing_organisation'])
+          .to eq("title" => "title1")
+      end
+
+      def content_with_taxons
+        {
+          "base_path" => "/base_path",
+          "content_id" => "d282d35a-2bd2-4e14-a7a6-a04e6b10520f",
+          "links" => {
+            "taxons" => [{ "content_id" => "237b2e72-c465-42fe-9293-8b6af21713c0" },
+                         { "content_id" => "8da62d85-47c0-42df-94c4-eaaeac329671" }]
+          }
+        }
+      end
+
+      def content_with_ppo
+        {
+          "base_path" => "/base_path",
+          "content_id" => "d282d35a-2bd2-4e14-a7a6-a04e6b10520f",
+          "links" => {
+            "primary_publishing_organisation" => [
+              { "title" => "title1" }
+            ]
+          },
+        }
+      end
+
+      def content_no_taxon
+        {
+          "base_path" => "/base_path",
+          "content_id" => "d282d35a-2bd2-4e14-a7a6-a04e6b10520f",
+          "links" => {
+          }
+        }
+      end
+    end
+
+    describe '#content_links_enum' do
+      it 'returns an empty enumerator' do
+        expect(Services.rummager).to receive(:search).and_return empty_content
+        expect(ContentExport.new.content_links_enum).to be_a(Enumerator)
+        expect(ContentExport.new.content_links_enum.to_a).to eq([])
+      end
+      it 'returns two windows' do
+        expect(Services.rummager).to receive(:search).with(hash_including(start: 0)).and_return two_content_items
+        expect(Services.rummager).to receive(:search).with(hash_including(start: 2)).and_return one_content_item
+        expect(ContentExport.new.content_links_enum(2).to_a).to eq(["/first/path", "/second/path", "/one/path"])
+      end
+      it 'returns one window - edge case' do
+        expect(Services.rummager).to receive(:search).with(hash_including(start: 0)).and_return two_content_items
+        expect(Services.rummager).to receive(:search).with(hash_including(start: 2)).and_return empty_content
+        expect(ContentExport.new.content_links_enum(2).to_a).to eq(["/first/path", "/second/path"])
+      end
+    end
+
+    def two_content_items
+      {
+        "results" => [
+          {
+            "link" => "/first/path",
+          },
+          {
+            "link" => "/second/path",
+          },
+        ]
+      }
+    end
+
+    def one_content_item
+      {
+        "results" => [
+          {
+            "link" => "/one/path",
+          }
+        ]
+      }
+    end
+
+    def empty_content
+      {
+        "results" => []
+      }
+    end
+  end
+end

--- a/spec/services/data_export/taxon_export_spec.rb
+++ b/spec/services/data_export/taxon_export_spec.rb
@@ -1,0 +1,122 @@
+require 'rails_helper'
+
+module DataExport
+  RSpec.describe TaxonExport do
+    describe '#root_taxons' do
+      it 'returns an empty array' do
+        expect(Services.content_store).to receive(:content_item).with('/').and_return no_taxons
+        expect(TaxonExport.new.root_taxons).to be_empty
+      end
+
+      it 'returns root taxons' do
+        expect(Services.content_store).to receive(:content_item).with('/').and_return root_taxons
+        expect(TaxonExport.new.root_taxons)
+          .to match_array [{ 'content_id' => 'aaaa', 'base_path' => '/taxons/taxon_a' },
+                           { 'content_id' => 'bbbb', 'base_path' => '/taxons/taxon_b' }]
+      end
+    end
+
+    describe '#branch' do
+      it 'returns an empty array' do
+        expect(Services.content_store).to receive(:content_item).with('/taxons/root_taxon').and_return no_taxons
+        expect(TaxonExport.new.child_taxons('/taxons/root_taxon')).to be_empty
+      end
+      it 'returns an single level of taxons' do
+        expect(Services.content_store).to receive(:content_item).with('/taxons/root_taxon').and_return single_level_child_taxons
+        expect(TaxonExport.new.child_taxons('/taxons/root_taxon'))
+          .to match_array [{ 'content_id' => 'aaaa', 'base_path' => '/taxons/root_taxon/taxon_a', 'parent_content_id' => 'rrrr' },
+                           { 'content_id' => 'bbbb', 'base_path' => '/taxons/root_taxon/taxon_b', 'parent_content_id' => 'rrrr' }]
+      end
+      it 'returns multiple levels of taxons' do
+        expect(Services.content_store).to receive(:content_item).with('/taxons/root_taxon').and_return multi_level_child_taxons
+        expect(TaxonExport.new.child_taxons('/taxons/root_taxon'))
+          .to match_array [{ 'content_id' => 'aaaa', 'base_path' => '/taxons/root_taxon/taxon_a', 'parent_content_id' => 'rrrr' },
+                           { 'content_id' => 'aaaa_1111', 'base_path' => '/taxons/root_taxon/taxon_a/taxon_1', 'parent_content_id' => 'aaaa' },
+                           { 'content_id' => 'aaaa_2222', 'base_path' => '/taxons/root_taxon/taxon_a/taxon_2', 'parent_content_id' => 'aaaa' }]
+      end
+    end
+
+    def multi_level_child_taxons
+      {
+        "content_id" => "rrrr",
+        "base_path" => "/taxons/root_taxon",
+        "title" => "Root Taxon",
+        "links" => {
+          "child_taxons" => [
+            {
+              "base_path" => "/taxons/root_taxon/taxon_a",
+              "content_id" => "aaaa",
+              "description" => "Taxon A",
+              "links" => {
+                "child_taxons" => [
+                  {
+                    "base_path" => "/taxons/root_taxon/taxon_a/taxon_1",
+                    "content_id" => "aaaa_1111",
+                    "description" => "Taxon A 1",
+                    "links" => {}
+                  },
+                  {
+                    "base_path" => "/taxons/root_taxon/taxon_a/taxon_2",
+                    "content_id" => "aaaa_2222",
+                    "description" => "Taxon A 2",
+                    "links" => {}
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    end
+
+    def single_level_child_taxons
+      {
+        "content_id" => "rrrr",
+        "base_path" => "/taxons/root_taxon",
+        "title" => "Root Taxon",
+        "links" => {
+          "child_taxons" => [
+            {
+              "base_path" => "/taxons/root_taxon/taxon_a",
+              "content_id" => "aaaa",
+              "description" => "Taxon A",
+              "links" => {}
+            },
+            {
+              "base_path" => "/taxons/root_taxon/taxon_b",
+              "content_id" => "bbbb",
+              "description" => "Taxon B",
+              "links" => {}
+            }
+          ]
+        }
+      }
+    end
+
+    def root_taxons
+      {
+        "base_path" => "/",
+        "content_id" => "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a",
+        "links" => {
+          "root_taxons" => [
+            {
+              "base_path" => "/taxons/taxon_a",
+              "content_id" => "aaaa"
+            },
+            {
+              "base_path" => "/taxons/taxon_b",
+              "content_id" => "bbbb"
+            }
+          ],
+        }
+      }
+    end
+
+    def no_taxons
+      {
+        "base_path" => "/",
+        "content_id" => "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a"
+      }
+    end
+  end
+end


### PR DESCRIPTION
Added two rake tasks to export taxons and  content to file.

- `rake export_data::taxons::export `
exports taxons as a single array in a JSON file. Root taxons are encoded as : `{content_id: , base_path: }` and child taxons as `{content_id: , base_path: , parent_content_id: }`

- `rake export_data::content::export`
exports content as a single array in a JSON file. Content is encoded as `{link: , description: , taxons: , content_id:, 'content_store_document_type: , indexable_content: }`

trello: https://trello.com/c/pzvssOL5/120-provide-data-for-assessing-concept-coverage
