### PR TITLE
Remove require_signin_permission!

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,7 @@ class ApplicationController < ActionController::Base
   add_flash_types :success, :info, :warning, :danger
 
   include GDS::SSO::ControllerMethods
-  before_action :require_signin_permission!
+  before_action :authenticate_user!
   before_action :set_authenticated_user_header
   before_action :ensure_user_can_use_application!
 


### PR DESCRIPTION
This is no longer necessary, as Signon will check this now.

From the GDS::SSO README:

The signon application makes sure that only users who have been
granted access to the application can access it (e.g. they have the
signin permission for your app). This used to be left up to the
applications themselves to check with the require_signin_permission!
method. This is now deprecated and can be removed from your
controllers. You should replace it with a call to authenticate_user!
if you aren't already using that method, otherwise no signon
authentication will be performed.