### PR TITLE
Rename 'root_taxons' variables to 'level_one_taxons'

### DIFF
--- a/app/services/taxonomy/taxonomy_query.rb
+++ b/app/services/taxonomy/taxonomy_query.rb
@@ -6,7 +6,7 @@ module Taxonomy
       @taxon_fields = (fields.map(&:to_s) + ['base_path']).uniq
     end
 
-    def root_taxons
+    def level_one_taxons
       taxons = get_content_hash('/').dig('links', 'level_one_taxons') || []
       taxons.map { |taxon| taxon.slice(*@taxon_fields) }
     end
@@ -18,7 +18,7 @@ module Taxonomy
     end
 
     def taxons_per_level
-      sibling_hashes = root_taxons.map { |h| get_content_hash(h['base_path']) }
+      sibling_hashes = level_one_taxons.map { |h| get_content_hash(h['base_path']) }
       recursive_taxons_per_level([], sibling_hashes)
     end
 

--- a/lib/tasks/export_data.rake
+++ b/lib/tasks/export_data.rake
@@ -3,8 +3,8 @@ namespace :export_data do
     desc "Export all taxons to file"
     task export: :environment do
       query = Taxonomy::TaxonomyQuery.new
-      root_taxons = query.root_taxons
-      result = root_taxons + root_taxons.flat_map { |t| query.child_taxons(t['base_path']) }
+      level_one_taxons = query.level_one_taxons
+      result = level_one_taxons + level_one_taxons.flat_map { |t| query.child_taxons(t['base_path']) }
 
       open('tmp/taxons.json', 'w') do |f|
         f << JSON.dump(result)

--- a/spec/services/metrics/content_coverage_metrics_spec.rb
+++ b/spec/services/metrics/content_coverage_metrics_spec.rb
@@ -26,14 +26,14 @@ module Metrics
             }
           ).to_return(body: JSON.dump(total: 500))
 
-        @root_taxons = FactoryGirl.build_list(:linkable_taxon_hash, 2)
+        level_one_taxons = FactoryGirl.build_list(:linkable_taxon_hash, 2)
 
         stub_request(:get, "#{Plek.find('rummager')}/search.json")
           .with(
             query: {
               count: 0,
               debug: 'include_withdrawn',
-              filter_part_of_taxonomy_tree: @root_taxons.map { |x| x[:content_id] },
+              filter_part_of_taxonomy_tree: level_one_taxons.map { |x| x[:content_id] },
               reject_content_store_document_type: blacklist
             }
           ).to_return(body: JSON.dump(total: 400))
@@ -41,7 +41,7 @@ module Metrics
         publishing_api_has_expanded_links(
           content_id: GovukTaxonomy::ROOT_CONTENT_ID,
           expanded_links: {
-            level_one_taxons: @root_taxons
+            level_one_taxons: level_one_taxons
           }
         )
         publishing_api_has_expanded_links(

--- a/spec/services/taxonomy/taxonomy_query_spec.rb
+++ b/spec/services/taxonomy/taxonomy_query_spec.rb
@@ -8,15 +8,15 @@ RSpec.describe Taxonomy::TaxonomyQuery do
   def query
     TaxonomyQuery.new(%w[content_id base_path])
   end
-  describe '#root_taxons' do
+  describe '#level_one_taxons' do
     it 'returns an empty array' do
       content_store_has_item('/', no_taxons.to_json, draft: true)
-      expect(query.root_taxons).to be_empty
+      expect(query.level_one_taxons).to be_empty
     end
 
     it 'returns root taxons' do
-      content_store_has_item('/', root_taxons.to_json, draft: true)
-      expect(query.root_taxons)
+      content_store_has_item('/', level_one_taxons.to_json, draft: true)
+      expect(query.level_one_taxons)
         .to match_array [{ 'content_id' => 'rrrr_aaaa', 'base_path' => '/taxons/root_taxon_a' },
                          { 'content_id' => 'rrrr_bbbb', 'base_path' => '/taxons/root_taxon_b' }]
     end
@@ -79,7 +79,7 @@ RSpec.describe Taxonomy::TaxonomyQuery do
 
     context 'there are root taxons and one level of children' do
       before :each do
-        content_store_has_item('/', root_taxons.to_json, draft: true)
+        content_store_has_item('/', level_one_taxons.to_json, draft: true)
         content_store_has_item('/taxons/root_taxon_a',
                                single_level_child_taxons('root_taxon_a', 'child_a_1', 'child_a_2').to_json,
                                draft: true)
@@ -164,7 +164,7 @@ RSpec.describe Taxonomy::TaxonomyQuery do
     }
   end
 
-  def root_taxons
+  def level_one_taxons
     {
       "base_path" => "/",
       "content_id" => "hhhh",

--- a/spec/support/taxonomy_helper.rb
+++ b/spec/support/taxonomy_helper.rb
@@ -14,7 +14,7 @@ module TaxonomyHelper
   def stub_draft_taxonomy_branch
     root_content_id = GovukTaxonomy::ROOT_CONTENT_ID
 
-    draft_root_taxons = {
+    draft_level_one_taxons = {
       'level_one_taxons' => [
         {
           'content_id' => valid_taxon_uuid,
@@ -32,7 +32,7 @@ module TaxonomyHelper
     root_taxon_expanded_links = {}
 
     publishing_api_has_expanded_links({ content_id: root_content_id }, with_drafts: false)
-    publishing_api_has_expanded_links(content_id: root_content_id, expanded_links: draft_root_taxons)
+    publishing_api_has_expanded_links(content_id: root_content_id, expanded_links: draft_level_one_taxons)
     publishing_api_has_item(root_taxon_content)
     publishing_api_has_expanded_links(content_id: valid_taxon_uuid, expanded_links: root_taxon_expanded_links)
   end


### PR DESCRIPTION
To reflect the new changes of the link type and avoid confusion of the
old language used.