### PR TITLE
Change behaviour for users with no permissions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,6 @@ class ApplicationController < ActionController::Base
   include GDS::SSO::ControllerMethods
   before_action :authenticate_user!
   before_action :set_authenticated_user_header
-  before_action :ensure_user_can_use_application!
 
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
@@ -15,6 +14,8 @@ class ApplicationController < ActionController::Base
       redirect_to lookup_taggings_path
     elsif user_can_access_tagathon_tools?
       redirect_to projects_path
+    else
+      redirect_to taxons_path
     end
   end
 
@@ -28,14 +29,9 @@ private
     :user_can_access_tagathon_tools?
   )
 
-  delegate :user_can_access_application?,
-           :user_can_administer_taxonomy?,
+  delegate :user_can_administer_taxonomy?,
            :user_can_access_tagathon_tools?,
            to: :permission_checker
-
-  def ensure_user_can_use_application!
-    deny_access_to(:application) unless user_can_access_application?
-  end
 
   def ensure_user_can_administer_taxonomy!
     deny_access_to(:feature) unless user_can_administer_taxonomy?

--- a/app/controllers/tagging_history_controller.rb
+++ b/app/controllers/tagging_history_controller.rb
@@ -1,6 +1,4 @@
 class TaggingHistoryController < ApplicationController
-  before_action :ensure_user_can_access_tagathon_tools!
-
   def index
     render :index,
            locals: { link_changes: TaggingHistory::LinkChanges.new(filter_params) }

--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -4,7 +4,7 @@ class TaxonsController < ApplicationController
 
   before_action(
     :ensure_user_can_administer_taxonomy!,
-    except: %i[index drafts trash show visualisation_data tagged_content]
+    except: %i[index drafts trash show visualisation_data tagged_content download]
   )
 
   def index

--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -2,7 +2,6 @@
 class TaxonsController < ApplicationController
   VISUALISATIONS = %w[list bubbles taxonomy_tree].freeze
 
-  before_action :ensure_user_can_use_application!
   before_action(
     :ensure_user_can_administer_taxonomy!,
     except: %i[index drafts trash show visualisation_data tagged_content]

--- a/app/lib/permission_checker.rb
+++ b/app/lib/permission_checker.rb
@@ -6,10 +6,6 @@ class PermissionChecker
     @user = user
   end
 
-  def user_can_access_application?
-    gds_editor? || tagathon_participant?
-  end
-
   def user_can_administer_taxonomy?
     gds_editor?
   end

--- a/app/views/tagging_history/index.html.erb
+++ b/app/views/tagging_history/index.html.erb
@@ -23,7 +23,7 @@
         <td>
           <% if link_change[:source] %>
             <%= link_to link_change[:source][:title],
-                        tagging_path(content_id: link_change[:source][:content_id]) %>
+                        website_url(link_change[:source][:base_path]) %>
           <% else %>
             An unknown document
           <% end %>

--- a/app/views/tagging_history/show.html.erb
+++ b/app/views/tagging_history/show.html.erb
@@ -38,7 +38,7 @@
         <td>
           <% if link_change[:source] %>
             <%= link_to link_change[:source][:title],
-                        tagging_path(content_id: link_change[:source][:content_id]) %>
+                        website_url(link_change[:source][:base_path]) %>
           <% else %>
             An unknown document
           <% end %>

--- a/app/views/taxons/_tagged_content.html.erb
+++ b/app/views/taxons/_tagged_content.html.erb
@@ -16,14 +16,16 @@
         <tr>
           <td><%= link_to content_item["title"], website_url(content_item["base_path"]) %></td>
           <td><%= content_item["document_type"].humanize %></td>
-          <td>
-            <%=
+          <% if user_can_administer_taxonomy? %>
+            <td>
+              <%=
               link_to(
                 t('views.taxons.edit_tagging'),
                 tagging_url(content_item["content_id"])
               )
-            %>
-          </td>
+              %>
+            </td>
+          <% end %>
           <td>
             <%=
               link_to(

--- a/app/views/taxons/index.html.erb
+++ b/app/views/taxons/index.html.erb
@@ -1,4 +1,4 @@
-<%= display_header title: t("views.taxons.#{params[:action]}.title"), breadcrumbs: [t('navigation.taxons')] do %>
+<%= display_header title: t("views.taxons.#{params[:action]}.title"), breadcrumbs: ['Taxons'] do %>
   <% if user_can_administer_taxonomy? %>
     <%= link_to new_taxon_path, class: 'btn btn-default' do %>
       <i class="glyphicon glyphicon-plus"></i>

--- a/app/views/taxons/index.html.erb
+++ b/app/views/taxons/index.html.erb
@@ -25,13 +25,13 @@
     <%= f.input :query,
       input_html: {
         type: :text,
-        class: 'form-control',
+        class: 'form-control input-lg',
         value: page.query,
         name: 'q',
         placeholder: t("views.taxons.index.search_placeholder")
       },
       label: false %>
-    <%= f.submit "Search", class: "btn btn-md btn-success" %>
+    <%= f.submit "Search", class: "btn btn-lg btn-success" %>
   </div>
 <% end %>
 

--- a/app/views/taxons/index.html.erb
+++ b/app/views/taxons/index.html.erb
@@ -20,14 +20,16 @@
   <li role="presentation" class="<%= current_page?(trash_taxons_path) ? "active" : nil%>"><%= link_to "Deleted", trash_taxons_path(q: page.query) %></li>
 </ul>
 
-<div class="lead">
-  <%= t "views.taxons.#{params[:action]}.explain" %>
-</div>
-
 <%= simple_form_for :taxon_search, url: '', method: :get do |f| %>
   <div class="form-group">
     <%= f.input :query,
-      input_html: { type: :text, class: 'form-control', value: page.query, name: 'q' },
+      input_html: {
+        type: :text,
+        class: 'form-control',
+        value: page.query,
+        name: 'q',
+        placeholder: t("views.taxons.index.search_placeholder")
+      },
       label: false %>
     <%= f.submit "Search", class: "btn btn-md btn-success" %>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -63,7 +63,7 @@ en:
     taxons:
       index:
         title: Taxons
-        explain: Search for a taxon to see its place in the taxonomy, edit the taxon or move its content
+        search_placeholder: Search for taxons by title, base path or internal name...
       drafts:
         title: Draft
         explain: Search drafts

--- a/spec/controllers/root_path_request_spec.rb
+++ b/spec/controllers/root_path_request_spec.rb
@@ -18,10 +18,10 @@ RSpec.describe "Root Path", type: :request do
   end
 
   describe "as an unprivileged user" do
-    it "denies access" do
+    it "redirects to 'Taxons'" do
       login_as create(:user)
       get root_path
-      expect(response.code).to eql "403"
+      expect(response).to redirect_to taxons_path
     end
   end
 end

--- a/spec/features/navigation_spec.rb
+++ b/spec/features/navigation_spec.rb
@@ -2,11 +2,12 @@ require "rails_helper"
 
 RSpec.feature "Navigation", type: :feature do
   include TaxonomyHelper
+  include PublishingApiHelper
 
   scenario "User with no specific permissions" do
     given_i_am_logged_in_as_a_user_with_no_special_permissions
     when_i_visit_the_application
-    then_i_will_see_the_permission_denied_page
+    then_i_dont_have_any_options_in_the_nav_bar
   end
 
   scenario "Tagathon participants can access Projects and Analytics only" do
@@ -34,11 +35,17 @@ RSpec.feature "Navigation", type: :feature do
   end
 
   def when_i_visit_the_application
+    publishing_api_has_taxons([])
     visit root_path
   end
 
-  def then_i_will_see_the_permission_denied_page
-    expect(page).to have_text "Sorry, you are not authorised to access this application."
+  def then_i_dont_have_any_options_in_the_nav_bar
+    within "#navbar-header-menu-items" do
+      expect(page).not_to have_text "Edit a page"
+      expect(page).not_to have_text "Bulk tag"
+      expect(page).not_to have_text "Edit taxonomy"
+      expect(page).not_to have_text "Projects"
+    end
   end
 
   def then_i_can_only_see_the_tagathon_options_in_the_nav_bar

--- a/spec/features/tagging_history_spec.rb
+++ b/spec/features/tagging_history_spec.rb
@@ -105,7 +105,7 @@ RSpec.feature "Tagging History", type: :feature do
       if link_change['source']
         expect(tr).to have_link(
           link_change['source']['title'],
-          href: tagging_path(link_change['source']['content_id'])
+          href: website_url(link_change['source']['base_path'])
         )
       else
         expect(tr).to have_text 'unknown document'
@@ -136,7 +136,7 @@ RSpec.feature "Tagging History", type: :feature do
     page.all('tbody tr').zip(link_changes_for_an_individual_taxon).each do |tr, link_change|
       expect(tr).to have_link(
         link_change['source']['title'],
-        href: tagging_path(link_change['source']['content_id'])
+        href: website_url(link_change['source']['base_path'])
       )
     end
   end
@@ -146,7 +146,7 @@ RSpec.feature "Tagging History", type: :feature do
       if link_change['source']
         expect(tr).to have_link(
           link_change['source']['title'],
-          href: tagging_path(link_change['source']['content_id'])
+          href: website_url(link_change['source']['base_path'])
         )
       else
         expect(tr).to have_text('unknown document')
@@ -205,5 +205,9 @@ RSpec.feature "Tagging History", type: :feature do
       3,
       target: { content_id: individual_taxon[:content_id] }
     )
+  end
+
+  def website_url(base_path)
+    Plek.new.website_root + base_path
   end
 end

--- a/spec/lib/permission_checker_spec.rb
+++ b/spec/lib/permission_checker_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe PermissionChecker do
   let(:user) { instance_double(User, has_permission?: false) }
 
   context "when the current_user has no special permissions" do
-    it { is_expected.not_to have_permission(:user_can_access_application?) }
     it { is_expected.not_to have_permission(:user_can_administer_taxonomy?) }
     it { is_expected.not_to have_permission(:user_can_access_tagathon_tools?) }
   end
@@ -18,7 +17,6 @@ RSpec.describe PermissionChecker do
         .and_return(true)
     end
 
-    it { is_expected.to have_permission(:user_can_access_application?) }
     it { is_expected.to have_permission(:user_can_administer_taxonomy?) }
     it { is_expected.to have_permission(:user_can_access_tagathon_tools?) }
   end
@@ -31,7 +29,6 @@ RSpec.describe PermissionChecker do
         .and_return(true)
     end
 
-    it { is_expected.to have_permission(:user_can_access_application?) }
     it { is_expected.not_to have_permission(:user_can_administer_taxonomy?) }
     it { is_expected.to have_permission(:user_can_access_tagathon_tools?) }
   end


### PR DESCRIPTION
Signon has a concept of access (which means the signin permission),
and other permissions (which are "GDS Editor" and "Tagathon
participant" in the case of Content Tagger).

Previously, just giving a user access to Content Tagger in Signon,
would not have given them any access to the app. This commit changes
that behaviour, and gives them access to see the taxonomy, but not
make any changes through Content Tagger.

The aim here is to neaten up the user experience. Now that it's
possible for a user of Content Tagger to have access to see the
taxonomy, but not to change it, this makes a good default experience
for users without other permissions, but who do have access to the
app.

For a user who just has access to Content Tagger, but no additional
permissions, the effect will be as follows.

# Before
![before](https://user-images.githubusercontent.com/1130010/34672631-1830d276-f477-11e7-8fdc-2c55c891a134.png)

# After
![after](https://user-images.githubusercontent.com/1130010/34672630-180f626c-f477-11e7-8be2-b844681a9c36.png)

