### PR TITLE
Display taxon base paths across pages

### DIFF
--- a/app/models/govuk_taxonomy/branches.rb
+++ b/app/models/govuk_taxonomy/branches.rb
@@ -26,7 +26,7 @@ module GovukTaxonomy
   private
 
     def transform(taxon, status)
-      taxon.slice("content_id", "title").merge("status" => status)
+      taxon.slice("content_id", "title", "base_path").merge("status" => status)
     end
 
     def get_root_taxons(with_drafts:)

--- a/app/views/branches/index.html.erb
+++ b/app/views/branches/index.html.erb
@@ -13,7 +13,8 @@
 <table class="table queries-list table-bordered table-striped">
   <thead>
     <tr class="table-header">
-      <th>Title</th>
+      <th>Taxon</th>
+      <th></th>
     </tr>
   </thead>
 
@@ -21,8 +22,13 @@
     <% GovukTaxonomy::Branches.new.all.each do |taxon| %>
       <tr>
         <td>
+           <%= taxon['title'] %>
+          <br>
+          <span class="text-muted"><%= taxon['base_path'] %></span>
+        </td>
+        <td>
           <a href="<%= taxon_path(taxon['content_id']) %>">
-             <%= taxon['title'] %>
+            View taxon
           </a>
         </td>
       </tr>

--- a/app/views/taxons/index.html.erb
+++ b/app/views/taxons/index.html.erb
@@ -49,8 +49,14 @@
   <tbody>
     <% page.taxons.each do |taxon| %>
       <tr>
-        <td><%= taxon.internal_name %></td>
-        <td><%= link_to I18n.t('views.taxons.view'), taxon_path(taxon.content_id) %></td>
+        <td>
+          <%= taxon.internal_name %>
+          <br>
+          <span class="text-muted"><%= taxon.base_path %></span>
+        </td>
+        <td>
+          <%= link_to I18n.t('views.taxons.view'), taxon_path(taxon.content_id) %>
+        </td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -9,7 +9,7 @@
     <% if page.published? %>
       View on site: <%= link_to page.base_path, website_url(page.base_path) %>
     <% elsif page.draft? %>
-      <%= link_to "View draft page", website_url(page.base_path, draft: true) %>
+      View draft page: <%= link_to page.base_path, website_url(page.base_path, draft: true) %>
     <% end %>
   </div>
 


### PR DESCRIPTION
# /taxons

**Before**
> <img width="952" alt="taxons-before" src="https://user-images.githubusercontent.com/885223/34153642-ad3e015e-e4aa-11e7-863f-08ecb67364b0.png">
**After**
> <img width="953" alt="taxons-after" src="https://user-images.githubusercontent.com/885223/34153641-ad25a10e-e4aa-11e7-881a-69e795ebb172.png">

# /branches

**Before**
> <img width="954" alt="branches-before" src="https://user-images.githubusercontent.com/885223/34153648-b3668ede-e4aa-11e7-89e4-4f9b563167eb.png">
**After**
> <img width="957" alt="branches-after" src="https://user-images.githubusercontent.com/885223/34153647-b3516022-e4aa-11e7-897c-2b1f1e28af65.png">

# /taxons/:uuid

**Before**
> <img width="955" alt="taxons-show-before" src="https://user-images.githubusercontent.com/885223/34153659-ba4d64d4-e4aa-11e7-90df-a1d5e26411eb.png">
**After**
> <img width="953" alt="taxons-show-after" src="https://user-images.githubusercontent.com/885223/34153658-ba33f54e-e4aa-11e7-8082-82ddd7f088b5.png">