### PR TITLE
Document type tagging

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -399,4 +399,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.15.3
+   1.16.0

--- a/app/services/bulk_tagging/document_type_tagger.rb
+++ b/app/services/bulk_tagging/document_type_tagger.rb
@@ -1,0 +1,37 @@
+module BulkTagging
+  class DocumentTypeTagger
+    def self.call(taxon_base_path:, document_type:)
+      new(taxon_base_path: taxon_base_path, document_type: document_type).call
+    end
+
+    def initialize(taxon_base_path:, document_type:)
+      @taxon_base_path = taxon_base_path
+      @document_type = document_type
+    end
+
+    def call
+      taxon_content_id = Services.publishing_api.lookup_content_id(base_path: @taxon_base_path)
+      raise StandardError, "Cannot find taxon with base path #{@taxon_base_path}" if taxon_content_id.nil?
+
+      Services.publishing_api.get_content_items_enum(document_type: @document_type, fields: ['content_id']).lazy.map do |document|
+        begin
+          content_id = document.fetch('content_id')
+          new_taxons = add_taxon_link(content_id, taxon_content_id)
+          { status: 'success', message: 'success', content_id: content_id, new_taxons: new_taxons }
+        rescue StandardError => ex
+          { status: 'error', message: ex.message, content_id: content_id, new_taxons: [] }
+        end
+      end
+    end
+
+  private
+
+    def add_taxon_link(content_id, taxon_content_id)
+      response_hash = Services.publishing_api.get_links(content_id).to_h
+      version = response_hash['version']
+      new_taxons = (Array.wrap(response_hash.dig('links', 'taxons')) + [taxon_content_id]).uniq
+      Services.publishing_api.patch_links(content_id, links: { taxons: new_taxons }, previous_version: version)
+      new_taxons
+    end
+  end
+end

--- a/lib/tasks/taxonomy/bulk_tag_document_type.rake
+++ b/lib/tasks/taxonomy/bulk_tag_document_type.rake
@@ -1,0 +1,21 @@
+require 'csv'
+require_relative Rails.root.join('lib', 'tagged_content_exporter')
+
+namespace :taxonomy do
+  desc <<-DESC
+    Bulk tag all content items with a given document type to one taxon.
+    A JSON representation of the output is sent to STDOUT and can be
+    redirected to a file if needed.
+  DESC
+  task :bulk_tag_document_type, %i[document_type taxon_base_path] => :environment do |_, args|
+    document_type = args[:document_type]
+    taxon_base_path = args[:taxon_base_path]
+
+    results = BulkTagging::DocumentTypeTagger.call(taxon_base_path: taxon_base_path, document_type: document_type).map do |result|
+      STDERR.puts(result)
+      result
+    end
+
+    puts results.to_json
+  end
+end

--- a/spec/services/bulk_tagging/document_type_tagger_spec.rb
+++ b/spec/services/bulk_tagging/document_type_tagger_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+include GdsApi::TestHelpers::PublishingApiV2
+
+RSpec.describe BulkTagging::DocumentTypeTagger do
+  it 'cannot find a taxon and raises an error' do
+    publishing_api_has_lookups("/path/to/taxon" => nil)
+    expect { BulkTagging::DocumentTypeTagger.call(taxon_base_path: '/nowhere', document_type: 'document_type') }
+            .to raise_error(StandardError, /Cannot find taxon with base path/)
+  end
+  context 'there is a taxon, some content and links' do
+    before :each do
+      @taxon_content_id = "51ac4247-fd92-470a-a207-6b852a97f2db"
+      publishing_api_has_lookups("/path/to/taxon" => @taxon_content_id)
+      publishing_api_has_content([{ 'content_id' => 'c1' }, { 'content_id' => 'c2' }],
+                                 page: 1,
+                                 document_type: 'document_type',
+                                 fields: ['content_id'])
+
+      publishing_api_has_links(
+        content_id: 'c1',
+        links: {
+          taxons: ["569a9ee5-c195-4b7f-b9dc-edc17a09113f"]
+        },
+        version: 6
+      )
+      publishing_api_has_links(
+        "content_id": 'c2',
+        "links": {},
+        "version": 10
+      )
+    end
+    it 'returns two error messages' do
+      stub_any_publishing_api_patch_links.to_return(status: 404)
+
+      expect(BulkTagging::DocumentTypeTagger.call(taxon_base_path: '/path/to/taxon', document_type: 'document_type').force)
+        .to match_array([{ status: 'error', message: /Response body/, content_id: 'c1', new_taxons: [] },
+                         { status: 'error', message: /Response body/, content_id: 'c2', new_taxons: [] }])
+    end
+    it 'it tags two content items' do
+      stub_any_publishing_api_patch_links
+
+      expect(BulkTagging::DocumentTypeTagger.call(taxon_base_path: '/path/to/taxon', document_type: 'document_type').force)
+        .to match_array([{ status: 'success', message: 'success', content_id: 'c1', new_taxons: ["569a9ee5-c195-4b7f-b9dc-edc17a09113f", @taxon_content_id] },
+                         { status: 'success', message: 'success', content_id: 'c2', new_taxons: [@taxon_content_id] }])
+
+      assert_publishing_api_patch_links('c1',
+                                        links: { taxons: ["569a9ee5-c195-4b7f-b9dc-edc17a09113f", @taxon_content_id] },
+                                        previous_version: 6)
+      assert_publishing_api_patch_links('c2',
+                                        links: { taxons: [@taxon_content_id] },
+                                        previous_version: 10)
+    end
+  end
+end


### PR DESCRIPTION
Adds the `taxonomy:bulk_tag_document_type[document_type, taxon_base_path]` rake task to enable tagging of all content items of a given document type to a single taxon.

https://trello.com/c/ZIOFIqoT/162-bulk-tag-content-items-that-belongs-to-a-single-taxon