### PR TITLE
Remove "Choose one..." placeholder from taxon typeahead

### DIFF
--- a/app/views/projects/_content_item.html.erb
+++ b/app/views/projects/_content_item.html.erb
@@ -25,7 +25,6 @@
     <p><%= content_item.description %></p>
 
     <%= f.input :taxons,
-      placeholder: 'Choose one...',
       label: false,
       input_html: {
         class: [:select2, :tagging_project, :js_bulk_tagger_input],


### PR DESCRIPTION
When the placeholder text shows, this means that the content item has no
taggings at all.

When the placeholder text does not show, but the typeahead box shows as
empty, this means that the content item has taggings but from other
branches.

From the perspective of the project's view, these two circumstances are
the same: the content item doesn't have any tags applied to it that are
from the project's branch.

It is confusing to the user as to why some boxes show the placeholder,
and others do not but by removing the placeholder text, we should be
able to remove this confusion.

---

Trello: https://trello.com/c/g0ZMrpQN/243-investigate-content-tagger-projects-issues-for-the-coming-to-the-uk-tagging-on-friday