### PR TITLE
Fix tree display of the root taxon.

### DIFF
--- a/app/models/taxonomy/expanded_taxonomy.rb
+++ b/app/models/taxonomy/expanded_taxonomy.rb
@@ -11,7 +11,7 @@ module Taxonomy
         build_child_expansion_for_home_page
       else
         build_child_expansion
-        @parent_expansion.tree.last << home_page_linked_content_item
+        @parent_expansion.tree.last << home_page_linked_content_item if attached_to_root?(@parent_expansion.tree.last.content_id)
       end
       self
     end
@@ -60,6 +60,10 @@ module Taxonomy
 
     def root_content_item
       @root_content_item ||= Services.publishing_api.get_content(@content_id).to_h
+    end
+
+    def attached_to_root?(content_id)
+      Services.publishing_api.get_content(content_id).dig('links', 'root_taxon').present?
     end
 
     def expand_parent_nodes(start_node:, parent:)

--- a/spec/features/viewing_taxons_spec.rb
+++ b/spec/features/viewing_taxons_spec.rb
@@ -6,7 +6,11 @@ RSpec.describe "Viewing taxons" do
   let(:fruits) do
     content_item_with_details(
       "Fruits",
-      other_fields: { document_type: "homepage" }
+      other_fields: { document_type: "taxon" }
+    ).merge(
+      "links" => {
+        "root_taxon" => [GovukTaxonomy::ROOT_CONTENT_ID]
+      }
     )
   end
   let(:apples) { taxon_with_details("Apples") }

--- a/spec/models/taxonomy/expanded_taxonomy_spec.rb
+++ b/spec/models/taxonomy/expanded_taxonomy_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe Taxonomy::ExpandedTaxonomy do
 
   describe 'Ask for the Homepage' do
     before :each do
-      @taxonomy = ExpandedTaxonomy.new(GovukTaxonomy::ROOT_CONTENT_ID).build
+      @taxonomy = Taxonomy::ExpandedTaxonomy.new(GovukTaxonomy::ROOT_CONTENT_ID).build
     end
     it 'has no parent children' do
       expect(@taxonomy.parent_expansion.children).to be_empty
@@ -143,7 +143,7 @@ RSpec.describe Taxonomy::ExpandedTaxonomy do
 
   describe "#build" do
     it "returns a representation of the taxonomy, with both parent and child taxons expanded" do
-      taxonomy = ExpandedTaxonomy.new(apples["content_id"]).build
+      taxonomy = Taxonomy::ExpandedTaxonomy.new(apples["content_id"]).build
 
       expect(taxonomy.root_node.internal_name).to eq "i-Apples"
       expect(taxonomy.parent_expansion.map(&:internal_name)).to eq [
@@ -164,7 +164,7 @@ RSpec.describe Taxonomy::ExpandedTaxonomy do
 
   describe "#immediate_parents" do
     it "returns immediate parents of the root node" do
-      taxonomy = ExpandedTaxonomy.new(apples["content_id"]).build
+      taxonomy = Taxonomy::ExpandedTaxonomy.new(apples["content_id"]).build
 
       expect(taxonomy.immediate_parents.map(&:internal_name)).to eq %w[
         i-Fruits
@@ -174,7 +174,7 @@ RSpec.describe Taxonomy::ExpandedTaxonomy do
 
   describe "#immediate_children" do
     it "returns immediate children of the root node" do
-      taxonomy = ExpandedTaxonomy.new(apples["content_id"]).build
+      taxonomy = Taxonomy::ExpandedTaxonomy.new(apples["content_id"]).build
 
       expect(taxonomy.immediate_children.map(&:internal_name)).to eq %w[
         i-Bramley
@@ -184,12 +184,12 @@ RSpec.describe Taxonomy::ExpandedTaxonomy do
   end
 
   describe "#child_expansion" do
-    let(:taxonomy) { ExpandedTaxonomy.new(apples["content_id"]) }
+    let(:taxonomy) { Taxonomy::ExpandedTaxonomy.new(apples["content_id"]) }
 
     context "when the expansion hasn't been built yet" do
       it "raises an error" do
         expect { taxonomy.child_expansion }.to raise_error(
-          ExpandedTaxonomy::ExpansionNotBuiltError
+          Taxonomy::ExpandedTaxonomy::ExpansionNotBuiltError
         )
       end
     end
@@ -228,12 +228,12 @@ RSpec.describe Taxonomy::ExpandedTaxonomy do
   end
 
   describe "#parent_expansion" do
-    let(:taxonomy) { ExpandedTaxonomy.new(apples["content_id"]) }
+    let(:taxonomy) { Taxonomy::ExpandedTaxonomy.new(apples["content_id"]) }
 
     context "when the expansion hasn't been built yet" do
       it "raises an error" do
         expect { taxonomy.parent_expansion }.to raise_error(
-          ExpandedTaxonomy::ExpansionNotBuiltError
+          Taxonomy::ExpandedTaxonomy::ExpansionNotBuiltError
         )
       end
     end


### PR DESCRIPTION
The tree visualisation of the taxonomy will now only show taxons
to be attached to the 'Root of the Taxonomy' if this is actually
the case.

Trello: https://trello.com/c/RN7uU0EM/299-dont-show-the-root-of-taxonomy-in-the-taxonomy-visualisation-if-this-isnt-the-case