### PR TITLE
Exclude placeholder_world_location_news_page

### DIFF
--- a/config/document_types_excluded_from_the_topic_taxonomy.yml
+++ b/config/document_types_excluded_from_the_topic_taxonomy.yml
@@ -52,3 +52,4 @@ document_types:
   - service_manual_guide
   - service_manual_topic
   - gone
+  - placeholder_world_location_news_page


### PR DESCRIPTION
From being in scope in the topic taxonomy.

https://trello.com/c/AwIIPzrU/51-remove-the-world-branch-from-the-topic-taxonomy