### PR TITLE
Prevent homepage from being unpublished

### DIFF
--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -87,7 +87,9 @@ class TaxonsController < ApplicationController
   end
 
   def destroy
-    if params[:taxon][:redirect_to].empty?
+    if content_id == GovukTaxonomy::ROOT_CONTENT_ID
+      redirect_to taxon_path(content_id), danger: t("controllers.taxons.destroy_homepage")
+    elsif params[:taxon][:redirect_to].empty?
       flash.now[:danger] = t("controllers.taxons.destroy_no_redirect")
       render :confirm_delete, locals: { page: Taxonomy::ShowPage.new(taxon) }
     else

--- a/app/services/taxonomy/show_page.rb
+++ b/app/services/taxonomy/show_page.rb
@@ -59,5 +59,9 @@ module Taxonomy
     def associated_taxons
       taxonomy_tree.associated_taxons
     end
+
+    def taxon_deletable?
+      taxon.content_id != GovukTaxonomy::ROOT_CONTENT_ID
+    end
   end
 end

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -20,7 +20,7 @@
         (redirects to <%= page.redirect_to %>)
       <% end %>
     </div>
-    <% if page.published? %>
+    <% if page.taxon_deletable? && page.published? %>
       <%= link_to "Delete", taxon_confirm_delete_path(page.taxon_content_id), class: 'delete-link' %>
     <% elsif page.draft? %>
       <%= link_to taxon_confirm_publish_path(page.taxon_content_id), class: 'btn btn-md btn-default' do %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -122,6 +122,7 @@ en:
       destroy_success: You have sucessfully deleted the taxon
       destroy_alert: It was not possible to delete the taxon
       destroy_no_redirect: Please select a taxon to redirect to
+      destroy_homepage: You cannot delete the homepage
       restore_success: You have sucessfully restored the taxon
       restore_alert: It was not possible to restore the taxon
       discard_draft_success: You have successfully deleted the draft taxon

--- a/spec/controllers/taxons_controller_spec.rb
+++ b/spec/controllers/taxons_controller_spec.rb
@@ -86,6 +86,14 @@ RSpec.describe TaxonsController, type: :controller do
       delete :destroy, params: { id: foo_content_id, taxon: { redirect_to: "" } }
       expect(WebMock).to_not have_requested(:post, "https://publishing-api.test.gov.uk/v2/content/#{foo_content_id}/unpublish")
     end
+
+    it "prevents deletion of the homepage" do
+      delete :destroy, params: { id: GovukTaxonomy::ROOT_CONTENT_ID }
+
+      expect(WebMock).to_not have_requested(:any, /publishing-api/)
+      expect(flash[:danger]).to eq "You cannot delete the homepage"
+      expect(request).to redirect_to taxon_path(GovukTaxonomy::ROOT_CONTENT_ID)
+    end
   end
 
   describe '#bulk_publish' do


### PR DESCRIPTION
Trello: https://trello.com/c/a8sp0YWv/307-remove-ability-to-delete-or-unpublish-the-homepage-in-content-tagger