### PR TITLE
Add link to GOV.UK Homepage taxon from Edit Taxonomy page

### DIFF
--- a/app/views/taxons/index.html.erb
+++ b/app/views/taxons/index.html.erb
@@ -1,11 +1,14 @@
 <%= display_header title: t("views.taxons.#{params[:action]}.title"), breadcrumbs: ['Taxons'] do %>
+  <%= link_to taxon_path(GovukTaxonomy::ROOT_CONTENT_ID), class: 'btn btn-md btn-default' do %>
+    View homepage taxon
+  <% end %>
+
   <% if user_can_administer_taxonomy? %>
     <%= link_to new_taxon_path, class: 'btn btn-default' do %>
       <i class="glyphicon glyphicon-plus"></i>
         <%= I18n.t('views.taxons.add_taxon') %>
       </i>
     <% end %>
-
   <% end %>
 
   <%= link_to download_taxons_path, class: 'btn btn-md btn-default' do %>


### PR DESCRIPTION
The only way to navigate to this taxon page before was to choose a
random taxon in the list (hoping to choose one that does exist within
the Topic Taxonomy) and then following the link in the tree
visualisation.

Now we've added a link to this taxon page so that it is more easily
accessible.

<img width="1000" alt="screen shot 2018-01-24 at 14 59 47" src="https://user-images.githubusercontent.com/885223/35339267-1091f876-0118-11e8-97d8-20962778005a.png">
