### PR TITLE
Restrict taxon routes to taxon content type

### DIFF
--- a/app/services/taxonomy/build_taxon.rb
+++ b/app/services/taxonomy/build_taxon.rb
@@ -3,6 +3,7 @@ module Taxonomy
     attr_reader :content_id
 
     class TaxonNotFoundError < StandardError; end
+    class DocumentTypeError < StandardError; end
 
     def initialize(content_id:)
       @content_id = content_id
@@ -13,6 +14,8 @@ module Taxonomy
     end
 
     def build
+      validate_taxon_response!
+
       Taxon.new(
         content_id: content_id,
         title: content_item["title"],
@@ -42,6 +45,11 @@ module Taxonomy
       @content_item ||= Services.publishing_api.get_content(content_id)
     rescue GdsApi::HTTPNotFound => e
       raise(TaxonNotFoundError, e.message)
+    end
+
+    def validate_taxon_response!
+      return if content_item["document_type"].in? %(homepage taxon)
+      raise DocumentTypeError
     end
 
     def links

--- a/spec/controllers/taxons_controller_spec.rb
+++ b/spec/controllers/taxons_controller_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe TaxonsController, type: :controller do
 
   def stub_taxon_show_page(content_id)
     stub_requests_for_show_page(
-      content_item_with_details("Foo", other_fields: { content_id: content_id })
+      content_item_with_details("Foo", other_fields: { content_id: content_id, document_type: "taxon" })
     )
   end
 end

--- a/spec/factories/taxon.rb
+++ b/spec/factories/taxon.rb
@@ -2,6 +2,7 @@ FactoryGirl.define do
   factory :taxon do
     title 'A taxon'
     description 'A description'
+    document_type 'taxon'
     parent nil
     content_id 'taxon-content-id'
     base_path '/education/taxon-base-path'

--- a/spec/features/delete_taxon_spec.rb
+++ b/spec/features/delete_taxon_spec.rb
@@ -48,7 +48,7 @@ RSpec.feature "Delete Taxon", type: :feature do
 
   def given_a_taxon_with_no_children
     @taxon_content_id = SecureRandom.uuid
-    @taxon = content_item_with_details(
+    @taxon = taxon_with_details(
       "Taxon 1",
       other_fields: { content_id: @taxon_content_id }
     )
@@ -68,7 +68,7 @@ RSpec.feature "Delete Taxon", type: :feature do
 
   def given_a_deleted_taxon
     @taxon_content_id = SecureRandom.uuid
-    @taxon = content_item_with_details(
+    @taxon = taxon_with_details(
       "Taxon 2",
       other_fields: {
         base_path: "/education/taxon-2",
@@ -170,7 +170,7 @@ private
 
   def add_a_child_taxon
     @child_taxon_content_id = SecureRandom.uuid
-    @child_taxon = content_item_with_details(
+    @child_taxon = taxon_with_details(
       "A child taxon",
       other_fields: { content_id: @child_taxon_content_id }
     )

--- a/spec/features/download_tagged_content_spec.rb
+++ b/spec/features/download_tagged_content_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature "Download taggings", type: :feature do
   def given_a_taxon_with_tagged_content
     @content_id = SecureRandom.uuid
 
-    taxon = content_item_with_details(
+    taxon = taxon_with_details(
       "Taxon 1",
       other_fields: { content_id: @content_id }
     )

--- a/spec/features/draft_taxons_spec.rb
+++ b/spec/features/draft_taxons_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature "Draft taxonomy" do
   end
 
   def given_there_are_draft_taxons
-    @taxon_1 = content_item_with_details(
+    @taxon_1 = taxon_with_details(
       "I Am A Taxon 1",
       other_fields: {
         content_id: "ID-1",
@@ -35,7 +35,7 @@ RSpec.feature "Draft taxonomy" do
         publication_state: 'active'
       }
     )
-    @taxon_2 = content_item_with_details(
+    @taxon_2 = taxon_with_details(
       "I Am Another Taxon 2",
       other_fields: {
         content_id: "ID-2",
@@ -43,7 +43,7 @@ RSpec.feature "Draft taxonomy" do
         publication_state: 'active'
       }
     )
-    @taxon_3 = content_item_with_details(
+    @taxon_3 = taxon_with_details(
       "I Am Yet Another Taxon 3",
       other_fields: {
         content_id: "ID-3",
@@ -72,7 +72,7 @@ RSpec.feature "Draft taxonomy" do
   def given_there_is_a_draft_taxon
     @taxon_content_id = SecureRandom.uuid
 
-    @taxon = content_item_with_details(
+    @taxon = taxon_with_details(
       "Taxon 2",
       other_fields: {
         base_path: "/education/taxon-2",

--- a/spec/features/taxonomy_editing_spec.rb
+++ b/spec/features/taxonomy_editing_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Taxonomy editing" do
   include ContentItemHelper
 
   before do
-    @taxon_1 = content_item_with_details(
+    @taxon_1 = taxon_with_details(
       "School planning",
       other_fields: {
         content_id: "ID-1",
@@ -13,7 +13,7 @@ RSpec.feature "Taxonomy editing" do
         publication_state: 'published'
       }
     )
-    @taxon_2 = content_item_with_details(
+    @taxon_2 = taxon_with_details(
       "Starting and attending school (draft)",
       other_fields: {
         content_id: "ID-2",
@@ -21,7 +21,7 @@ RSpec.feature "Taxonomy editing" do
         publication_state: 'draft'
       }
     )
-    @taxon_3 = content_item_with_details(
+    @taxon_3 = taxon_with_details(
       "Rail",
       other_fields: {
         content_id: "ID-3",
@@ -250,6 +250,7 @@ RSpec.feature "Taxonomy editing" do
       .to_return(body: {
         base_path: "/education/newly-created-taxon",
         content_id: "ID-4",
+        document_type: "taxon",
         details: { internal_name: "Newly created taxon" },
         publication_state: "published",
         title: "Newly created taxon",

--- a/spec/features/viewing_taxons_spec.rb
+++ b/spec/features/viewing_taxons_spec.rb
@@ -3,11 +3,11 @@ require "rails_helper"
 RSpec.describe "Viewing taxons" do
   include ContentItemHelper
 
-  let(:fruits) { fake_taxon("Fruits") }
-  let(:apples) { fake_taxon("Apples") }
-  let(:pears) { fake_taxon("Pears") }
-  let(:oranges) { fake_taxon("Oranges") }
-  let(:cox) { fake_taxon("Cox") }
+  let(:fruits) { taxon_with_details("Fruits") }
+  let(:apples) { taxon_with_details("Apples") }
+  let(:pears) { taxon_with_details("Pears") }
+  let(:oranges) { taxon_with_details("Oranges") }
+  let(:cox) { taxon_with_details("Cox") }
 
   scenario "Viewing a taxonomy" do
     given_a_taxonomy
@@ -174,11 +174,5 @@ RSpec.describe "Viewing taxons" do
       expect(page).to have_content("Pears")
       expect(page).to have_content("Oranges")
     end
-  end
-
-private
-
-  def fake_taxon(title)
-    content_item_with_details(title)
   end
 end

--- a/spec/features/viewing_taxons_spec.rb
+++ b/spec/features/viewing_taxons_spec.rb
@@ -3,13 +3,18 @@ require "rails_helper"
 RSpec.describe "Viewing taxons" do
   include ContentItemHelper
 
-  let(:fruits) { taxon_with_details("Fruits") }
+  let(:fruits) do
+    content_item_with_details(
+      "Fruits",
+      other_fields: { document_type: "homepage" }
+    )
+  end
   let(:apples) { taxon_with_details("Apples") }
   let(:pears) { taxon_with_details("Pears") }
   let(:oranges) { taxon_with_details("Oranges") }
   let(:cox) { taxon_with_details("Cox") }
 
-  scenario "Viewing a taxonomy" do
+  scenario "Viewing the taxonomy from the homepage" do
     given_a_taxonomy
     given_im_ignoring_tagged_content_for_now
     when_i_view_the_root_taxon

--- a/spec/models/remote_taxons_spec.rb
+++ b/spec/models/remote_taxons_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe RemoteTaxons do
 
     let(:parent_taxon_id) { SecureRandom.uuid }
     let(:parent_taxon) do
-      content_item_with_details(
+      taxon_with_details(
         'foo',
         other_fields: {
           base_path: '/foo/1',

--- a/spec/services/taxonomy/build_taxon_spec.rb
+++ b/spec/services/taxonomy/build_taxon_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Taxonomy::BuildTaxon do
         content_id: content_id,
         title: 'A title',
         description: 'A description',
+        document_type: 'taxon',
         base_path: '/foo/bar',
         publication_state: 'State',
         details: {

--- a/spec/services/taxonomy/build_taxon_spec.rb
+++ b/spec/services/taxonomy/build_taxon_spec.rb
@@ -2,13 +2,14 @@ require 'rails_helper'
 
 RSpec.describe Taxonomy::BuildTaxon do
   describe '.call(content_id:)' do
+    let(:document_type) { 'taxon' }
     let(:content_id) { SecureRandom.uuid }
     let(:content) do
       {
         content_id: content_id,
         title: 'A title',
         description: 'A description',
-        document_type: 'taxon',
+        document_type: document_type,
         base_path: '/foo/bar',
         publication_state: 'State',
         details: {
@@ -111,6 +112,16 @@ RSpec.describe Taxonomy::BuildTaxon do
       it 'raises an exception' do
         expect { taxon }.to raise_error(
           Taxonomy::BuildTaxon::TaxonNotFoundError
+        )
+      end
+    end
+
+    context 'with a content item that is not a taxon or homepage' do
+      let(:document_type) { 'guidance' }
+
+      it 'raises an exception' do
+        expect { taxon }.to raise_error(
+          Taxonomy::BuildTaxon::DocumentTypeError
         )
       end
     end

--- a/spec/support/content_item_helper.rb
+++ b/spec/support/content_item_helper.rb
@@ -1,4 +1,12 @@
 module ContentItemHelper
+  def taxon_with_details(title, other_fields: {}, unpublished: false)
+    content_item_with_details(
+      title,
+      other_fields: other_fields.merge(document_type: "taxon"),
+      unpublished: unpublished
+    )
+  end
+
   def content_item_with_details(title, other_fields: {}, unpublished: false)
     other_fields_with_details = other_fields.merge(
       details: {


### PR DESCRIPTION
Trello: https://trello.com/c/qKMvPNau/258-restrict-the-content-which-content-tagger-can-view-and-delete