### PR TITLE
Order the project items the same way as the spreadsheet

### DIFF
--- a/app/queries/project_filter_query.rb
+++ b/app/queries/project_filter_query.rb
@@ -27,7 +27,9 @@ class ProjectFilterQuery
 
     case current_filter
     when FILTER_TODO
-      items = items.todo
+      items = items
+                .todo
+                .order(id: :asc) # Retain the spreadsheet order
     when FILTER_FLAGGED
       items = items.flagged
     when FILTER_DONE


### PR DESCRIPTION
Order by the id field, as this will reflect the order in which the
items were imported from the spreadsheet.