### PR TITLE
Resolve Bundler/OrderedGems lint issue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,6 @@ group :test do
   gem 'database_cleaner'
   gem 'headless'
   gem 'poltergeist'
-  gem 'webmock'
   gem 'timecop'
+  gem 'webmock'
 end


### PR DESCRIPTION
```
Gemfile:46:3: C: Bundler/OrderedGems: Gems should be sorted in an
alphabetical order within their section of the Gemfile. Gem timecop
should appear before webmock.
  gem 'timecop'
  ^^^^^^^^^^^^^
```