### PR TITLE
Fix base path preview when "Root of the taxonomy" selected as parent

### DIFF
--- a/app/assets/javascripts/base-path-preview.js
+++ b/app/assets/javascripts/base-path-preview.js
@@ -2,10 +2,11 @@
   "use strict";
 
   Modules.BasePathPreview = function () {
-    this.start = function() {
+    this.start = function(el) {
       var $parentSelectEl = $('select.js-parent-taxon');
       var $pathSlugInputEl = $('input.js-path-slug');
       var $previewBasePathEl = $('.js-predicted-base-path');
+      var rootContentID = el.data('root-content-id');
 
       updateBasePathPreview();
       $parentSelectEl.change(updateBasePathPreview);
@@ -22,7 +23,7 @@
         var parentTaxonContentId = $parentSelectEl.val();
         var url = window.location.origin + '/taxons/' + parentTaxonContentId + '.json';
 
-        if (parentTaxonContentId.length !== 0) {
+        if (parentTaxonContentId.length !== 0 && parentTaxonContentId !== rootContentID ) {
           $.getJSON(url, function(taxon) {
             $previewBasePathEl.text('/' + taxon.path_prefix + '/' + $pathSlugInputEl.val());
           });

--- a/app/views/taxons/_form_fields.html.erb
+++ b/app/views/taxons/_form_fields.html.erb
@@ -1,4 +1,4 @@
-<div data-module="base-path-preview">
+<div data-module="base-path-preview" data-root-content-id="<%= GovukTaxonomy::ROOT_CONTENT_ID %>">
   <%= f.input :parent, collection: page.taxons_for_select,
     input_html: { class: 'js-parent-taxon form-control', include_blank: true } %>
 


### PR DESCRIPTION
Trello: https://trello.com/c/BSA5p5Cv/315-fix-basepaths-shown-in-content-tagger-on-the-edit-page-for-level-one-taxons

The logic that exists for the base path preview assumed that a parent
taxon selected would have a path_prefix, and we use this assumption to
form the base path preview.

However, if the "Root of the taxonomy" taxon was selected as the parent,
the base path preview was producing a path such as "/undefined/taxon".
This is because the top of the tree has a base path of "/".

We have therefore added an exception for this particular taxon, so that
the base path preview only uses the path_slug to produce the preview
when the "Root of the taxonomy" taxon is selected as the parent.