### PR TITLE
Stub the publish request in the Bulk publishing test

### DIFF
--- a/spec/features/bulk_publishing_spec.rb
+++ b/spec/features/bulk_publishing_spec.rb
@@ -42,6 +42,7 @@ RSpec.feature 'Bulk publishing', type: :feature do
   end
 
   def when_i_click_confirm_publish
+    stub_any_publishing_api_publish
     click_button 'Confirm publish'
   end
 


### PR DESCRIPTION
For some reason, this test passed on CI, and was merged, but now it's
failing.