### PR TITLE
Fix intermittently failing feature spec

### DIFF
--- a/app/views/project_content_items/flags.js.erb
+++ b/app/views/project_content_items/flags.js.erb
@@ -1,4 +1,7 @@
-$('#flags-modal').html("<%= escape_javascript(render partial: 'flags', locals: local_assigns) %>");
-
-var radioToggle = new GOVUKAdmin.Modules.RadioToggle;
-radioToggle.start($('#flags-modal'));
+$('#flags-modal')
+  .html("<%= escape_javascript(render partial: 'flags', locals: local_assigns) %>")
+  .promise()
+  .done(function () {
+    var radioToggle = new GOVUKAdmin.Modules.RadioToggle;
+    radioToggle.start($('#flags-modal'));
+  });

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -5,7 +5,7 @@
 <% end %>
 
 <%= render partial: 'shared/iframe_proxy_modal' %>
-<div id="flags-modal" class="modal fade" tabindex="-1" role="dialog"></div>
+<div id="flags-modal" class="modal" tabindex="-1" role="dialog"></div>
 
 <div class="row tagathon-project">
   <div class="col-md-3 filter-controls">

--- a/spec/features/flagging_a_content_item_spec.rb
+++ b/spec/features/flagging_a_content_item_spec.rb
@@ -18,7 +18,9 @@ RSpec.describe "flagging a content item" do
   scenario "flagging a content item and suggesting a new term", js: true do
     given_there_is_a_project_with_a_content_item
     when_i_visit_the_project_page
-    and_i_flag_the_first_content_item_as_missing_a_relevant_topic_and_i_suggest_a_new_term
+    and_i_flag_the_first_content_item_as_missing_a_relevant_topic
+    and_i_suggest_a_new_topic
+    and_i_submit_my_flag_for_review_choice
     and_i_apply_the_flagged_filter
     then_the_content_item_should_be_flagged_as_missing_topic
     and_the_suggested_topic_should_be_displayed
@@ -66,12 +68,10 @@ RSpec.describe "flagging a content item" do
 
   def and_i_flag_the_first_content_item_as_i_need_help
     click_link 'Flag for review'
-    find('#flag_modal_id', wait: 60).visible?
     choose "I need help tagging this"
   end
 
   def and_i_enter_a_comment_to_explain_why_i_need_help
-    expect(page).to have_field("Comment (optional)")
     fill_in "Comment (optional)", with: "I don't know what I'm doing"
   end
 
@@ -89,14 +89,13 @@ RSpec.describe "flagging a content item" do
     expect(page).to have_content "Flagged: needs publisher review"
   end
 
-  def and_i_flag_the_first_content_item_as_missing_a_relevant_topic_and_i_suggest_a_new_term
+  def and_i_flag_the_first_content_item_as_missing_a_relevant_topic
     click_link 'Flag for review'
-    find('#flag_modal_id', wait: 60).visible?
     choose "There's no relevant topic for this"
-    expect(page).to have_field("Suggest a new topic")
+  end
+
+  def and_i_suggest_a_new_topic
     fill_in "Suggest a new topic", with: "cool new topic"
-    click_button "Continue"
-    wait_for_ajax
   end
 
   def and_i_mark_the_content_item_as_done


### PR DESCRIPTION
There were two problems that I believe have been causing this intermittent spec:

1. inability to click on an element after CSS animations had moved the element (an issue with the Poltergeist driver). Our solution: remove the modal fade animation: https://github.com/alphagov/content-tagger/commit/d0f4cbd46cc4b57a3356443effb710ad55f46669 
2. a race condition between HTML rendering and initialising another JS module. Our solution: wait until the HTML is fully rendered before initialising: https://github.com/alphagov/content-tagger/commit/cc52513c7555bda5249dd7dcf4b6fbb0b116500e

<br>

**How confident am I that these two changes resolve the problem?**

Quite! I've been running the problematic scenario continuously with these changes, and each run has succeeded without any failure for 657 iterations, as of writing, on my local machine. Without these changes, I was able to have a failing test interrupt the script on the 12th, 45th, 96th, 27th, 46th, etc. attempt. It's not a perfect measurement but in comparison to how early on I was able to get a failing attempt, it's probably good enough.

<details>
<summary>le script</summary>

<code>count=0; while bundle exec rspec spec/features/flagging_a_content_item_spec.rb:18; do (( count++ )); echo $count; done; echo "Failed after $count reruns"</code>
</details>