### PR TITLE
Fix flaky capybara errors

### DIFF
--- a/app/views/project_content_items/_flags.html.erb
+++ b/app/views/project_content_items/_flags.html.erb
@@ -1,4 +1,4 @@
-<div class="modal-dialog" role="document">
+<div id="flag_modal_id" class="modal-dialog" role="document">
   <div class="modal-content">
     <div class="modal-header">
       <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>

--- a/spec/features/flagging_a_content_item_spec.rb
+++ b/spec/features/flagging_a_content_item_spec.rb
@@ -66,6 +66,7 @@ RSpec.describe "flagging a content item" do
 
   def and_i_flag_the_first_content_item_as_i_need_help
     click_link 'Flag for review'
+    find('#flag_modal_id', wait: 60).visible?
     choose "I need help tagging this"
   end
 
@@ -90,6 +91,7 @@ RSpec.describe "flagging a content item" do
 
   def and_i_flag_the_first_content_item_as_missing_a_relevant_topic_and_i_suggest_a_new_term
     click_link 'Flag for review'
+    find('#flag_modal_id', wait: 60).visible?
     choose "There's no relevant topic for this"
     expect(page).to have_field("Suggest a new topic")
     fill_in "Suggest a new topic", with: "cool new topic"


### PR DESCRIPTION
Capybara sometimes fails on integration on:

 ` scenario "flagging a content_item as 'I need help'"`

and

`scenario "flagging a content item and suggesting a new term"`

This PR adds an explicit wait for the modal to appear which seems to fix the problem.

Trello: https://trello.com/c/Sri4YI7D/240-fix-flaky-tests-in-content-tagger