### PR TITLE
Run content tagger end to end tests downstream job as part of CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,5 +2,9 @@
 
 node {
   def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
-  govuk.buildProject(sassLint: false)
+  govuk.setEnvar("PUBLISHING_E2E_TESTS_COMMAND", "test-content-tagger")
+  govuk.buildProject(
+    sassLint: false,
+    publishingE2ETests: true
+  )
 }


### PR DESCRIPTION
Hey :wave: !

This PR will enable a set of [end-to-end tests](https://github.com/alphagov/publishing-e2e-tests) to run every time a commit is made to this repo. :boom:

You can read through the scenarios at a [high level](https://docs.google.com/document/d/1VguaNdE-KYCQBWGbKaKVUJzW5asY92Igr6oZSsN6OlY/edit), and the capybara [here](https://github.com/alphagov/publishing-e2e-tests/tree/master/spec/content_tagger). Only 2 of them (creating a draft and publishing) can cause a failure currently, we'll be enabling the others over the course of the next week, once we've run them a larger amount of times.

Look at the merge box below and you'll see a new check performed on this PR.

![image](https://user-images.githubusercontent.com/976274/33369450-8d36f00a-d4ec-11e7-845c-690420f1b801.png)

Enabling these tests will give increased confidence when making changes to this repo that the change doesn't break the publisher in an end-to-end environment.   The downside is that running these tests takes time, with build times between 6 - 11 minutes currently.