### PR TITLE
Adds blacklisted_documents rake task

### DIFF
--- a/app/services/data_export/content_export.rb
+++ b/app/services/data_export/content_export.rb
@@ -98,7 +98,23 @@ module DataExport
       {}
     end
 
+    def blacklisted_content_stats(document_types = ContentExport::BLACKLIST_DOCUMENT_TYPES)
+      filtered_aggregates = document_aggregates.keep_if do |aggregate|
+        document_types.include?(aggregate.dig('value', 'slug'))
+      end
+      results = filtered_aggregates.map do |aggregate|
+        { document_type: aggregate.dig('value', 'slug'),
+          count: aggregate["documents"] }
+      end
+      results.sort_by { |r| -r[:count] }
+    end
+
   private
+
+    def document_aggregates
+      Services.rummager.search(aggregate_content_store_document_type: 10_000, count: 0)
+        .dig('aggregates', 'content_store_document_type', 'options')
+    end
 
     def get_content_hash(path)
       Services.content_store.content_item(path).to_h

--- a/lib/tasks/export_data.rake
+++ b/lib/tasks/export_data.rake
@@ -30,5 +30,13 @@ namespace :export_data do
         f << "]\n"
       end
     end
+
+    desc "Get number of documents per document type omitted in the document export"
+    task blacklisted_documents: :environment do
+      blacklisted_content_stats = DataExport::ContentExport.new.blacklisted_content_stats
+      File.open('tmp/blacklisted_content_stats.json', 'w') do |f|
+        f << JSON.dump(blacklisted_content_stats)
+      end
+    end
   end
 end


### PR DESCRIPTION
This rake task exports the number of documents per document type
omitted in the document export to tmp/blacklisted_content_stats.json

https://trello.com/c/rEYHJoS0/213-get-numbers-of-rejected-data-science-content