### PR TITLE
Update query used for organisation tagging progress

### DIFF
--- a/app/queries/tagging_progress_by_organisations_query.rb
+++ b/app/queries/tagging_progress_by_organisations_query.rb
@@ -54,7 +54,13 @@ private
       start: 0,
       aggregate_primary_publishing_organisation: '0,scope:all_filters',
       filter_primary_publishing_organisation: organisations,
-      reject_taxons: '_MISSING',
+      filter_part_of_taxonomy_tree: root_taxon_content_ids,
     ).to_h.dig("aggregates", "primary_publishing_organisation", "options")
+  end
+
+  def root_taxon_content_ids
+    GovukTaxonomy::Branches.new.all.map do |root_taxon|
+      root_taxon['content_id']
+    end
   end
 end

--- a/spec/features/project_spec.rb
+++ b/spec/features/project_spec.rb
@@ -83,6 +83,7 @@ RSpec.feature "Projects", type: :feature do
   end
 
   scenario "viewing tagging progress for organisations" do
+    stub_draft_taxonomy_branch
     stub_organisation_tagging_progress
 
     when_i_visit_the_project_index_page

--- a/spec/queries/tagging_progress_by_organisations_query_spec.rb
+++ b/spec/queries/tagging_progress_by_organisations_query_spec.rb
@@ -1,6 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe TaggingProgressByOrganisationsQuery do
+  include TaxonomyHelper
+
+  before do
+    stub_draft_taxonomy_branch
+  end
+
   let(:name) do
     ['department-for-transport', 'high-speed-two-limited']
   end
@@ -8,13 +14,13 @@ RSpec.describe TaggingProgressByOrganisationsQuery do
   describe '#percentage_tagged' do
     it 'returns an empty table when nothing is returned' do
       stub_rummager_totals(rummager_empty)
-      stub_rummager_untagged(rummager_empty)
+      stub_rummager_tagged(rummager_empty)
       expect(TaggingProgressByOrganisationsQuery.new(organisations).percentage_tagged).to be_empty
     end
 
     it 'returns zeros when there are no documents' do
       stub_rummager_totals(rummager_zeros)
-      stub_rummager_untagged(rummager_zeros)
+      stub_rummager_tagged(rummager_zeros)
       expect(TaggingProgressByOrganisationsQuery.new(organisations).percentage_tagged)
         .to eq('department-for-transport' => { percentage: 0.0, total: 0, tagged: 0 },
                'high-speed-two-limited' => { percentage: 0.0, total: 0, tagged: 0 })
@@ -22,7 +28,7 @@ RSpec.describe TaggingProgressByOrganisationsQuery do
 
     it 'returns correct values' do
       stub_rummager_totals(rummager_totals)
-      stub_rummager_untagged(rummager_untagged)
+      stub_rummager_tagged(rummager_tagged)
       expect(TaggingProgressByOrganisationsQuery.new(organisations).percentage_tagged)
         .to eq('department-for-transport' => { percentage: 25.0, total: 20, tagged: 5 },
                'high-speed-two-limited' => { percentage: 56.25, total: 80, tagged: 45 })
@@ -32,31 +38,35 @@ RSpec.describe TaggingProgressByOrganisationsQuery do
   describe '#total_counts' do
     it 'returns an empty hash when nothing is returned' do
       stub_rummager_totals(rummager_empty)
-      stub_rummager_untagged(rummager_empty)
+      stub_rummager_tagged(rummager_empty)
       expect(TaggingProgressByOrganisationsQuery.new(organisations).total_counts).to be_empty
     end
 
     it 'returns zeros when there are no documents' do
       stub_rummager_totals(rummager_zeros)
-      stub_rummager_untagged(rummager_zeros)
+      stub_rummager_tagged(rummager_zeros)
       expect(TaggingProgressByOrganisationsQuery.new(organisations).total_counts).to eq(percentage: 0.0, total: 0, tagged: 0)
     end
 
     it 'returns correct totals' do
       stub_rummager_totals(rummager_totals)
-      stub_rummager_untagged(rummager_untagged)
+      stub_rummager_tagged(rummager_tagged)
       expect(TaggingProgressByOrganisationsQuery.new(organisations).total_counts)
         .to eq(percentage: 50.0, total: 100, tagged: 50)
     end
   end
 
   # HELPERS #
-  def stub_rummager_untagged(return_hash)
-    allow(Services.rummager).to receive(:search).with(hash_including(reject_taxons: '_MISSING')).and_return return_hash
+  def stub_rummager_tagged(return_hash)
+    allow(Services.rummager).to receive(:search).with(
+      hash_including(filter_part_of_taxonomy_tree: anything)
+    ).and_return return_hash
   end
 
   def stub_rummager_totals(return_hash)
-    allow(Services.rummager).to receive(:search).with(hash_excluding(reject_taxons: '_MISSING')).and_return return_hash
+    allow(Services.rummager).to receive(:search).with(
+      hash_excluding(filter_part_of_taxonomy_tree: anything)
+    ).and_return return_hash
   end
 
   def organisations
@@ -98,7 +108,7 @@ RSpec.describe TaggingProgressByOrganisationsQuery do
       "suggested_queries" => [] }
   end
 
-  def rummager_untagged
+  def rummager_tagged
     { "results" => [],
       "total" => 50,
       "start" => 0,

--- a/spec/support/taxonomy_helper.rb
+++ b/spec/support/taxonomy_helper.rb
@@ -50,16 +50,16 @@ module TaxonomyHelper
   end
 
   def stub_organisation_tagging_progress
-    stub_request(:get, rummager_url_for_all_document_counts)
+    stub_request(:get, rummager_url_for_all_document_counts_url)
       .to_return(body: all_document_counts_response.to_json)
 
-    stub_request(:get, rummager_url_for_tagged_document_counts)
+    stub_request(:get, rummager_url_for_tagged_document_counts_url)
       .to_return(body: tagged_documents_counts_response.to_json)
   end
 
 private
 
-  def rummager_url_for_all_document_counts
+  def rummager_url_for_all_document_counts_url
     "https://rummager.test.gov.uk/search.json?aggregate_primary_publishing_organisation=0,scope:all_filters&count=0&filter_primary_publishing_organisation%5B%5D=department-for-transport&filter_primary_publishing_organisation%5B%5D=high-speed-two-limited&filter_primary_publishing_organisation%5B%5D=home-office&filter_primary_publishing_organisation%5B%5D=maritime-and-coastguard-agency&start=0"
   end
 
@@ -86,8 +86,8 @@ private
     }
   end
 
-  def rummager_url_for_tagged_document_counts
-    "https://rummager.test.gov.uk/search.json?aggregate_primary_publishing_organisation=0,scope:all_filters&count=0&filter_primary_publishing_organisation%5B%5D=department-for-transport&filter_primary_publishing_organisation%5B%5D=high-speed-two-limited&filter_primary_publishing_organisation%5B%5D=home-office&filter_primary_publishing_organisation%5B%5D=maritime-and-coastguard-agency&reject_taxons=_MISSING&start=0"
+  def rummager_url_for_tagged_document_counts_url
+    "https://rummager.test.gov.uk/search.json?aggregate_primary_publishing_organisation=0,scope:all_filters&count=0&filter_part_of_taxonomy_tree%5B%5D=aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa&filter_primary_publishing_organisation%5B%5D=department-for-transport&filter_primary_publishing_organisation%5B%5D=high-speed-two-limited&filter_primary_publishing_organisation%5B%5D=home-office&filter_primary_publishing_organisation%5B%5D=maritime-and-coastguard-agency&start=0"
   end
 
   def tagged_documents_counts_response


### PR DESCRIPTION
Using the reject_taxons field to calculate the number of tagged content
items did not correctly represent the Topic Taxonomy. Now that we have
taxons imported from policies, mainstream browse, etc. there are a
number of content items that are not tagged to the Topic Taxonomy.
However, they are "tagged" and so the reject_taxons field is not fit for
purpose anymore.