### PR TITLE
Display link to conflicting taxon when publish/save call fails

### DIFF
--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -132,17 +132,18 @@ class TaxonsController < ApplicationController
     # Perform a lookup on the base path to determine whether there
     # is already another content item published with the same path
 
-    existing_content_item = Services.publishing_api.lookup_content_id(
+    existing_content_id = Services.publishing_api.lookup_content_id(
       base_path: taxon.base_path
     )
 
-    GovukError.notify(e, level: "warning")
-
-    flash.now[:danger] = if existing_content_item.present?
-                           I18n.t('errors.invalid_taxon_base_path')
-                         else
-                           I18n.t('errors.invalid_taxon')
-                         end
+    if existing_content_id.present?
+      flash.now[:danger] = ActionController::Base.helpers.sanitize(
+        I18n.t('errors.invalid_taxon_base_path', taxon_path: taxon_path(existing_content_id))
+      )
+    else
+      GovukError.notify(e, level: "warning")
+      flash.now[:danger] = I18n.t('errors.invalid_taxon')
+    end
 
     render :edit, locals: { page: Taxonomy::EditPage.new(taxon) }
   end

--- a/app/services/taxonomy/update_taxon.rb
+++ b/app/services/taxonomy/update_taxon.rb
@@ -24,16 +24,18 @@ module Taxonomy
       # Since we cannot easily differentiate the reasons for getting a 422
       # error code, we do a lookup to see if a content item with the slug
       # already exists, and if so, provide a more customised error message.
-      existing_content_item = Services.publishing_api.lookup_content_id(
+      existing_content_id = Services.publishing_api.lookup_content_id(
         base_path: taxon.base_path,
         with_drafts: true,
       )
 
-      if existing_content_item.nil?
+      if existing_content_id.present?
+        taxon_path = Rails.application.routes.url_helpers.taxon_path(existing_content_id)
+        error_message = I18n.t('errors.invalid_taxon_base_path', taxon_path: taxon_path)
+        raise(InvalidTaxonError, ActionController::Base.helpers.sanitize(error_message))
+      else
         GovukError.notify(e)
         raise(InvalidTaxonError, I18n.t('errors.invalid_taxon'))
-      else
-        raise(InvalidTaxonError, I18n.t('errors.invalid_taxon_base_path'))
       end
     end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,7 +12,7 @@ en:
     taxons: 'Edit taxonomy'
   errors:
     invalid_taxon: There was a problem with your request. We have been notified of the issue and will fix it as soon as possible.
-    invalid_taxon_base_path: A taxon with this slug already exists. If the taxon has been deleted, you can restore it.
+    invalid_taxon_base_path: A <a href="%{taxon_path}">taxon</a> with this slug already exists. If the taxon has been deleted, you can restore it.
     invalid_hostname: Is not a Google Docs URL
     invalid_path: Does not have the expected public path /spreadsheets/d/<id>/pub
     missing_gid: Is missing a Google Spreadsheet ID parameter (gid)

--- a/spec/controllers/taxons_controller_spec.rb
+++ b/spec/controllers/taxons_controller_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe TaxonsController, type: :controller do
 
       post :publish, params: { taxon_id: taxon.content_id }
 
-      expect(flash.now[:danger]).to eq I18n.t('errors.invalid_taxon_base_path')
+      expect(flash.now[:danger]).to match(/<a href="(.+)">taxon<\/a> with this slug already exists/)
     end
   end
 

--- a/spec/services/taxonomy/update_taxon_spec.rb
+++ b/spec/services/taxonomy/update_taxon_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe Taxonomy::UpdateTaxon do
         allow(Services.publishing_api).to receive(:lookup_content_id).and_return(SecureRandom.uuid)
         expect { publish }.to raise_error(
           Taxonomy::UpdateTaxon::InvalidTaxonError,
-          /a taxon with this slug already exists/i
+          /<a href="(.+)">taxon<\/a> with this slug already exists/
         )
       end
     end


### PR DESCRIPTION
Trello: https://trello.com/c/WVTtiLie/150-provide-a-useful-error-message-in-content-tagger-when-you-try-to-create-or-move-a-taxon-where-one-already-exists