### PR TITLE
Fix bug is displaying of the root of the Taxonomy Tree.

### DIFF
--- a/app/models/taxonomy/expanded_taxonomy.rb
+++ b/app/models/taxonomy/expanded_taxonomy.rb
@@ -63,7 +63,7 @@ module Taxonomy
     end
 
     def attached_to_root?(content_id)
-      Services.publishing_api.get_content(content_id).dig('links', 'root_taxon').present?
+      Services.publishing_api.get_expanded_links(content_id).dig('expanded_links', 'root_taxon').present?
     end
 
     def expand_parent_nodes(start_node:, parent:)

--- a/spec/features/viewing_taxons_spec.rb
+++ b/spec/features/viewing_taxons_spec.rb
@@ -7,10 +7,6 @@ RSpec.describe "Viewing taxons" do
     content_item_with_details(
       "Fruits",
       other_fields: { document_type: "taxon" }
-    ).merge(
-      "links" => {
-        "root_taxon" => [GovukTaxonomy::ROOT_CONTENT_ID]
-      }
     )
   end
   let(:apples) { taxon_with_details("Apples") }
@@ -55,6 +51,7 @@ RSpec.describe "Viewing taxons" do
             }
           )
         ],
+        root_taxon: [GovukTaxonomy::ROOT_CONTENT_ID]
       }
     )
 
@@ -76,6 +73,7 @@ RSpec.describe "Viewing taxons" do
         child_taxons: [
           apples
         ],
+        root_taxon: [GovukTaxonomy::ROOT_CONTENT_ID]
       }
     )
 

--- a/spec/models/taxonomy/expanded_taxonomy_spec.rb
+++ b/spec/models/taxonomy/expanded_taxonomy_spec.rb
@@ -24,13 +24,7 @@ RSpec.describe Taxonomy::ExpandedTaxonomy do
   end
 
   # parent taxons
-  let(:food) do
-    fake_taxon("Food").merge(
-      "links" => {
-        "root_taxon" => [GovukTaxonomy::ROOT_CONTENT_ID]
-      }
-  )
-  end
+  let(:food) { fake_taxon("Food") }
   let(:fruits) do
     fake_taxon("Fruits").merge(
       "links" => {
@@ -93,6 +87,13 @@ RSpec.describe Taxonomy::ExpandedTaxonomy do
       content_id: GovukTaxonomy::ROOT_CONTENT_ID,
       expanded_links: {
         level_one_taxons: [apples]
+      },
+    )
+
+    publishing_api_has_expanded_links(
+      content_id: food['content_id'],
+      expanded_links: {
+        root_taxon: [GovukTaxonomy::ROOT_CONTENT_ID]
       },
     )
 


### PR DESCRIPTION
The 'root_taxon' link does not show up in a get_content call to
the publishing-api; instead a call to get_expanded_links is
necessary.

Trello: https://trello.com/c/RN7uU0EM/299-dont-show-the-root-of-taxonomy-in-the-taxonomy-visualisation-if-this-isnt-the-case