### PR TITLE
Freeze time to avoid flaky test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,4 +43,5 @@ group :test do
   gem 'headless'
   gem 'poltergeist'
   gem 'webmock'
+  gem 'timecop'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -343,6 +343,7 @@ GEM
     thor (0.20.0)
     thread_safe (0.3.6)
     tilt (2.0.8)
+    timecop (0.9.1)
     tzinfo (1.2.4)
       thread_safe (~> 0.1)
     uglifier (4.1.2)
@@ -406,6 +407,7 @@ DEPENDENCIES
   simple_form (~> 3.2, >= 3.2.1)
   simplecov
   simplecov-rcov
+  timecop
   uglifier (~> 4.1)
   web-console
   webmock


### PR DESCRIPTION
An example failure:

```

Failures:

  1) TaxonsController#restore sends a request to Publishing API to mark the taxon as 'draft'
     Failure/Error: Services.publishing_api.put_content(content_id, payload)

     WebMock::NetConnectNotAllowedError:
       Real HTTP connections are disabled. Unregistered request: PUT https://publishing-api.test.gov.uk/v2/content/taxon-content-id with body '{"base_path":"/education/taxon-base-path","document_type":"taxon","schema_name":"taxon","title":"A taxon","description":"A description","publishing_app":"content-tagger","rendering_app":"collections","public_updated_at":"2018-01-02T14:12:20+00:00","locale":"en","details":{"internal_name":"An internal name","notes_for_editors":"","visible_to_departmental_editors":false},"routes":[{"path":"/education/taxon-base-path","type":"exact"}],"update_type":"major"}' with headers {'Accept'=>'application/json', 'Accept-Encoding'=>'gzip, deflate', 'Authorization'=>'Bearer example', 'Content-Length'=>'458', 'Content-Type'=>'application/json', 'Host'=>'publishing-api.test.gov.uk', 'User-Agent'=>'gds-api-adapters/50.8.0 ()', 'X-Govuk-Authenticated-User'=>'87667ced-5ca7-4e7a-8b41-397c74bf64c9'}

       You can stub this request with the following snippet:

       stub_request(:put, "https://publishing-api.test.gov.uk/v2/content/taxon-content-id").
         with(body: "{\"base_path\":\"/education/taxon-base-path\",\"document_type\":\"taxon\",\"schema_name\":\"taxon\",\"title\":\"A taxon\",\"description\":\"A description\",\"publishing_app\":\"content-tagger\",\"rendering_app\":\"collections\",\"public_updated_at\":\"2018-01-02T14:12:20+00:00\",\"locale\":\"en\",\"details\":{\"internal_name\":\"An internal name\",\"notes_for_editors\":\"\",\"visible_to_departmental_editors\":false},\"routes\":[{\"path\":\"/education/taxon-base-path\",\"type\":\"exact\"}],\"update_type\":\"major\"}",
              headers: {'Accept'=>'application/json', 'Accept-Encoding'=>'gzip, deflate', 'Authorization'=>'Bearer example', 'Content-Length'=>'458', 'Content-Type'=>'application/json', 'Host'=>'publishing-api.test.gov.uk', 'User-Agent'=>'gds-api-adapters/50.8.0 ()', 'X-Govuk-Authenticated-User'=>'87667ced-5ca7-4e7a-8b41-397c74bf64c9'}).
         to_return(status: 200, body: "", headers: {})

       registered request stubs:

       stub_request(:patch, "https://publishing-api.test.gov.uk/v2/links/taxon-content-id").
         with(body: "{\"links\":{\"parent_taxons\":[\"guid\"],\"associated_taxons\":[\"1234\"]}}")

       Body diff:
        [["-", "base_path", "/education/taxon-base-path"],
        ["-", "description", "A description"],
        ["-",
         "details",
         {"internal_name"=>"An internal name",
          "notes_for_editors"=>"",
          "visible_to_departmental_editors"=>false}],
        ["-", "document_type", "taxon"],
        ["-", "locale", "en"],
        ["-", "public_updated_at", "2018-01-02T14:12:20+00:00"],
        ["-", "publishing_app", "content-tagger"],
        ["-", "rendering_app", "collections"],
        ["-", "routes", [{"path"=>"/education/taxon-base-path", "type"=>"exact"}]],
        ["-", "schema_name", "taxon"],
        ["-", "title", "A taxon"],
        ["-", "update_type", "major"],
        ["+", "links", {"parent_taxons"=>["guid"], "associated_taxons"=>["1234"]}]]

       stub_request(:put, "https://publishing-api.test.gov.uk/v2/content/taxon-content-id").
         with(body: {"base_path"=>"/education/taxon-base-path", "description"=>"A description", "details"=>{"internal_name"=>"An internal name", "notes_for_editors"=>"", "visible_to_departmental_editors"=>false}, "document_type"=>"taxon", "locale"=>"en", "public_updated_at"=>"2018-01-02T14:12:19+00:00", "publishing_app"=>"content-tagger", "rendering_app"=>"collections", "routes"=>[{"path"=>"/education/taxon-base-path", "type"=>"exact"}], "schema_name"=>"taxon", "title"=>"A taxon", "update_type"=>"major"})

       Body diff:
        [["~",
         "public_updated_at",
         "2018-01-02T14:12:20+00:00",
         "2018-01-02T14:12:19+00:00"]]

       stub_request(:get, "https://publishing-api.test.gov.uk/v2/links/taxon-content-id")
       stub_request(:get, "https://publishing-api.test.gov.uk/v2/content/taxon-content-id with query params hash_including({})")

       ============================================================
     # /var/lib/jenkins/bundles/ruby/2.4.0/gems/webmock-3.1.1/lib/webmock/http_lib_adapters/net_http.rb:114:in `request'
     # /var/lib/jenkins/bundles/ruby/2.4.0/gems/rest-client-2.0.2/lib/restclient/request.rb:446:in `net_http_do_request'
     # /var/lib/jenkins/bundles/ruby/2.4.0/gems/rest-client-2.0.2/lib/restclient/request.rb:721:in `block in transmit'
     # /var/lib/jenkins/bundles/ruby/2.4.0/gems/webmock-3.1.1/lib/webmock/http_lib_adapters/net_http.rb:123:in `start_without_connect'
     # /var/lib/jenkins/bundles/ruby/2.4.0/gems/webmock-3.1.1/lib/webmock/http_lib_adapters/net_http.rb:150:in `start'
     # /var/lib/jenkins/bundles/ruby/2.4.0/gems/rest-client-2.0.2/lib/restclient/request.rb:715:in `transmit'
     # /var/lib/jenkins/bundles/ruby/2.4.0/gems/rest-client-2.0.2/lib/restclient/request.rb:145:in `execute'
     # /var/lib/jenkins/bundles/ruby/2.4.0/gems/rest-client-2.0.2/lib/restclient/request.rb:52:in `execute'
     # /var/lib/jenkins/bundles/ruby/2.4.0/gems/gds-api-adapters-50.8.0/lib/gds_api/json_client.rb:260:in `do_request'
     # /var/lib/jenkins/bundles/ruby/2.4.0/gems/gds-api-adapters-50.8.0/lib/gds_api/json_client.rb:215:in `do_request_with_cache'
     # /var/lib/jenkins/bundles/ruby/2.4.0/gems/gds-api-adapters-50.8.0/lib/gds_api/json_client.rb:144:in `do_json_request'
     # /var/lib/jenkins/bundles/ruby/2.4.0/gems/gds-api-adapters-50.8.0/lib/gds_api/json_client.rb:92:in `put_json'
     # /var/lib/jenkins/bundles/ruby/2.4.0/gems/gds-api-adapters-50.8.0/lib/gds_api/publishing_api_v2.rb:17:in `put_content'
     # ./app/services/taxonomy/update_taxon.rb:21:in `publish'
     # ./app/services/taxonomy/update_taxon.rb:13:in `call'
     # ./app/controllers/taxons_controller.rb:108:in `restore'
     # /var/lib/jenkins/bundles/ruby/2.4.0/gems/actionpack-5.1.4/lib/action_controller/metal/basic_implicit_render.rb:4:in `send_action'
     # /var/lib/jenkins/bundles/ruby/2.4.0/gems/actionpack-5.1.4/lib/abstract_controller/base.rb:186:in `process_action'
     # /var/lib/jenkins/bundles/ruby/2.4.0/gems/actionpack-5.1.4/lib/action_controller/metal/rendering.rb:30:in `process_action'
     # /var/lib/jenkins/bundles/ruby/2.4.0/gems/actionpack-5.1.4/lib/abstract_controller/callbacks.rb:20:in `block in process_action'
     # /var/lib/jenkins/bundles/ruby/2.4.0/gems/activesupport-5.1.4/lib/active_support/callbacks.rb:108:in `block in run_callbacks'
     # /var/lib/jenkins/bundles/ruby/2.4.0/gems/sentry-raven-2.7.1/lib/raven/integrations/rails/controller_transaction.rb:7:in `block in included'
     # /var/lib/jenkins/bundles/ruby/2.4.0/gems/activesupport-5.1.4/lib/active_support/callbacks.rb:117:in `instance_exec'
     # /var/lib/jenkins/bundles/ruby/2.4.0/gems/activesupport-5.1.4/lib/active_support/callbacks.rb:117:in `block in run_callbacks'
     # /var/lib/jenkins/bundles/ruby/2.4.0/gems/activesupport-5.1.4/lib/active_support/callbacks.rb:135:in `run_callbacks'
     # /var/lib/jenkins/bundles/ruby/2.4.0/gems/actionpack-5.1.4/lib/abstract_controller/callbacks.rb:19:in `process_action'
     # /var/lib/jenkins/bundles/ruby/2.4.0/gems/actionpack-5.1.4/lib/action_controller/metal/rescue.rb:20:in `process_action'
     # /var/lib/jenkins/bundles/ruby/2.4.0/gems/actionpack-5.1.4/lib/action_controller/metal/instrumentation.rb:32:in `block in process_action'
     # /var/lib/jenkins/bundles/ruby/2.4.0/gems/activesupport-5.1.4/lib/active_support/notifications.rb:166:in `block in instrument'
     # /var/lib/jenkins/bundles/ruby/2.4.0/gems/activesupport-5.1.4/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
     # /var/lib/jenkins/bundles/ruby/2.4.0/gems/activesupport-5.1.4/lib/active_support/notifications.rb:166:in `instrument'
     # /var/lib/jenkins/bundles/ruby/2.4.0/gems/actionpack-5.1.4/lib/action_controller/metal/instrumentation.rb:30:in `process_action'
     # /var/lib/jenkins/bundles/ruby/2.4.0/gems/actionpack-5.1.4/lib/action_controller/metal/params_wrapper.rb:252:in `process_action'
     # /var/lib/jenkins/bundles/ruby/2.4.0/gems/activerecord-5.1.4/lib/active_record/railties/controller_runtime.rb:22:in `process_action'
     # /var/lib/jenkins/bundles/ruby/2.4.0/gems/actionpack-5.1.4/lib/abstract_controller/base.rb:124:in `process'
     # /var/lib/jenkins/bundles/ruby/2.4.0/gems/actionview-5.1.4/lib/action_view/rendering.rb:30:in `process'
     # /var/lib/jenkins/bundles/ruby/2.4.0/gems/actionpack-5.1.4/lib/action_controller/metal.rb:189:in `dispatch'
     # /var/lib/jenkins/bundles/ruby/2.4.0/gems/actionpack-5.1.4/lib/action_controller/test_case.rb:513:in `process'
     # /var/lib/jenkins/bundles/ruby/2.4.0/gems/actionpack-5.1.4/lib/action_controller/test_case.rb:400:in `post'
     # ./spec/controllers/taxons_controller_spec.rb:146:in `block (3 levels) in <top (required)>'

Finished in 20.15 seconds (files took 2.93 seconds to load)
359 examples, 1 failure

Failed examples:

rspec ./spec/controllers/taxons_controller_spec.rb:131 # TaxonsController#restore sends a request to Publishing API to mark the taxon as 'draft'
```