### PR TITLE
Update schema.rb formatting

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,85 +15,85 @@ ActiveRecord::Schema.define(version: 20171106134207) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "project_content_items", force: :cascade do |t|
-    t.string   "url"
-    t.string   "title"
-    t.string   "description"
-    t.datetime "created_at",                        null: false
-    t.datetime "updated_at",                        null: false
-    t.integer  "project_id"
-    t.boolean  "done",              default: false
-    t.uuid     "content_id"
-    t.integer  "flag"
-    t.string   "suggested_tags"
-    t.text     "need_help_comment"
-    t.index ["content_id"], name: "index_project_content_items_on_content_id", unique: true, using: :btree
-    t.index ["flag"], name: "index_project_content_items_on_flag", using: :btree
-    t.index ["project_id"], name: "index_project_content_items_on_project_id", using: :btree
+  create_table "project_content_items", id: :serial, force: :cascade do |t|
+    t.string "url"
+    t.string "title"
+    t.string "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "project_id"
+    t.boolean "done", default: false
+    t.uuid "content_id"
+    t.integer "flag"
+    t.string "suggested_tags"
+    t.text "need_help_comment"
+    t.index ["content_id"], name: "index_project_content_items_on_content_id", unique: true
+    t.index ["flag"], name: "index_project_content_items_on_flag"
+    t.index ["project_id"], name: "index_project_content_items_on_project_id"
   end
 
-  create_table "projects", force: :cascade do |t|
-    t.string   "name"
-    t.datetime "created_at",                           null: false
-    t.datetime "updated_at",                           null: false
-    t.uuid     "taxonomy_branch"
-    t.boolean  "bulk_tagging_enabled", default: false
+  create_table "projects", id: :serial, force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.uuid "taxonomy_branch"
+    t.boolean "bulk_tagging_enabled", default: false
   end
 
-  create_table "tag_mappings", force: :cascade do |t|
-    t.integer  "tagging_source_id",    null: false
-    t.string   "content_base_path",    null: false
-    t.string   "link_title"
-    t.string   "link_content_id",      null: false
-    t.string   "link_type",            null: false
-    t.datetime "created_at",           null: false
-    t.datetime "updated_at",           null: false
+  create_table "tag_mappings", id: :serial, force: :cascade do |t|
+    t.integer "tagging_source_id", null: false
+    t.string "content_base_path", null: false
+    t.string "link_title"
+    t.string "link_content_id", null: false
+    t.string "link_type", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.datetime "publish_requested_at"
     t.datetime "publish_completed_at"
-    t.string   "state",                null: false
-    t.string   "messages"
-    t.string   "tagging_source_type"
-    t.index ["tagging_source_id"], name: "index_tag_mappings_on_tagging_source_id", using: :btree
+    t.string "state", null: false
+    t.string "messages"
+    t.string "tagging_source_type"
+    t.index ["tagging_source_id"], name: "index_tag_mappings_on_tagging_source_id"
   end
 
-  create_table "tag_migrations", force: :cascade do |t|
-    t.datetime "created_at",                           null: false
-    t.datetime "updated_at",                           null: false
-    t.string   "source_content_id"
-    t.string   "state"
+  create_table "tag_migrations", id: :serial, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "source_content_id"
+    t.string "state"
     t.datetime "last_published_at"
-    t.string   "last_published_by"
+    t.string "last_published_by"
     t.datetime "deleted_at"
-    t.string   "error_message"
-    t.boolean  "delete_source_link",   default: false
-    t.string   "source_title"
-    t.string   "source_document_type"
+    t.string "error_message"
+    t.boolean "delete_source_link", default: false
+    t.string "source_title"
+    t.string "source_document_type"
   end
 
-  create_table "tagging_spreadsheets", force: :cascade do |t|
-    t.string   "url",               null: false
-    t.datetime "created_at",        null: false
-    t.datetime "updated_at",        null: false
-    t.string   "user_uid",          null: false
-    t.string   "last_published_by"
+  create_table "tagging_spreadsheets", id: :serial, force: :cascade do |t|
+    t.string "url", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "user_uid", null: false
+    t.string "last_published_by"
     t.datetime "last_published_at"
-    t.string   "state",             null: false
-    t.text     "error_message"
+    t.string "state", null: false
+    t.text "error_message"
     t.datetime "deleted_at"
-    t.string   "description"
+    t.string "description"
   end
 
-  create_table "users", force: :cascade do |t|
-    t.string   "name"
-    t.string   "email"
-    t.string   "uid"
-    t.string   "organisation_slug"
-    t.string   "organisation_content_id"
-    t.text     "permissions"
-    t.boolean  "remotely_signed_out"
-    t.boolean  "disabled"
-    t.datetime "created_at",              null: false
-    t.datetime "updated_at",              null: false
+  create_table "users", id: :serial, force: :cascade do |t|
+    t.string "name"
+    t.string "email"
+    t.string "uid"
+    t.string "organisation_slug"
+    t.string "organisation_content_id"
+    t.text "permissions"
+    t.boolean "remotely_signed_out"
+    t.boolean "disabled"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   add_foreign_key "project_content_items", "projects"


### PR DESCRIPTION
Rails 5.1.0 updated the default column type/argument spacing in the
schema dump. Before then there was an option to disable the column
formatting (introduced in [1]), but the default remained the same.

However, in 5.1.0, that formatting default changed in [2]. We upgraded
from Rails 5.0.2 to 5.1.4 on 2017-11-02, but there hasn't been any
additions to the schema since 2017-10-19.

This commit is separate to the work that I am doing to introduce a
Versions table, to avoid additional changes in the schema which doesn't
introduce any _real_ change.

[1] https://github.com/rails/rails/pull/25675
[2] https://github.com/rails/rails/commit/df84e9867219e9311aef6f4efd5dd9ec675bee5c