### PR TITLE
Allow content to be tagged to the branch's root taxon

### DIFF
--- a/app/assets/javascripts/taxon-tagger.js
+++ b/app/assets/javascripts/taxon-tagger.js
@@ -167,7 +167,10 @@
     **/
     taxons_for_select2: function(taxons) {
       var self = this;
-      return Object.keys(taxons).reduce(function(acc, taxon_id) {
+      var taxon_content_ids = Object.keys(taxons);
+      var root_content_id = taxon_content_ids.shift();
+
+      return taxon_content_ids.reduce(function(acc, taxon_id) {
         var ancestors = self.taxon_ancestors(taxon_id, taxons);
         ancestors.shift(); // lose the first ancestor, it's common to all taxons
 
@@ -176,7 +179,10 @@
           "text": ancestors.join(' > ')
         });
         return acc;
-      }, []);
+      }, [{
+        "id": root_content_id,
+        "text": taxons[root_content_id].name
+      }]);
     },
 
     // Returns the ancestors array of taxon names


### PR DESCRIPTION
As a temporary measure, we allow taxons in the Project view to be tagged
to the root taxon while there is uncertainly about branch-specific
tagging during the Transport tagathon.

Trello: https://trello.com/c/bgt7eeza/251-add-ability-to-tag-to-the-top-level-taxon-eg-transport

> ![dec-06-2017 15-29-17](https://user-images.githubusercontent.com/885223/33669403-4496b6ec-da9a-11e7-9de9-bf6b29134232.gif)
