### PR TITLE
Use with_drafts option when finding content by base_path

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'simple_form', '~> 3.2', '>= 3.2.1'
 gem 'uglifier', '~> 4.0'
 
 # GDS managed dependencies
-gem 'gds-api-adapters', '~> 50.5'
+gem 'gds-api-adapters', '~> 50.6'
 gem 'gds-sso', '~> 13.4'
 gem 'govuk_admin_template', '~> 6.4'
 gem 'govuk_sidekiq', '~> 3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,7 +88,7 @@ GEM
     faraday (0.12.2)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.18)
-    gds-api-adapters (50.5.0)
+    gds-api-adapters (50.6.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -383,7 +383,7 @@ DEPENDENCIES
   capybara
   database_cleaner
   factory_girl_rails
-  gds-api-adapters (~> 50.5)
+  gds-api-adapters (~> 50.6)
   gds-sso (~> 13.4)
   govuk-content-schema-test-helpers
   govuk-lint

--- a/app/services/taxonomy/update_taxon.rb
+++ b/app/services/taxonomy/update_taxon.rb
@@ -25,7 +25,8 @@ module Taxonomy
       # error code, we do a lookup to see if a content item with the slug
       # already exists, and if so, provide a more customised error message.
       existing_content_item = Services.publishing_api.lookup_content_id(
-        base_path: taxon.base_path
+        base_path: taxon.base_path,
+        with_drafts: true,
       )
 
       if existing_content_item.nil?

--- a/spec/features/taxonomy_editing_spec.rb
+++ b/spec/features/taxonomy_editing_spec.rb
@@ -287,6 +287,7 @@ RSpec.feature "Taxonomy editing" do
     stub_request(:put, %r{https://publishing-api.test.gov.uk/v2/content*})
       .to_return(status: 422, body: {}.to_json)
     stub_request(:post, %r{https://publishing-api.test.gov.uk/lookup-by-base-path})
+      .with(body: hash_including(base_paths: ['/slug'], with_drafts: true))
       .to_return(status: 200, body: {
         '/slug' => SecureRandom.uuid
       }.to_json)


### PR DESCRIPTION
If a taxon fails to update (a 422 error code responds from the
publishing api), we perform a lookup by base path to find whether the
URL has been used.

Previously, this lookup endpoint only returned content that was
published. However, since a recent addition, we can use the with_drafts
option to include draft content as well, to provide the same error
messaging when draft content exists at the given base path, instead of a
generic error.

Trello: https://trello.com/c/WVTtiLie/150-provide-a-useful-error-message-in-content-tagger-when-you-try-to-create-or-move-a-taxon-where-one-already-exists