### PR TITLE
[DO NOT MERGE] Set visible_to_department_editors to true on publish

### DIFF
--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -104,7 +104,7 @@ class TaxonsController < ApplicationController
   end
 
   def publish
-    Services.publishing_api.publish(content_id)
+    Taxonomy::PublishTaxon.call(taxon)
     redirect_to taxon_path(content_id), success: "You have successfully published the taxon"
   end
 

--- a/app/services/taxonomy/bulk_update_taxon.rb
+++ b/app/services/taxonomy/bulk_update_taxon.rb
@@ -12,7 +12,7 @@ module Taxonomy
       linked_content_item = GovukTaxonomyHelpers::LinkedContentItem.from_content_id(content_id: @root_taxon_content_id,
                                                                                     publishing_api: Services.publishing_api)
       linked_content_item.each do |taxon|
-        PublishTaxonWorker.perform_async(taxon.content_id)
+        PublishTaxonWorker.perform_async(taxon)
       end
     end
   end

--- a/app/services/taxonomy/publish_taxon.rb
+++ b/app/services/taxonomy/publish_taxon.rb
@@ -1,0 +1,20 @@
+module Taxonomy
+  class PublishTaxon
+    def initialize(taxon)
+      @taxon = taxon
+    end
+
+    def self.call(taxon)
+      new(taxon).publish
+    end
+
+    def publish
+      if @taxon.parent.nil? && @taxon.visible_to_departmental_editors == false
+        @taxon.visible_to_departmental_editors = true
+        Taxonomy::UpdateTaxon.call(taxon: @taxon)
+      end
+
+      Services.publishing_api.publish(@taxon.content_id)
+    end
+  end
+end

--- a/app/services/taxonomy/update_taxon.rb
+++ b/app/services/taxonomy/update_taxon.rb
@@ -45,7 +45,7 @@ module Taxonomy
 
     def links
       {
-        parent_taxons: parent.empty? ? [] : Array(parent),
+        parent_taxons: parent.blank? ? [] : Array(parent),
         associated_taxons: associated_taxons.blank? ? [] : Array(associated_taxons.reject(&:blank?)),
       }
     end

--- a/app/workers/publish_taxon_worker.rb
+++ b/app/workers/publish_taxon_worker.rb
@@ -1,8 +1,8 @@
 class PublishTaxonWorker
   include Sidekiq::Worker
 
-  def perform(taxon_content_id)
-    Services.publishing_api.publish(taxon_content_id)
+  def perform(taxon)
+    Taxonomy::PublishTaxon.call(taxon)
   rescue GdsApi::HTTPConflict => ex # Ignore attempts to publish already published content
     puts "409 #{ex.message}"
   end

--- a/spec/features/draft_taxons_spec.rb
+++ b/spec/features/draft_taxons_spec.rb
@@ -11,6 +11,7 @@ RSpec.feature "Draft taxonomy" do
   end
 
   scenario "User can publish draft taxons" do
+    given_there_is_an_education_theme
     given_there_is_a_draft_taxon
     when_i_visit_the_taxon_page
     and_i_click_the_publish_button
@@ -69,6 +70,10 @@ RSpec.feature "Draft taxonomy" do
     expect(page).to have_text(@taxon_3[:title])
   end
 
+  def given_there_is_an_education_theme
+    create(:theme, :education)
+  end
+
   def given_there_is_a_draft_taxon
     @taxon_content_id = SecureRandom.uuid
 
@@ -98,6 +103,9 @@ RSpec.feature "Draft taxonomy" do
   end
 
   def and_i_confirm_that_i_want_to_publish
+    stub_request(:put, "https://publishing-api.test.gov.uk/v2/content/#{@taxon_content_id}")
+    stub_request(:patch, "https://publishing-api.test.gov.uk/v2/links/#{@taxon_content_id}")
+
     @publish_request = stub_request(:post, "https://publishing-api.test.gov.uk/v2/content/#{@taxon_content_id}/publish")
       .to_return(status: 200, body: "{}")
 

--- a/spec/services/taxonomy/bulk_update_taxon_spec.rb
+++ b/spec/services/taxonomy/bulk_update_taxon_spec.rb
@@ -2,20 +2,21 @@ require 'rails_helper'
 
 RSpec.describe Taxonomy::BulkUpdateTaxon do
   before do
-    item = GovukTaxonomyHelpers::LinkedContentItem.new(title: 'item1', base_path: '/item1', content_id: 'id1')
-    item << GovukTaxonomyHelpers::LinkedContentItem.new(title: 'item2', base_path: '/item2', content_id: 'id2')
+    @item = GovukTaxonomyHelpers::LinkedContentItem.new(title: 'item1', base_path: '/item1', content_id: 'id1')
+    @child_item = GovukTaxonomyHelpers::LinkedContentItem.new(title: 'item2', base_path: '/item2', content_id: 'id2')
+    @item << @child_item
 
     @root_taxon_id = 123
     allow(GovukTaxonomyHelpers::LinkedContentItem)
       .to receive(:from_content_id)
       .with(content_id: @root_taxon_id, publishing_api: Services.publishing_api)
-      .and_return(item)
+      .and_return(@item)
   end
 
   describe '#call' do
     it 'spawns a worker for each id' do
-      expect(PublishTaxonWorker).to receive(:perform_async).with('id1')
-      expect(PublishTaxonWorker).to receive(:perform_async).with('id2')
+      expect(PublishTaxonWorker).to receive(:perform_async).with(@item)
+      expect(PublishTaxonWorker).to receive(:perform_async).with(@child_item)
       Taxonomy::BulkUpdateTaxon.call(@root_taxon_id)
     end
   end

--- a/spec/services/taxonomy/publish_taxon_spec.rb
+++ b/spec/services/taxonomy/publish_taxon_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe Taxonomy::PublishTaxon do
+  let(:parent_taxon) do
+    Taxon.new(
+      content_id: '1234',
+      title: 'Parent taxon',
+      visible_to_departmental_editors: false,
+    )
+  end
+
+  let(:taxon) do
+    Taxon.new(
+      content_id: '5678',
+      title: 'Taxon',
+      parent: parent_taxon,
+      visible_to_departmental_editors: false,
+    )
+  end
+
+  describe '#call' do
+    it 'sends publish request to publishing api' do
+      expect(Services.publishing_api).to receive(:publish).with(taxon.content_id)
+      Taxonomy::PublishTaxon.call(taxon)
+    end
+
+    context 'when publishing a branch root taxon' do
+      context 'when visible_to_department_editors is false' do
+        it 'sets visible_to_department_editors field to true' do
+          expect(Taxonomy::UpdateTaxon).to receive(:call).with(taxon: parent_taxon)
+          expect(Services.publishing_api).to receive(:publish).with(parent_taxon.content_id)
+          Taxonomy::PublishTaxon.call(parent_taxon)
+
+          expect(parent_taxon.visible_to_departmental_editors).to be_truthy
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
For https://trello.com/c/b3TTdin2/157-prevent-publishers-seeing-draft-taxons-in-government-frontend

Add a `PublishService` class to encapsulate the logic for setting the `visible_to_department_editors` field to `true` when a taxon is published. This commit goes hand in hand with code changes to NavigationHelpers to enable showing/hiding taxons based on the `visible_to_department_editors` value.