### PR TITLE
Update lint task to run against all files

### DIFF
--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,4 +1,4 @@
-desc "Run govuk-lint on files changed since origin/master"
+desc "Run govuk-lint on all files"
 task "lint" do
-  system "govuk-lint-ruby --diff"
+  system "govuk-lint-ruby"
 end


### PR DESCRIPTION
Now that we have resolved all of the linting issues, we can change our
local lint rake task to run against all files.

However, our CI build will still run in the diff mode as documented
here [1].

[1] https://github.com/alphagov/govuk-puppet/blob/master/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy#L455-L473