### PR TITLE
Provide informative error message when project creation fails

### DIFF
--- a/app/lib/project_builder.rb
+++ b/app/lib/project_builder.rb
@@ -34,7 +34,14 @@ class ProjectBuilder
     end
 
     def message
-      'Project creation failed. The spreadsheet contains content that may have already been imported'
+      <<~MSG
+        The project was not created because the spreadsheet contains content
+        that has already been imported to other projects.
+
+        To resolve this, remove the following rows from the spreadsheet before
+        creating the project again. Please note that it may take Google sheets
+        up to 5 minutes for the changes to be republished to the CSV format.
+      MSG
     end
   end
 end

--- a/spec/features/project_spec.rb
+++ b/spec/features/project_spec.rb
@@ -272,7 +272,7 @@ RSpec.feature "Projects", type: :feature do
   end
 
   def then_i_see_an_duplicate_content_error_message
-    expect(page).to have_content 'Project creation failed. The spreadsheet contains content that may have already been imported'
+    expect(page).to have_content 'The project was not created'
     expect(page).to have_content 'https://www.gov.uk/vat-rates'
   end
 

--- a/spec/forms/new_project_form_spec.rb
+++ b/spec/forms/new_project_form_spec.rb
@@ -64,12 +64,7 @@ RSpec.describe NewProjectForm, '#create' do
     form = NewProjectForm.new(valid_params)
 
     expect(form.create).to eq(false)
-    expect(form.errors[:base]).to eq [
-      [
-        "Project creation failed. The spreadsheet contains content that may have already been imported",
-        ["https://www.gov.uk/path"]
-      ]
-    ]
+    expect(form.errors[:base]).to include [/project was not created/, ["https://www.gov.uk/path"]]
   end
 end
 


### PR DESCRIPTION
Trello: https://trello.com/c/FQQyOQf0/246-surface-duplicate-content-import-errors-from-spreadsheet-upload

We can make the error message that is displayed when a spreadsheet
contains content that has already been imported more useful by
suggesting a resolution and noting a quirk of Google sheets