### PR TITLE
Display errors related to item in 'related content items' field

### DIFF
--- a/app/views/taggings/_related_item_tagging_entry.html.erb
+++ b/app/views/taggings/_related_item_tagging_entry.html.erb
@@ -1,7 +1,7 @@
 <li class="related-content-item-entry">
-  <% # JavaScript-specific HTML, which should only be included in tags with populated, error-free base paths,
-     # or for the template used by JavaScript to create new tags %>
-  <% if is_template || (!base_path.blank? && !tagging_update.related_item_errors[base_path]) %>
+  <% # JavaScript-specific HTML, which should only be included in tags with populated
+     # base paths, or for the template used by JavaScript to create new tags %>
+  <% if is_template || base_path.present? %>
     <div class="title select2-search-choice ui-sortable-handle ">
       <a href="https://www.gov.uk<%= base_path %>" class="js-artefact-name">
         <%= tagging_update.title_for_related_link(base_path) %> (<%= base_path %>)
@@ -10,6 +10,12 @@
       <a href="#" class="select2-search-choice-close" tabindex="-1"></a>
 
       <span class="glyphicon glyphicon-resize-vertical" aria-hidden="true"></span>
+
+      <% if tagging_update.related_item_errors[base_path].present? %>
+        <span class="label label-danger">
+          <%= tagging_update.related_item_errors[base_path] %>
+        </span>
+      <% end %>
     </div>
   <% end %>
 


### PR DESCRIPTION
Trello: https://trello.com/c/sR07Xs6T/94-bug-content-bau-unable-to-administer-related-links-in-content-tagger

When JS is enabled, these input fields are replaced by a select2 UI
element. However, in using this library, the original Rails input fields
are hidden, including any related error messages that might prevent the
form from saving.

This happens to be the case in a recent Zendesk ticket [1] where the
user was unable to edit the fields, but also unable to self-diagnose and
resolve the problem because no error was being displayed, other than
"This form contains errors. Please correct them and try again."

In this commit, we include the error message related to the field, next
to the select2 item to allow the user updating the resource to rectify
the problem.

[1] https://govuk.zendesk.com/agent/tickets/2520366

<img width="959" alt="4 proposed solution" src="https://user-images.githubusercontent.com/885223/35868597-dd9575dc-0b54-11e8-9834-ef1778efd6d5.png">
