### PR TITLE
Taxon version history

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gem 'rails', '5.1.4'
 
 gem 'bootstrap-kaminari-views', '~> 0.0.5'
 gem 'govuk_app_config', '~> 1.3'
+gem 'hashdiff', '~> 0.3.7'
 gem 'jquery-ui-rails', '6.0.1'
 gem 'kaminari', '~> 1.1'
 gem 'pg'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -394,6 +394,7 @@ DEPENDENCIES
   govuk_app_config (~> 1.3)
   govuk_sidekiq (~> 3.0)
   govuk_taxonomy_helpers (~> 0.1.1)
+  hashdiff (~> 0.3.7)
   headless
   jquery-ui-rails (= 6.0.1)
   kaminari (~> 1.1)

--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -27,7 +27,7 @@ class TaxonsController < ApplicationController
     taxon = Taxon.new taxon_params
 
     if taxon.valid?
-      Taxonomy::UpdateTaxon.call(taxon: taxon)
+      Taxonomy::UpdateTaxon.call(taxon: taxon, version_note: params[:version_note])
       redirect_to taxon_path(taxon.content_id), success: t('controllers.taxons.create_success')
     else
       error_messages = taxon.errors.full_messages.join('; ')
@@ -69,7 +69,7 @@ class TaxonsController < ApplicationController
     taxon = Taxon.new taxon_params
 
     if taxon.valid?
-      Taxonomy::UpdateTaxon.call(taxon: taxon)
+      Taxonomy::UpdateTaxon.call(taxon: taxon, version_note: params[:version_note])
 
       if params[:publish_taxon_on_save] == "true"
         Services.publishing_api.publish(taxon.content_id)
@@ -104,7 +104,7 @@ class TaxonsController < ApplicationController
   end
 
   def restore
-    Taxonomy::UpdateTaxon.call(taxon: taxon)
+    Taxonomy::UpdateTaxon.call(taxon: taxon, version_note: 'Restore')
     redirect_to taxon_path(taxon.content_id), success: t("controllers.taxons.restore_success")
   rescue Taxonomy::UpdateTaxon::InvalidTaxonError => e
     redirect_to trash_taxons_path, danger: e.message

--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -27,7 +27,7 @@ class TaxonsController < ApplicationController
     taxon = Taxon.new taxon_params
 
     if taxon.valid?
-      Taxonomy::UpdateTaxon.call(taxon: taxon, version_note: params[:version_note])
+      Taxonomy::UpdateTaxon.call(taxon: taxon, version_note: params[:internal_change_note])
       redirect_to taxon_path(taxon.content_id), success: t('controllers.taxons.create_success')
     else
       error_messages = taxon.errors.full_messages.join('; ')
@@ -61,8 +61,8 @@ class TaxonsController < ApplicationController
     render :tagged_content_page, locals: { page: Taxonomy::TaggedContentPage.new(taxon) }
   end
 
-  def version_history
-    render :version_history, locals: { page: Taxonomy::VersionHistoryPage.new(taxon) }
+  def history
+    render :history, locals: { page: Taxonomy::TaxonHistoryPage.new(taxon) }
   end
 
   def edit
@@ -73,7 +73,7 @@ class TaxonsController < ApplicationController
     taxon = Taxon.new taxon_params
 
     if taxon.valid?
-      Taxonomy::UpdateTaxon.call(taxon: taxon, version_note: params[:version_note])
+      Taxonomy::UpdateTaxon.call(taxon: taxon, version_note: params[:internal_change_note])
 
       if params[:publish_taxon_on_save] == "true"
         Services.publishing_api.publish(taxon.content_id)

--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -61,6 +61,10 @@ class TaxonsController < ApplicationController
     render :tagged_content_page, locals: { page: Taxonomy::TaggedContentPage.new(taxon) }
   end
 
+  def version_history
+    render :version_history, locals: { page: Taxonomy::VersionHistoryPage.new(taxon) }
+  end
+
   def edit
     render :edit, locals: { page: Taxonomy::EditPage.new(taxon) }
   end

--- a/app/lib/taxon_diff_builder.rb
+++ b/app/lib/taxon_diff_builder.rb
@@ -1,0 +1,30 @@
+class TaxonDiffBuilder
+  def initialize(previous_item:, current_item:)
+    @previous_fields = fields_for(previous_item)
+    @current_fields = fields_for(current_item)
+  end
+
+  def diff
+    HashDiff.diff(previous_fields, current_fields)
+  end
+
+private
+
+  attr_reader :previous_fields, :current_fields
+
+  def fields_for(taxon)
+    return {} if taxon.blank?
+
+    %i[
+      parent
+      base_path
+      internal_name
+      title
+      description
+      notes_for_editors
+      associated_taxons
+    ].each_with_object({}) do |field, hash|
+      hash[field] = taxon.send(field)
+    end
+  end
+end

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -1,0 +1,16 @@
+class Version < ActiveRecord::Base
+  scope :history, ->(content_id) { where(content_id: content_id).order(number: :desc) }
+
+  before_create :increment_number
+
+  def self.latest_version(content_id)
+    history(content_id).first
+  end
+
+private
+
+  def increment_number
+    previous_revision = Version.latest_version(content_id)
+    self.number = previous_revision.present? ? previous_revision.number + 1 : 1
+  end
+end

--- a/app/presenters/version_presenter.rb
+++ b/app/presenters/version_presenter.rb
@@ -1,0 +1,14 @@
+class VersionPresenter < SimpleDelegator
+  def changes
+    object_changes.map do |modifier, attribute, *values|
+      case modifier
+      when '+'
+        values.unshift(nil)
+      when '-'
+        values.push(nil)
+      end
+
+      [attribute, values]
+    end
+  end
+end

--- a/app/services/taxonomy/save_taxon_version.rb
+++ b/app/services/taxonomy/save_taxon_version.rb
@@ -1,0 +1,37 @@
+module Taxonomy
+  class SaveTaxonVersion
+    def self.call(taxon, version_note)
+      new(taxon, version_note).save
+    end
+
+    def initialize(taxon, version_note)
+      @taxon = taxon
+      @version_note = version_note
+    end
+
+    def save
+      Version.create(
+        content_id: content_id,
+        object_changes: taxon_changes,
+        note: version_note
+      )
+    end
+
+  private
+
+    attr_reader :version_note, :taxon
+    delegate :content_id, to: :taxon
+
+    def taxon_changes
+      TaxonDiffBuilder.new(previous_item: previous_taxon, current_item: taxon).diff
+    end
+
+    def previous_taxon
+      @_previous_taxon ||= begin
+        Taxonomy::BuildTaxon.call(content_id: content_id)
+      rescue Taxonomy::BuildTaxon::TaxonNotFoundError
+        nil
+      end
+    end
+  end
+end

--- a/app/services/taxonomy/save_taxon_version.rb
+++ b/app/services/taxonomy/save_taxon_version.rb
@@ -10,6 +10,8 @@ module Taxonomy
     end
 
     def save
+      return if no_change_to_record
+
       Version.create(
         content_id: content_id,
         object_changes: taxon_changes,
@@ -22,8 +24,14 @@ module Taxonomy
     attr_reader :version_note, :taxon
     delegate :content_id, to: :taxon
 
+    def no_change_to_record
+      version_note.blank? && taxon_changes.blank?
+    end
+
     def taxon_changes
-      TaxonDiffBuilder.new(previous_item: previous_taxon, current_item: taxon).diff
+      @_taxon_changes ||= begin
+        TaxonDiffBuilder.new(previous_item: previous_taxon, current_item: taxon).diff
+      end
     end
 
     def previous_taxon

--- a/app/services/taxonomy/taxon_history_page.rb
+++ b/app/services/taxonomy/taxon_history_page.rb
@@ -1,5 +1,5 @@
 module Taxonomy
-  class VersionHistoryPage
+  class TaxonHistoryPage
     attr_reader :taxon
 
     def initialize(taxon)
@@ -7,7 +7,7 @@ module Taxonomy
     end
 
     def title
-      "Version history for #{taxon.title}"
+      "History for #{taxon.title}"
     end
 
     def version_history

--- a/app/services/taxonomy/version_history_page.rb
+++ b/app/services/taxonomy/version_history_page.rb
@@ -1,0 +1,17 @@
+module Taxonomy
+  class VersionHistoryPage
+    attr_reader :taxon
+
+    def initialize(taxon)
+      @taxon = taxon
+    end
+
+    def title
+      "Version history for #{taxon.title}"
+    end
+
+    def version_history
+      Version.history(taxon.content_id).map { |v| VersionPresenter.new(v) }
+    end
+  end
+end

--- a/app/views/taxons/_form_fields.html.erb
+++ b/app/views/taxons/_form_fields.html.erb
@@ -40,7 +40,8 @@
 <%= f.input :associated_taxons,
     collection: page.taxons_for_select,
     placeholder: "Choose associated taxons...",
-    input_html: { multiple: true, class: :select2 } %>
+    input_html: { multiple: true, class: :select2 },
+    include_hidden: false %>
 
 <hr>
 

--- a/app/views/taxons/_form_fields.html.erb
+++ b/app/views/taxons/_form_fields.html.erb
@@ -41,3 +41,11 @@
     collection: page.taxons_for_select,
     placeholder: "Choose associated taxons...",
     input_html: { multiple: true, class: :select2 } %>
+
+<hr>
+
+<div class="form-group">
+  <label class="control-label" for="version_note">Version history note</label>
+  <%= text_area_tag :version_note, nil, class: 'form-control' %>
+  <p class="help-block">Displayed in Content Tagger</p>
+</div>

--- a/app/views/taxons/_form_fields.html.erb
+++ b/app/views/taxons/_form_fields.html.erb
@@ -46,7 +46,7 @@
 <hr>
 
 <div class="form-group">
-  <label class="control-label" for="version_note">Version history note</label>
-  <%= text_area_tag :version_note, nil, class: 'form-control' %>
+  <label class="control-label" for="version_note">Internal change note</label>
+  <%= text_area_tag :internal_change_note, nil, class: 'form-control' %>
   <p class="help-block">Displayed in Content Tagger</p>
 </div>

--- a/app/views/taxons/history.html.erb
+++ b/app/views/taxons/history.html.erb
@@ -1,5 +1,5 @@
 <%= display_header title: page.title,
-      breadcrumbs: [:taxons, link_to(page.taxon.title, taxon_path(page.taxon.content_id)), 'Version history'] %>
+      breadcrumbs: [:taxons, link_to(page.taxon.title, taxon_path(page.taxon.content_id)), 'History'] %>
 
 <% page.version_history.each do |version| %>
   <div class="well well-sm">
@@ -8,13 +8,16 @@
       <span class="text-muted">(#<%= version.number %>)</span>
     </p>
 
-    <% if version.note.present? %>
-      <p class="lead">
-        <%= version.note %>
-      </p>
-    <% end %>
 
     <dl class="dl-horizontal">
+      <% if version.note.present? %>
+        <dt>
+          internal_change_note
+        </dt>
+        <dd>
+          <%= version.note %>
+        </dd>
+      <% end %>
       <% version.changes.each do |attribute, (before, after)| %>
         <dt>
           <%= attribute %>

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -8,6 +8,10 @@
       View draft page: <%= link_to page.base_path, website_url(page.base_path, draft: true) %>
     <% end %>
   </div>
+
+  <%= link_to 'View version history',
+              taxon_version_history_path(page.taxon_content_id),
+              class: "btn btn-default" %>
 <% end %>
 
 <% unless page.unpublished? %>

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -9,8 +9,8 @@
     <% end %>
   </div>
 
-  <%= link_to 'View version history',
-              taxon_version_history_path(page.taxon_content_id),
+  <%= link_to 'View taxon history',
+              taxon_history_path(page.taxon_content_id),
               class: "btn btn-default" %>
 <% end %>
 

--- a/app/views/taxons/version_history.html.erb
+++ b/app/views/taxons/version_history.html.erb
@@ -1,0 +1,28 @@
+<%= display_header title: page.title,
+      breadcrumbs: [:taxons, link_to(page.taxon.title, taxon_path(page.taxon.content_id)), 'Version history'] %>
+
+<% page.version_history.each do |version| %>
+  <div class="well well-sm">
+    <p>
+      <%= version.created_at.to_s(:govuk_date) %>
+      <span class="text-muted">(#<%= version.number %>)</span>
+    </p>
+
+    <% if version.note.present? %>
+      <p class="lead">
+        <%= version.note %>
+      </p>
+    <% end %>
+
+    <dl class="dl-horizontal">
+      <% version.changes.each do |attribute, (before, after)| %>
+        <dt>
+          <%= attribute %>
+        </dt>
+        <dd>
+          <code><%= before.inspect %></code> &rarr; <code><%= after.inspect %></code>
+        </dd>
+      <% end %>
+    </dl>
+  </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
     get :confirm_restore
     get :confirm_discard
     get :tagged_content
-    get :version_history
+    get :history
     get :confirm_publish
     get :confirm_bulk_publish
     get :download_tagged

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
     get :confirm_restore
     get :confirm_discard
     get :tagged_content
+    get :version_history
     get :confirm_publish
     get :confirm_bulk_publish
     get :download_tagged

--- a/db/migrate/20180126094058_create_versions.rb
+++ b/db/migrate/20180126094058_create_versions.rb
@@ -1,0 +1,14 @@
+class CreateVersions < ActiveRecord::Migration[5.1]
+  def change
+    create_table :versions do |t|
+      t.string :content_id, null: false
+      t.integer :number, null: false
+      t.json :object_changes
+      t.text :note
+
+      t.index [:content_id, :number], unique: true
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171106134207) do
+ActiveRecord::Schema.define(version: 20180126094058) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -94,6 +94,16 @@ ActiveRecord::Schema.define(version: 20171106134207) do
     t.boolean "disabled"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "versions", force: :cascade do |t|
+    t.string "content_id", null: false
+    t.integer "number", null: false
+    t.json "object_changes"
+    t.text "note"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["content_id", "number"], name: "index_versions_on_content_id_and_number", unique: true
   end
 
   add_foreign_key "project_content_items", "projects"

--- a/spec/features/taxon_history_spec.rb
+++ b/spec/features/taxon_history_spec.rb
@@ -62,4 +62,8 @@ RSpec.feature 'Taxon history' do
     expect(page).to have_content '(#1) User research shows that the title was too generic'
     expect(page).to have_content 'title "Business" → "Business tax"'
   end
+
+  def and_there_will_not_be_an_empty_associated_taxon_change
+    expect(page).to_not have_content 'associated_taxons nil → [""]'
+  end
 end

--- a/spec/features/taxon_history_spec.rb
+++ b/spec/features/taxon_history_spec.rb
@@ -38,7 +38,7 @@ RSpec.feature 'Taxon history' do
 
   def and_i_change_the_title_and_fill_the_version_note_field
     fill_in 'taxon_title', with: 'Business tax'
-    fill_in 'version_note', with: 'User research shows that the title was too generic'
+    fill_in 'internal_change_note', with: 'User research shows that the title was too generic'
   end
 
   def and_i_click_save
@@ -55,11 +55,12 @@ RSpec.feature 'Taxon history' do
   end
 
   def and_i_click_view_version_history
-    click_on 'View version history'
+    click_on 'View taxon history'
   end
 
   def then_i_will_see_the_version_history_on_the_taxon_page
-    expect(page).to have_content '(#1) User research shows that the title was too generic'
+    expect(page).to have_content '(#1)'
+    expect(page).to have_content 'internal_change_note User research shows that the title was too generic'
     expect(page).to have_content 'title "Business" → "Business tax"'
   end
 

--- a/spec/features/taxon_history_spec.rb
+++ b/spec/features/taxon_history_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+RSpec.feature 'Taxon history' do
+  include ContentItemHelper
+  include PublishingApiHelper
+
+  scenario 'leaving a version note when updating the taxon' do
+    given_a_taxon_exists
+    when_i_visit_the_taxon_edit_form
+    and_i_change_the_title_and_fill_the_version_note_field
+    and_i_click_save
+    and_i_click_view_version_history
+    then_i_will_see_the_version_history_on_the_taxon_page
+  end
+
+  def given_a_taxon_exists
+    title = 'Business'
+
+    @taxon = taxon_with_details(title, other_fields: { description: '...' })
+  end
+
+  def when_i_visit_the_taxon_edit_form
+    stub_request(:get, "https://publishing-api.test.gov.uk/v2/content/#{@taxon['content_id']}")
+      .to_return(body: @taxon.to_json)
+    stub_request(:get, "https://publishing-api.test.gov.uk/v2/links/#{@taxon['content_id']}")
+      .to_return(body: { links: { parent_taxons: [] } }.to_json)
+    stub_request(:get, "https://publishing-api.test.gov.uk/v2/linkables?document_type=taxon")
+      .to_return(body: [{
+        title: @taxon['title'],
+        content_id: @taxon['content_id'],
+        base_path: @taxon['base_path'],
+        internal_name: @taxon['title'],
+        publication_state: @taxon['publication_state']
+      }].to_json)
+
+    visit edit_taxon_path(@taxon['content_id'])
+  end
+
+  def and_i_change_the_title_and_fill_the_version_note_field
+    fill_in 'taxon_title', with: 'Business tax'
+    fill_in 'version_note', with: 'User research shows that the title was too generic'
+  end
+
+  def and_i_click_save
+    stub_request(:put, "https://publishing-api.test.gov.uk/v2/content/#{@taxon['content_id']}")
+      .to_return(body: {}.to_json)
+    stub_request(:patch, "https://publishing-api.test.gov.uk/v2/links/#{@taxon['content_id']}")
+      .to_return(body: {}.to_json)
+    stub_request(:post, "https://publishing-api.test.gov.uk/v2/content/#{@taxon['content_id']}/publish")
+      .to_return(body: {}.to_json)
+    stub_request(:get, "https://publishing-api.test.gov.uk/v2/expanded-links/#{@taxon['content_id']}")
+      .to_return(body: { content_id: @taxon['content_id'], expanded_links: {} }.to_json)
+
+    click_on 'Save & publish'
+  end
+
+  def and_i_click_view_version_history
+    click_on 'View version history'
+  end
+
+  def then_i_will_see_the_version_history_on_the_taxon_page
+    expect(page).to have_content '(#1) User research shows that the title was too generic'
+    expect(page).to have_content 'title "Business" → "Business tax"'
+  end
+end

--- a/spec/features/taxonomy_editing_spec.rb
+++ b/spec/features/taxonomy_editing_spec.rb
@@ -245,6 +245,10 @@ RSpec.feature "Taxonomy editing" do
   end
 
   def and_i_submit_the_create_form
+    # Before the taxon is created, we compare the old attributes with the new,
+    # to create a diff. In this instance, a previous version does not exist.
+    stub_request(:get, %r{https://publishing-api.test.gov.uk/v2/content*})
+      .to_return(status: 404)
     # After the taxon is created we'll be redirected to the taxon's "view" page
     # which needs a bunch of API calls stubbed.
     stub_request(:get, %r{https://publishing-api.test.gov.uk/v2/content/*})
@@ -272,6 +276,10 @@ RSpec.feature "Taxonomy editing" do
     fill_in :taxon_internal_name, with: 'My Taxon'
     fill_in :taxon_path_slug, with: 'slug'
 
+    # Before the taxon is created, we compare the old attributes with the new,
+    # to create a diff. In this instance, a previous version does not exist.
+    stub_request(:get, %r{https://publishing-api.test.gov.uk/v2/content*})
+      .to_return(status: 404)
     stub_request(:put, %r{https://publishing-api.test.gov.uk/v2/content*})
       .to_return(status: 422, body: {}.to_json)
     stub_request(:post, %r{https://publishing-api.test.gov.uk/lookup-by-base-path})
@@ -286,6 +294,10 @@ RSpec.feature "Taxonomy editing" do
     fill_in :taxon_internal_name, with: 'My Taxon'
     fill_in :taxon_path_slug, with: 'slug'
 
+    # Before the taxon is created, we compare the old attributes with the new,
+    # to create a diff. In this instance, a previous version does not exist.
+    stub_request(:get, %r{https://publishing-api.test.gov.uk/v2/content*})
+      .to_return(status: 404)
     stub_request(:put, %r{https://publishing-api.test.gov.uk/v2/content*})
       .to_return(status: 422, body: {}.to_json)
     stub_request(:post, %r{https://publishing-api.test.gov.uk/lookup-by-base-path})

--- a/spec/models/version_spec.rb
+++ b/spec/models/version_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.describe Version, '.history' do
+  it 'returns the the version history in descending order' do
+    content_id = SecureRandom.uuid
+
+    Version.create(content_id: content_id)
+    Version.create(content_id: content_id)
+
+    expect(Version.history(content_id).pluck(:content_id, :number))
+      .to eq([[content_id, 2], [content_id, 1]])
+  end
+end
+
+RSpec.describe Version, '.latest_version' do
+  it 'returns the highest numbered version' do
+    content_id = SecureRandom.uuid
+
+    Version.create(content_id: content_id)
+    Version.create(content_id: content_id)
+
+    expect(Version.latest_version(content_id).number).to eq(2)
+  end
+end
+
+RSpec.describe Version, 'incrementing version number' do
+  it 'creates Version #1 if a Version does not exist yet' do
+    content_id = SecureRandom.uuid
+
+    expect(Version.where(content_id: content_id)).to be_empty
+
+    Version.create(content_id: content_id)
+
+    expect(Version.where(content_id: content_id).count).to eq(1)
+    expect(Version.last.number).to eq(1)
+  end
+
+  it 'increments the version number' do
+    Version.create(content_id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
+    Version.create(content_id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
+    Version.create(content_id: 'zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz')
+    Version.create(content_id: 'zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz')
+    Version.create(content_id: 'zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz')
+
+    expect(Version.pluck(:content_id, :number))
+      .to eq(
+        [
+          ['aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 1],
+          ['aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 2],
+          ['zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz', 1],
+          ['zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz', 2],
+          ['zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz', 3]
+        ]
+      )
+  end
+end

--- a/spec/presenters/version_presenter_spec.rb
+++ b/spec/presenters/version_presenter_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+RSpec.describe VersionPresenter, '#changes' do
+  it 'returns a change hash for an attribute addition' do
+    version = Version.create(
+      content_id: SecureRandom.uuid,
+      object_changes: [
+        ['+', 'title', 'Business'],
+      ]
+    )
+
+    changes = VersionPresenter.new(version).changes
+
+    expect(changes).to eq(
+      [
+        ['title', [nil, 'Business']]
+      ]
+    )
+  end
+
+  it 'returns a change hash for an attribute change' do
+    version = Version.create(
+      content_id: SecureRandom.uuid,
+      object_changes: [
+        ['~', 'title', 'Business', 'Business tax'],
+      ]
+    )
+
+    changes = VersionPresenter.new(version).changes
+
+    expect(changes).to eq(
+      [
+        ['title', ['Business', 'Business tax']]
+      ]
+    )
+  end
+
+  it 'returns a change hash for an attribute deletion' do
+    version = Version.create(
+      content_id: SecureRandom.uuid,
+      object_changes: [
+        ['-', 'title', 'Business'],
+      ]
+    )
+
+    changes = VersionPresenter.new(version).changes
+
+    expect(changes).to eq(
+      [
+        ['title', ['Business', nil]]
+      ]
+    )
+  end
+end

--- a/spec/services/taxonomy/save_taxon_version_spec.rb
+++ b/spec/services/taxonomy/save_taxon_version_spec.rb
@@ -1,0 +1,120 @@
+require 'rails_helper'
+
+RSpec.describe Taxonomy::SaveTaxonVersion, '.call' do
+  it 'saves a new version when the taxon is new' do
+    taxon = Taxon.new(
+      path_slug: 'business',
+      title: 'Business',
+      internal_name: 'Business [internal]',
+      description: 'Business as usual'
+    )
+
+    publishing_api_does_not_have_item(taxon.content_id)
+
+    described_class.call(taxon, 'A new taxon')
+
+    expect(Version.count).to eq(1)
+    expect(Version.last).to have_attributes(
+      content_id: taxon.content_id,
+      number: 1,
+      note: 'A new taxon',
+      object_changes: [
+        ["+", "associated_taxons", nil],
+        ["+", "base_path", "/business"],
+        ["+", "description", "Business as usual"],
+        ["+", "internal_name", "Business [internal]"],
+        ["+", "notes_for_editors", ""],
+        ["+", "parent", nil],
+        ["+", "title", "Business"]
+      ],
+    )
+  end
+
+  it 'saves the change between old and new when the draft taxon is updated' do
+    content_id = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+
+    previous_fields = {
+      content_id: content_id,
+      title: 'Tourism',
+      description: 'Send me a postcard',
+      base_path: '/tourism',
+      publication_state: 'draft',
+      document_type: 'taxon',
+      details: {
+        internal_name: 'Tourism [internal]',
+        notes_for_editors: '',
+      }
+    }
+
+    current_taxon = Taxon.new(
+      content_id: content_id,
+      path_prefix: 'business',
+      path_slug: 'tourism',
+      title: 'Tourism',
+      internal_name: 'Tourism [internal]',
+      description: 'Send me a postcard',
+      parent: 'zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz',
+    )
+
+    stub_request(:get, "https://publishing-api.test.gov.uk/v2/content/#{content_id}")
+      .to_return(body: previous_fields.to_json)
+    stub_request(:get, "https://publishing-api.test.gov.uk/v2/links/#{content_id}")
+      .to_return(body: {
+        links: {
+          associated_taxons: ['mmmmmmmm-mmmm-mmmm-mmmm-mmmmmmmmmmmm'],
+        }
+      }.to_json)
+
+    described_class.call(current_taxon, 'An update note')
+
+    expect(Version.count).to eq(1)
+    expect(Version.last).to have_attributes(
+      content_id: content_id,
+      note: 'An update note',
+      object_changes: [
+        ["~", "associated_taxons", ["mmmmmmmm-mmmm-mmmm-mmmm-mmmmmmmmmmmm"], nil],
+        ["~", "base_path", "/tourism", "/business/tourism"],
+        ["~", "parent", nil, "zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz"],
+      ],
+    )
+  end
+
+  it 'saves a restore event when the taxon is restored' do
+    content_id = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+
+    previous_fields = {
+      content_id: content_id,
+      title: 'Business',
+      description: 'Business as usual',
+      base_path: '/business',
+      publication_state: 'unpublished',
+      document_type: 'taxon',
+      details: {
+        internal_name: 'Business [internal]',
+        notes_for_editors: '',
+      }
+    }
+
+    current_taxon = Taxon.new(
+      content_id: content_id,
+      path_slug: 'business',
+      title: 'Business',
+      internal_name: 'Business [internal]',
+      description: 'Business as usual',
+    )
+
+    stub_request(:get, "https://publishing-api.test.gov.uk/v2/content/#{content_id}")
+      .to_return(body: previous_fields.to_json)
+    stub_request(:get, "https://publishing-api.test.gov.uk/v2/links/#{content_id}")
+      .to_return(body: {}.to_json)
+
+    described_class.call(current_taxon, 'Restoring a taxon')
+
+    expect(Version.count).to eq(1)
+    expect(Version.last).to have_attributes(
+      content_id: content_id,
+      note: 'Restoring a taxon',
+      object_changes: [],
+    )
+  end
+end

--- a/spec/services/taxonomy/save_taxon_version_spec.rb
+++ b/spec/services/taxonomy/save_taxon_version_spec.rb
@@ -79,6 +79,41 @@ RSpec.describe Taxonomy::SaveTaxonVersion, '.call' do
     )
   end
 
+  it 'does not saves a change when the old and new are the same' do
+    content_id = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+
+    previous_fields = {
+      content_id: content_id,
+      title: 'Business Tourism',
+      description: 'Send me a postcard',
+      base_path: '/business/tourism',
+      publication_state: 'draft',
+      document_type: 'taxon',
+      details: {
+        internal_name: 'Business Tourism [internal]',
+        notes_for_editors: '',
+      }
+    }
+
+    current_taxon = Taxon.new(
+      content_id: content_id,
+      path_prefix: 'business',
+      path_slug: 'tourism',
+      title: 'Business Tourism',
+      internal_name: 'Business Tourism [internal]',
+      description: 'Send me a postcard'
+    )
+
+    stub_request(:get, "https://publishing-api.test.gov.uk/v2/content/#{content_id}")
+      .to_return(body: previous_fields.to_json)
+    stub_request(:get, "https://publishing-api.test.gov.uk/v2/links/#{content_id}")
+      .to_return(body: {}.to_json)
+
+    described_class.call(current_taxon, '')
+
+    expect(Version.count).to eq(0)
+  end
+
   it 'saves a restore event when the taxon is restored' do
     content_id = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
 

--- a/spec/services/taxonomy/update_taxon_spec.rb
+++ b/spec/services/taxonomy/update_taxon_spec.rb
@@ -4,11 +4,13 @@ RSpec.describe Taxonomy::UpdateTaxon do
   before do
     @taxon = Taxon.new(
       title: 'A Title',
+      document_type: 'taxon',
       description: 'Description',
       base_path: '/education/slug',
       parent: 'guid',
       associated_taxons: ['1234']
     )
+    allow(Taxonomy::SaveTaxonVersion).to receive(:call)
   end
   let(:publish) { described_class.call(taxon: @taxon) }
 


### PR DESCRIPTION
Trello: https://trello.com/c/eiPbWr0O/87-record-changes-made-to-a-taxon-in-content-tagger

To record the changes to a Taxon, we rely on calling out to the
publishing API before the update request is made. Using the "current"
version from the API and the "updated" version from the validated form
parameters, a change diff is generated and stored in the Versions table.

This approach was chosen as it allows us to record changes over time,
regardless of its publishing state. For taxons which are published, we
would be able to harness the Publishing API edition versioning, and step
back in time with the user_facing_version query parameter.

---

New taxon

> <img width="959" alt="screen shot 2018-02-08 at 15 34 25" src="https://user-images.githubusercontent.com/885223/35981607-923d278c-0ce5-11e8-8f2c-75ae385c2803.png">


Changes to existing taxon

> <img width="967" alt="screen shot 2018-02-08 at 15 31 25" src="https://user-images.githubusercontent.com/885223/35981441-29a4aa38-0ce5-11e8-86bd-b77ec35b85ed.png">
