### PR TITLE
Fix taxon hierarchy for large taxons

### DIFF
--- a/app/assets/stylesheets/taxonomy-tree.scss
+++ b/app/assets/stylesheets/taxonomy-tree.scss
@@ -51,10 +51,13 @@ $blue-link: rgb(0, 0, 238);
     font-size: 1.5rem;
   }
 
-  .taxon-parents,
-  .taxon-children {
+  .taxon-parents {
     display: flex;
     justify-content: space-around;
+  }
+
+  .taxon-children {
+    display: flex;
   }
 
   .parent-expansion {

--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -42,6 +42,10 @@ class TaxonsController < ApplicationController
     render "taxon_not_found", status: 404
   end
 
+  def tagged_content
+    render :tagged_content_page, locals: { page: Taxonomy::TaggedContentPage.new(taxon) }
+  end
+
   def edit
     render :edit, locals: { page: Taxonomy::EditPage.new(taxon) }
   end

--- a/app/services/taxonomy/tagged_content_page.rb
+++ b/app/services/taxonomy/tagged_content_page.rb
@@ -1,0 +1,28 @@
+module Taxonomy
+  class TaggedContentPage
+    delegate :content_id, :draft?, :published?, :unpublished?, :redirected?,
+             :redirect_to, :base_path, to: :taxon
+
+    attr_reader :taxon
+
+    def initialize(taxon)
+      @taxon = taxon
+    end
+
+    def taxon_content_id
+      taxon.content_id
+    end
+
+    def tagged
+      @tagged ||= begin
+        return [] if taxon.unpublished?
+
+        Services.publishing_api.get_linked_items(
+          taxon.content_id,
+          link_type: "taxons",
+          fields: %w[title content_id base_path document_type]
+        )
+      end
+    end
+  end
+end

--- a/app/views/taxons/_show_header.html.erb
+++ b/app/views/taxons/_show_header.html.erb
@@ -2,6 +2,10 @@
 
 <%= link_to I18n.t('views.taxons.tagging_history'), tagging_history_path(taxon_content_id), class: "btn btn-default"%>
 
+<%= link_to I18n.t('views.taxons.tagged_content'),
+            taxon_tagged_content_path(taxon_content_id),
+            class: 'btn btn-default' %>
+
 <%= link_to new_taxon_migration_path(source_content_id: taxon_content_id),
 class: 'btn btn-md btn-default' do %>
   <i class="glyphicon glyphicon-move"></i>

--- a/app/views/taxons/_show_header.html.erb
+++ b/app/views/taxons/_show_header.html.erb
@@ -1,0 +1,14 @@
+<%= link_to I18n.t('views.taxons.edit'), edit_taxon_path(taxon_content_id), class: "btn btn-default"%>
+
+<%= link_to I18n.t('views.taxons.tagging_history'), tagging_history_path(taxon_content_id), class: "btn btn-default"%>
+
+<%= link_to new_taxon_migration_path(source_content_id: taxon_content_id),
+class: 'btn btn-md btn-default' do %>
+  <i class="glyphicon glyphicon-move"></i>
+  <%= I18n.t('views.taxons.move_content') %>
+<% end %>
+
+<%= link_to taxonomy_path(taxon_content_id, format: :csv), class: "btn btn-default" do %>
+  <i class="glyphicon glyphicon-download-alt"></i>
+  <%= I18n.t('views.taxons.download_csv') %>
+<% end %>

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -1,19 +1,6 @@
 <%= display_header title: page.title, breadcrumbs: [:taxons, page.taxon] do %>
   <% unless page.unpublished? %>
-    <%= link_to I18n.t('views.taxons.edit'), edit_taxon_path(page.taxon_content_id), class: "btn btn-default"%>
-
-    <%= link_to I18n.t('views.taxons.tagging_history'), tagging_history_path(page.taxon_content_id), class: "btn btn-default"%>
-
-    <%= link_to new_taxon_migration_path(source_content_id: page.taxon_content_id),
-      class: 'btn btn-md btn-default' do %>
-      <i class="glyphicon glyphicon-move"></i>
-      <%= I18n.t('views.taxons.move_content') %>
-    <% end %>
-
-    <%= link_to taxonomy_path(page.taxon_content_id, format: :csv), class: "btn btn-default" do %>
-      <i class="glyphicon glyphicon-download-alt"></i>
-      <%= I18n.t('views.taxons.download_csv') %>
-    <% end %>
+    <%= render 'show_header', taxon_content_id: page.taxon_content_id %>
   <% end %>
 <% end %>
 

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -54,24 +54,4 @@
       </ul>
     </div>
   <% end %>
-
-  <h3><%= t('views.taxons.metadata') %></h3>
-
-  <p>
-    Tagged content items: <%= page.tagged.count %>
-  </p>
-
-  <h3><%= t('views.taxons.tagged_content') %></h3>
-
-  <p>
-    <%= link_to 'Download as CSV',
-      taxon_download_tagged_path(page.taxon_content_id),
-      class: 'btn btn-md btn-default' %>
-  </p>
-
-  <% if page.tagged.any? %>
-    <%= render 'tagged_content', tagged: page.tagged %>
-  <% else %>
-    <p class="no-content no-content-bordered">No content tagged to this taxon</p>
-  <% end %>
 <% end %>

--- a/app/views/taxons/tagged_content_page.html.erb
+++ b/app/views/taxons/tagged_content_page.html.erb
@@ -1,0 +1,25 @@
+<%= display_header title: "Pages tagged to #{link_to page.taxon.internal_name, taxon_path(page.content_id)}",
+                   page_title: "Pages tagged to #{page.taxon.internal_name}",
+                   breadcrumbs: [:taxons, page.taxon] do %>
+  <% unless page.unpublished? %>
+    <%= render 'show_header', taxon_content_id: page.taxon_content_id %>
+  <% end %>
+<% end %>
+
+<% unless page.unpublished? %>
+  <h3>Total tagged pages: <%= page.tagged.count %></h3>
+
+  <p>
+    <%= link_to 'Download as CSV',
+    taxon_download_tagged_path(page.taxon_content_id),
+    class: 'btn btn-md btn-default' %>
+  </p>
+
+  <% if page.tagged.any? %>
+    <%= render 'tagged_content', tagged: page.tagged %>
+  <% else %>
+    <p class="no-content no-content-bordered">
+      No content tagged to this taxon
+    </p>
+  <% end %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -71,7 +71,8 @@ en:
         title: Deleted
         explain: Search for a deleted taxon to restore it
       tree: Taxon hierarchy
-      tagged_content: Pages tagged to this taxon
+      tagged_content: Tagged content
+      pages_tagged_to: Pages tagged to
       edit_tagging: Edit tagging
       move_content: Move content
       title: Taxons

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
     get :confirm_delete
     get :confirm_restore
     get :confirm_discard
+    get :tagged_content
     get :confirm_publish
     get :confirm_bulk_publish
     get :download_tagged

--- a/spec/features/delete_taxon_spec.rb
+++ b/spec/features/delete_taxon_spec.rb
@@ -27,8 +27,9 @@ RSpec.feature "Delete Taxon", type: :feature do
 
   scenario "deleting a taxon with tagged content" do
     given_a_taxon_with_tagged_content
-    when_i_visit_the_taxon_page
+    when_i_visit_the_taxon_tagged_content_page
     then_i_expect_to_see_the_tagged_content
+    when_i_visit_the_taxon_page
     when_i_click_delete_taxon
     then_i_see_a_prompt_to_delete_with_a_warning_message
     when_i_choose_a_taxon_to_redirect_to("Vehicle plating")
@@ -92,6 +93,10 @@ RSpec.feature "Delete Taxon", type: :feature do
 
   def when_i_visit_the_taxon_page
     visit taxon_path(@taxon_content_id)
+  end
+
+  def when_i_visit_the_taxon_tagged_content_page
+    visit taxon_tagged_content_path(@taxon_content_id)
   end
 
   def when_i_click_delete_taxon

--- a/spec/features/download_tagged_content_spec.rb
+++ b/spec/features/download_tagged_content_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature "Download taggings", type: :feature do
 
   scenario "downloading tagged content" do
     given_a_taxon_with_tagged_content
-    when_i_visit_the_taxon_page
+    when_i_visit_the_taxon_tagged_content_page
     when_i_click_the_download_button
     then_i_should_receive_a_csv_with_tagged_content
   end
@@ -38,8 +38,8 @@ RSpec.feature "Download taggings", type: :feature do
     )
   end
 
-  def when_i_visit_the_taxon_page
-    visit taxon_path(@content_id)
+  def when_i_visit_the_taxon_tagged_content_page
+    visit taxon_tagged_content_path(@content_id)
   end
 
   def when_i_click_the_download_button

--- a/spec/features/viewing_taxons_spec.rb
+++ b/spec/features/viewing_taxons_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Viewing taxons" do
   scenario "Viewing tagged content of a taxon" do
     given_a_taxonomy
     and_the_root_taxon_has_content_tagged_to_it
-    when_i_view_the_root_taxon
+    when_i_view_the_root_taxon_tagged_content
     then_i_see_the_count_of_tagged_content
     then_i_see_tagged_content
   end
@@ -98,7 +98,7 @@ RSpec.describe "Viewing taxons" do
   end
 
   def then_i_see_the_count_of_tagged_content
-    expect(page).to have_content("Tagged content items: 2")
+    expect(page).to have_content("Total tagged pages: 2")
   end
 
   def then_i_see_tagged_content
@@ -112,6 +112,14 @@ RSpec.describe "Viewing taxons" do
 
     visit taxon_path(apples["content_id"])
   end
+
+  def when_i_view_the_root_taxon_tagged_content
+    stub_request(:get, %r{https://publishing-api.test.gov.uk/v2/links/apples})
+      .to_return(status: 200, body: {}.to_json)
+
+    visit taxon_tagged_content_path(apples["content_id"])
+  end
+
 
   def then_i_see_the_entire_taxonomy
     expected_titles = [


### PR DESCRIPTION
This ended up being a one line CSS change, but I first moved the tagged content to a separate page.

![homepage-show-page](https://user-images.githubusercontent.com/1130010/33833496-bcd8a0ee-de77-11e7-9e07-288a69f83b11.png)
![tagged-content-page](https://user-images.githubusercontent.com/1130010/33833497-bcfb75d8-de77-11e7-9593-3295b3e8f8b3.png)
