### PR TITLE
Move content coverage metrics in to content tagger

### DIFF
--- a/app/services/metrics.rb
+++ b/app/services/metrics.rb
@@ -1,0 +1,9 @@
+module Metrics
+  def self.statsd
+    @_statsd ||= begin
+      statsd_client = Statsd.new
+      statsd_client.namespace = "govuk.topic-taxonomy"
+      statsd_client
+    end
+  end
+end

--- a/app/services/metrics/content_coverage_metrics.rb
+++ b/app/services/metrics/content_coverage_metrics.rb
@@ -1,0 +1,127 @@
+module Metrics
+  class ContentCoverageMetrics
+    BLACKLIST_DOCUMENT_TYPES = %w[
+      redirect
+      staff_update
+      coming_soon
+      travel_advice
+      html_publication
+      manual_section
+      hmrc_manual_section
+      contact
+      completed_transaction
+      service_standard_report
+      employment_tribunal_decision
+      tax_tribunal_decision
+      utaac_decision
+      dfid_research_output
+      asylum_support_decision
+      employment_appeal_tribunal_decision
+      cma_case
+      need
+      working_group
+      organisation
+      person
+      worldwide_organisation
+      world_location
+      topical_event
+      policy_area
+      field_of_operation
+      ministerial_role
+      topical_event_about_page
+      finder_email_signup
+      mainstream_browse_page
+      topic
+      homepage
+      licence_finder
+      search
+      taxon
+      travel_advice_index
+      business_support_finder
+      finder
+      about
+      about_our_services
+      personal_information_charter
+      equality_and_diversity
+      our_governance
+      services_and_information
+      our_energy_use
+      corporate_report
+      social_media_use
+      access_and_opening
+      membership
+      publication_scheme
+      media_enquiries
+      complaints_procedure
+      help_page
+      service_manual_homepage
+      service_manual_service_toolkit
+      service_manual_service_standard
+      service_manual_guide
+      service_manual_topic
+      gone
+    ].freeze
+
+    def record_all
+      all_govuk_items
+      average_tagging_depth
+      tagged_items_in_scope
+      untagged_items_in_scope
+    end
+
+    def all_govuk_items
+      gauge("all_govuk_items", all_govuk_items_count)
+    end
+
+    def average_tagging_depth
+      gauge("items_in_scope", items_in_scope_count)
+    end
+
+    def tagged_items_in_scope
+      gauge("tagged_items_in_scope", tagged_items_in_scope_count)
+    end
+
+    def untagged_items_in_scope
+      gauge(
+        "untagged_items_in_scope",
+        items_in_scope_count - tagged_items_in_scope_count
+      )
+    end
+
+  private
+
+    def all_govuk_items_count
+      @_items_count ||= Services.rummager.search(
+        count: 0,
+        debug: 'include_withdrawn'
+      ).to_h.fetch("total")
+    end
+
+    def items_in_scope_count
+      @_items_in_scope_count ||= Services.rummager.search(
+        count: 0,
+        reject_content_store_document_type: BLACKLIST_DOCUMENT_TYPES,
+        debug: 'include_withdrawn'
+      ).to_h.fetch("total")
+    end
+
+    def tagged_items_in_scope_count
+      @_tagged_items_in_scope_count ||= Services.rummager.search(
+        count: 0,
+        filter_part_of_taxonomy_tree: root_taxon_content_ids,
+        reject_content_store_document_type: BLACKLIST_DOCUMENT_TYPES,
+        debug: 'include_withdrawn'
+      ).to_h.fetch("total")
+    end
+
+    def root_taxon_content_ids
+      GovukTaxonomy::Branches.new.all.map do |root_taxon|
+        root_taxon['content_id']
+      end
+    end
+
+    def gauge(stat, value)
+      Metrics.statsd.gauge(stat, value)
+    end
+  end
+end

--- a/app/services/metrics/content_coverage_metrics.rb
+++ b/app/services/metrics/content_coverage_metrics.rb
@@ -1,67 +1,5 @@
 module Metrics
   class ContentCoverageMetrics
-    BLACKLIST_DOCUMENT_TYPES = %w[
-      redirect
-      staff_update
-      coming_soon
-      travel_advice
-      html_publication
-      manual_section
-      hmrc_manual_section
-      contact
-      completed_transaction
-      service_standard_report
-      employment_tribunal_decision
-      tax_tribunal_decision
-      utaac_decision
-      dfid_research_output
-      asylum_support_decision
-      employment_appeal_tribunal_decision
-      cma_case
-      need
-      working_group
-      organisation
-      person
-      worldwide_organisation
-      world_location
-      topical_event
-      policy_area
-      field_of_operation
-      ministerial_role
-      topical_event_about_page
-      finder_email_signup
-      mainstream_browse_page
-      topic
-      homepage
-      licence_finder
-      search
-      taxon
-      travel_advice_index
-      business_support_finder
-      finder
-      about
-      about_our_services
-      personal_information_charter
-      equality_and_diversity
-      our_governance
-      services_and_information
-      our_energy_use
-      corporate_report
-      social_media_use
-      access_and_opening
-      membership
-      publication_scheme
-      media_enquiries
-      complaints_procedure
-      help_page
-      service_manual_homepage
-      service_manual_service_toolkit
-      service_manual_service_standard
-      service_manual_guide
-      service_manual_topic
-      gone
-    ].freeze
-
     def record_all
       all_govuk_items
       average_tagging_depth
@@ -100,7 +38,7 @@ module Metrics
     def items_in_scope_count
       @_items_in_scope_count ||= Services.rummager.search(
         count: 0,
-        reject_content_store_document_type: BLACKLIST_DOCUMENT_TYPES,
+        reject_content_store_document_type: blacklisted_document_types,
         debug: 'include_withdrawn'
       ).to_h.fetch("total")
     end
@@ -109,7 +47,7 @@ module Metrics
       @_tagged_items_in_scope_count ||= Services.rummager.search(
         count: 0,
         filter_part_of_taxonomy_tree: root_taxon_content_ids,
-        reject_content_store_document_type: BLACKLIST_DOCUMENT_TYPES,
+        reject_content_store_document_type: blacklisted_document_types,
         debug: 'include_withdrawn'
       ).to_h.fetch("total")
     end
@@ -122,6 +60,11 @@ module Metrics
 
     def gauge(stat, value)
       Metrics.statsd.gauge(stat, value)
+    end
+
+    def blacklisted_document_types
+      @_blacklisted_document_types ||=
+        config_for(:blacklisted_document_types)['document_types']
     end
   end
 end

--- a/lib/tasks/taxonomy_metrics.rake
+++ b/lib/tasks/taxonomy_metrics.rake
@@ -6,5 +6,9 @@ namespace :metrics do
       m.count_content_per_level
       m.average_tagging_depth
     end
+
+    task record_content_coverage_metrics: :environment do
+      Metrics::ContentCoverageMetrics.new.record_all
+    end
   end
 end

--- a/spec/services/metrics/content_coverage_metrics_spec.rb
+++ b/spec/services/metrics/content_coverage_metrics_spec.rb
@@ -1,0 +1,81 @@
+require 'rails_helper'
+
+module Metrics
+  RSpec.describe ContentCoverageMetrics do
+    describe '#record_all' do
+      before do
+        blacklist = %w[taxon redirect]
+        stub_const(
+          "Metrics::ContentCoverageMetrics::BLACKLIST_DOCUMENT_TYPES",
+          blacklist
+        )
+
+        stub_request(:get, "#{Plek.find('rummager')}/search.json")
+          .with(
+            query: {
+              count: 0,
+              debug: 'include_withdrawn'
+            }
+          )
+          .to_return(body: JSON.dump(total: 1000))
+
+        stub_request(:get, "#{Plek.find('rummager')}/search.json")
+          .with(
+            query: {
+              count: 0,
+              debug: 'include_withdrawn',
+              reject_content_store_document_type: blacklist
+            }
+          ).to_return(body: JSON.dump(total: 500))
+
+        @root_taxons = FactoryGirl.build_list(:linkable_taxon_hash, 2)
+
+        stub_request(:get, "#{Plek.find('rummager')}/search.json")
+          .with(
+            query: {
+              count: 0,
+              debug: 'include_withdrawn',
+              filter_part_of_taxonomy_tree: @root_taxons.map { |x| x[:content_id] },
+              reject_content_store_document_type: blacklist
+            }
+          ).to_return(body: JSON.dump(total: 400))
+
+        publishing_api_has_expanded_links(
+          content_id: GovukTaxonomy::ROOT_CONTENT_ID,
+          expanded_links: {
+            root_taxons: @root_taxons
+          }
+        )
+        publishing_api_has_expanded_links(
+          {
+            content_id: GovukTaxonomy::ROOT_CONTENT_ID,
+            expanded_links: {
+              root_taxons: [],
+            }
+          },
+          with_drafts: false
+        )
+      end
+
+      it "sends the correct values to statsd" do
+        coverage_metrics = Metrics::ContentCoverageMetrics.new
+
+        allow(coverage_metrics).to receive(:gauge)
+
+        coverage_metrics.record_all
+
+        expect(coverage_metrics).to have_received(:gauge)
+                                      .with("all_govuk_items", 1000)
+
+        expect(coverage_metrics).to have_received(:gauge)
+                                     .with("items_in_scope", 500)
+
+        expect(coverage_metrics).to have_received(:gauge)
+                                     .with("tagged_items_in_scope", 400)
+
+        expect(coverage_metrics).to have_received(:gauge)
+                                     .with("untagged_items_in_scope", 100)
+      end
+    end
+  end
+end

--- a/spec/services/metrics/content_coverage_metrics_spec.rb
+++ b/spec/services/metrics/content_coverage_metrics_spec.rb
@@ -5,10 +5,8 @@ module Metrics
     describe '#record_all' do
       before do
         blacklist = %w[taxon redirect]
-        stub_const(
-          "Metrics::ContentCoverageMetrics::BLACKLIST_DOCUMENT_TYPES",
-          blacklist
-        )
+        allow_any_instance_of(Metrics::ContentCoverageMetrics)
+          .to receive(:blacklisted_document_types).and_return(blacklist)
 
         stub_request(:get, "#{Plek.find('rummager')}/search.json")
           .with(


### PR DESCRIPTION
Trello: https://trello.com/c/XU5HjSnb/218-move-the-taxonomy-metrics-out-of-the-govuk-tagging-monitor-and-in-to-content-tagger