### PR TITLE
Show a friendly error message on publish failure

### DIFF
--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -109,6 +109,10 @@ class TaxonsController < ApplicationController
   def publish
     Services.publishing_api.publish(content_id)
     redirect_to taxon_path(content_id), success: "You have successfully published the taxon"
+  rescue GdsApi::HTTPUnprocessableEntity => e
+    GovukError.notify(e, level: "warning")
+    flash.now[:danger] = I18n.t('errors.invalid_taxon')
+    render :edit, locals: { page: Taxonomy::EditPage.new(taxon) }
   end
 
   def confirm_discard


### PR DESCRIPTION
When trying to publish a taxon with the Publishing API sometimes this can fail. Rather than showing the user a 500 error, it seems like a good idea to show a slightly more useful error message while also recording the problem in Sentry for us to investigate.

This was found since Content Tagger relies on Publishing API to perform validation of base paths, and we will shortly be adding checks to make sure they are unique regardless of letter case which may affect users of the application.

[Trello Card](https://trello.com/c/TP0m8elk/317-case-insensitive-base-paths-in-content-tagger)