### PR TITLE
Simplify path slug validation

### DIFF
--- a/app/assets/javascripts/base-path-preview.js
+++ b/app/assets/javascripts/base-path-preview.js
@@ -24,10 +24,10 @@
 
         if (parentTaxonContentId.length !== 0) {
           $.getJSON(url, function(taxon) {
-            $previewBasePathEl.text(taxon.path_prefix + $pathSlugInputEl.val());
+            $previewBasePathEl.text('/' + taxon.path_prefix + '/' + $pathSlugInputEl.val());
           });
         } else {
-          $previewBasePathEl.text($pathSlugInputEl.val());
+          $previewBasePathEl.text('/' + $pathSlugInputEl.val());
         }
       }
     };

--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -25,11 +25,11 @@ class TaxonsController < ApplicationController
       redirect_to taxon_path(taxon.content_id), success: t('controllers.taxons.create_success')
     else
       error_messages = taxon.errors.full_messages.join('; ')
-      flash[:danger] = error_messages
+      flash.now[:danger] = error_messages
       render :new, locals: { page: Taxonomy::EditPage.new(taxon) }
     end
   rescue Taxonomy::UpdateTaxon::InvalidTaxonError => e
-    flash[:danger] = e.message
+    flash.now[:danger] = e.message
     render :new, locals: { page: Taxonomy::EditPage.new(taxon) }
   end
 
@@ -59,17 +59,17 @@ class TaxonsController < ApplicationController
       redirect_to taxon_path(taxon.content_id)
     else
       error_messages = taxon.errors.full_messages.join('; ')
-      flash[:danger] = error_messages
+      flash.now[:danger] = error_messages
       render :edit, locals: { page: Taxonomy::EditPage.new(taxon) }
     end
   rescue Taxonomy::UpdateTaxon::InvalidTaxonError => e
-    flash[:danger] = e.message
+    flash.now[:danger] = e.message
     render :edit, locals: { page: Taxonomy::EditPage.new(taxon) }
   end
 
   def destroy
     if params[:taxon][:redirect_to].empty?
-      flash[:danger] = t("controllers.taxons.destroy_no_redirect")
+      flash.now[:danger] = t("controllers.taxons.destroy_no_redirect")
       render :confirm_delete, locals: { page: Taxonomy::ShowPage.new(taxon) }
     else
       base_path = Services.publishing_api.get_content(params[:taxon][:redirect_to])['base_path']

--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -19,7 +19,7 @@ class Taxon
 
   validates_presence_of :title, :description, :internal_name, :path_slug
   validates_presence_of :path_prefix, if: -> { parent.present? }
-  validates :path_slug, format: { with: %r{\A/[a-zA-Z0-9\-]+\z}, message: "alphanumeric path must begin with /" }
+  validates :path_slug, format: { with: %r{\A[A-z0-9\-]+\z}, message: "path must not contain /" }
   validates_with CircularDependencyValidator
 
   def draft?
@@ -43,7 +43,7 @@ class Taxon
   end
 
   def base_path=(base_path)
-    path_components = %r{(?<prefix>/[^/]+)(?<slug>/.+)?}.match(base_path)
+    path_components = %r{\/(?<prefix>[A-z0-9\-]+)(\/(?<slug>[A-z0-9\-]+))?}.match(base_path)
 
     return if path_components.nil?
 
@@ -52,15 +52,7 @@ class Taxon
   end
 
   def base_path
-    @base_path ||= path_prefix + path_slug
-  end
-
-  def path_prefix
-    @path_prefix ||= ''
-  end
-
-  def path_slug
-    @path_slug ||= ''
+    @base_path ||= '/' + [path_prefix, path_slug].compact.join('/')
   end
 
   def link_type

--- a/spec/features/taxonomy_editing_spec.rb
+++ b/spec/features/taxonomy_editing_spec.rb
@@ -198,7 +198,7 @@ RSpec.feature "Taxonomy editing" do
     fill_in :taxon_description, with: "A description of my lovely taxon."
     fill_in :taxon_internal_name, with: "Newly created taxon"
     fill_in :taxon_notes_for_editors, with: @dummy_editor_notes
-    fill_in :taxon_path_slug, with: '/newly-created-taxon'
+    fill_in :taxon_path_slug, with: 'newly-created-taxon'
   end
 
   def and_i_select_associated_taxons
@@ -212,7 +212,7 @@ RSpec.feature "Taxonomy editing" do
   end
 
   def when_i_change_the_path
-    fill_in :taxon_path_slug, with: '/new-slug'
+    fill_in :taxon_path_slug, with: 'new-slug'
   end
 
   def when_i_update_the_taxon
@@ -268,7 +268,7 @@ RSpec.feature "Taxonomy editing" do
     fill_in :taxon_title, with: 'My Taxon'
     fill_in :taxon_description, with: 'Description of my taxon.'
     fill_in :taxon_internal_name, with: 'My Taxon'
-    fill_in :taxon_path_slug, with: '/slug'
+    fill_in :taxon_path_slug, with: 'slug'
 
     stub_request(:put, %r{https://publishing-api.test.gov.uk/v2/content*})
       .to_return(status: 422, body: {}.to_json)
@@ -282,7 +282,7 @@ RSpec.feature "Taxonomy editing" do
     fill_in :taxon_title, with: 'My Taxon'
     fill_in :taxon_description, with: 'Description of my taxon.'
     fill_in :taxon_internal_name, with: 'My Taxon'
-    fill_in :taxon_path_slug, with: '/slug'
+    fill_in :taxon_path_slug, with: 'slug'
 
     stub_request(:put, %r{https://publishing-api.test.gov.uk/v2/content*})
       .to_return(status: 422, body: {}.to_json)

--- a/spec/models/taxon_spec.rb
+++ b/spec/models/taxon_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Taxon do
 
       expect(taxon).to_not be_valid
       expect(taxon.errors.keys).to include(:path_slug)
-      expect(taxon.errors[:path_slug]).to include("alphanumeric path must begin with /")
+      expect(taxon.errors[:path_slug]).to include("path must not contain /")
     end
   end
 
@@ -43,8 +43,8 @@ RSpec.describe Taxon do
     valid_taxon = described_class.new(
       title: 'Title',
       description: 'Description',
-      path_prefix: "/education",
-      path_slug: '/ab01-cd02',
+      path_prefix: "education",
+      path_slug: 'ab01-cd02',
     )
 
     expect(valid_taxon).to be_valid
@@ -52,8 +52,8 @@ RSpec.describe Taxon do
     invalid_taxon = described_class.new(
       title: 'Title',
       description: 'Description',
-      path_prefix: "/education",
-      path_slug: '/slug/',
+      path_prefix: "education",
+      path_slug: 'foo/bar',
     )
 
     expect(invalid_taxon).to_not be_valid
@@ -66,8 +66,22 @@ RSpec.describe Taxon do
         base_path: '/childcare-parenting/childcare-and-early-years'
       )
 
-      expect(taxon.path_prefix).to eq '/childcare-parenting'
-      expect(taxon.path_slug).to eq '/childcare-and-early-years'
+      expect(taxon.path_prefix).to eq 'childcare-parenting'
+      expect(taxon.path_slug).to eq 'childcare-and-early-years'
+    end
+  end
+
+  describe '#base_path' do
+    it "returns the base_path for root taxons" do
+      expect(described_class.new(
+        base_path: '/childcare-parenting'
+      ).base_path).to eq '/childcare-parenting'
+    end
+
+    it "returns the base_path for child taxons" do
+      expect(described_class.new(
+        base_path: '/childcare-parenting/childcare-and-early-years'
+      ).base_path).to eq '/childcare-parenting/childcare-and-early-years'
     end
   end
 


### PR DESCRIPTION
A valid path would be /highest-level-taxon-name/taxon-name, and as we
are automatically prefixing the /highest-level-taxon-name, the user is
restricted to the last part of the path, and only to a single level.

We change the taxon form field to not require a leading slash as it's an
unnecessary requirement for the user when they can only define paths to
one level anyway.