### PR TITLE
Accept a content_id for bulk tagging of a document type

### DIFF
--- a/app/services/bulk_tagging/document_type_tagger.rb
+++ b/app/services/bulk_tagging/document_type_tagger.rb
@@ -1,22 +1,26 @@
 module BulkTagging
   class DocumentTypeTagger
-    def self.call(taxon_base_path:, document_type:)
-      new(taxon_base_path: taxon_base_path, document_type: document_type).call
+    def self.call(taxon_content_id:, document_type:)
+      new(taxon_content_id: taxon_content_id, document_type: document_type).call
     end
 
-    def initialize(taxon_base_path:, document_type:)
-      @taxon_base_path = taxon_base_path
+    def initialize(taxon_content_id:, document_type:)
+      @taxon_content_id = taxon_content_id
       @document_type = document_type
     end
 
     def call
-      taxon_content_id = Services.publishing_api.lookup_content_id(base_path: @taxon_base_path)
-      raise StandardError, "Cannot find taxon with base path #{@taxon_base_path}" if taxon_content_id.nil?
+      # Ensure @taxon_content_id exists in the publishing api
+      begin
+        Services.publishing_api.get_content(@taxon_content_id)
+      rescue GdsApi::HTTPNotFound
+        raise
+      end
 
       Services.publishing_api.get_content_items_enum(document_type: @document_type, fields: ['content_id']).lazy.map do |document|
         begin
           content_id = document.fetch('content_id')
-          new_taxons = add_taxon_link(content_id, taxon_content_id)
+          new_taxons = add_taxon_link(content_id, @taxon_content_id)
           { status: 'success', message: 'success', content_id: content_id, new_taxons: new_taxons }
         rescue StandardError => ex
           { status: 'error', message: ex.message, content_id: content_id, new_taxons: [] }

--- a/lib/tasks/taxonomy/bulk_tag_document_type.rake
+++ b/lib/tasks/taxonomy/bulk_tag_document_type.rake
@@ -7,11 +7,11 @@ namespace :taxonomy do
     A JSON representation of the output is sent to STDOUT and can be
     redirected to a file if needed.
   DESC
-  task :bulk_tag_document_type, %i[document_type taxon_base_path] => :environment do |_, args|
+  task :bulk_tag_document_type, %i[document_type taxon_content_id] => :environment do |_, args|
     document_type = args[:document_type]
-    taxon_base_path = args[:taxon_base_path]
+    taxon_content_id = args[:taxon_content_id]
 
-    results = BulkTagging::DocumentTypeTagger.call(taxon_base_path: taxon_base_path, document_type: document_type).map do |result|
+    results = BulkTagging::DocumentTypeTagger.call(taxon_content_id: taxon_content_id, document_type: document_type).map do |result|
       STDERR.puts(result)
       result
     end

--- a/spec/services/bulk_tagging/document_type_tagger_spec.rb
+++ b/spec/services/bulk_tagging/document_type_tagger_spec.rb
@@ -2,16 +2,18 @@ require 'rails_helper'
 include GdsApi::TestHelpers::PublishingApiV2
 
 RSpec.describe BulkTagging::DocumentTypeTagger do
+  before :each do
+    @taxon_content_id = "51ac4247-fd92-470a-a207-6b852a97f2db"
+  end
   it 'cannot find a taxon and raises an error' do
-    publishing_api_has_lookups("/path/to/taxon" => nil)
-    expect { BulkTagging::DocumentTypeTagger.call(taxon_base_path: '/nowhere', document_type: 'document_type') }
-            .to raise_error(StandardError, /Cannot find taxon with base path/)
+    publishing_api_does_not_have_item(@taxon_content_id)
+    expect { BulkTagging::DocumentTypeTagger.call(taxon_content_id: @taxon_content_id, document_type: 'document_type') }
+            .to raise_error(GdsApi::HTTPNotFound, /not find content item with/)
   end
   context 'there is a taxon, some content and links' do
     before :each do
-      @taxon_content_id = "51ac4247-fd92-470a-a207-6b852a97f2db"
-      publishing_api_has_lookups("/path/to/taxon" => @taxon_content_id)
-      publishing_api_has_content([{ 'content_id' => 'c1' }, { 'content_id' => 'c2' }],
+      publishing_api_has_item(content_id: @taxon_content_id)
+      publishing_api_has_content([{ content_id: 'c1' }, { content_id: 'c2' }],
                                  page: 1,
                                  document_type: 'document_type',
                                  fields: ['content_id'])
@@ -32,14 +34,14 @@ RSpec.describe BulkTagging::DocumentTypeTagger do
     it 'returns two error messages' do
       stub_any_publishing_api_patch_links.to_return(status: 404)
 
-      expect(BulkTagging::DocumentTypeTagger.call(taxon_base_path: '/path/to/taxon', document_type: 'document_type').force)
+      expect(BulkTagging::DocumentTypeTagger.call(taxon_content_id: @taxon_content_id, document_type: 'document_type').force)
         .to match_array([{ status: 'error', message: /Response body/, content_id: 'c1', new_taxons: [] },
                          { status: 'error', message: /Response body/, content_id: 'c2', new_taxons: [] }])
     end
     it 'it tags two content items' do
       stub_any_publishing_api_patch_links
 
-      expect(BulkTagging::DocumentTypeTagger.call(taxon_base_path: '/path/to/taxon', document_type: 'document_type').force)
+      expect(BulkTagging::DocumentTypeTagger.call(taxon_content_id: @taxon_content_id, document_type: 'document_type').force)
         .to match_array([{ status: 'success', message: 'success', content_id: 'c1', new_taxons: ["569a9ee5-c195-4b7f-b9dc-edc17a09113f", @taxon_content_id] },
                          { status: 'success', message: 'success', content_id: 'c2', new_taxons: [@taxon_content_id] }])
 


### PR DESCRIPTION
THe lookup function for finding a taxon using its base path only finds
live content. We switch to using content_id to identify a taxon to bulk tag