### PR TITLE
Modify taxon phases

### DIFF
--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -127,7 +127,7 @@ class TaxonsController < ApplicationController
   end
 
   def bulk_publish
-    Taxonomy::BulkUpdateTaxon.call(content_id)
+    Taxonomy::BulkPublishTaxon.call(content_id)
     redirect_to taxon_path(content_id), success: "The taxons will be published shortly"
   end
 

--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -126,9 +126,20 @@ class TaxonsController < ApplicationController
     render :confirm_bulk_publish, locals: { page: Taxonomy::ShowPage.new(taxon) }
   end
 
+  def confirm_bulk_update
+    render :confirm_bulk_update, locals: { page: Taxonomy::ShowPage.new(taxon) }
+  end
+
   def bulk_publish
     Taxonomy::BulkPublishTaxon.call(content_id)
     redirect_to taxon_path(content_id), success: "The taxons will be published shortly"
+  end
+
+  def bulk_update
+    return unless params[:taxon_phase].in? %w[alpha beta live]
+
+    Taxonomy::BulkUpdateTaxon.new(content_id, phase: params[:taxon_phase]).bulk_update
+    redirect_to taxon_path(content_id), success: "The taxons will be updated shortly"
   end
 
   def publish

--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -184,6 +184,7 @@ private
       :title,
       :description,
       :visible_to_departmental_editors,
+      :phase,
       :notes_for_editors,
       :parent,
       associated_taxons: [],

--- a/app/lib/taxon_diff_builder.rb
+++ b/app/lib/taxon_diff_builder.rb
@@ -23,6 +23,7 @@ private
       description
       notes_for_editors
       associated_taxons
+      phase
     ].each_with_object({}) do |field, hash|
       hash[field] = taxon.send(field)
     end

--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -6,6 +6,7 @@ class Taxon
     :path_prefix,
     :path_slug,
     :publication_state,
+    :phase,
     :document_type,
     :redirect_to,
     :associated_taxons

--- a/app/services/taxonomy/build_taxon.rb
+++ b/app/services/taxonomy/build_taxon.rb
@@ -22,6 +22,7 @@ module Taxonomy
         description: content_item["description"],
         base_path: content_item["base_path"],
         publication_state: content_item['publication_state'],
+        phase: content_item['phase'],
         internal_name: content_item['details']['internal_name'],
         notes_for_editors: content_item['details']['notes_for_editors'],
         parent: parent,

--- a/app/services/taxonomy/build_taxon_payload.rb
+++ b/app/services/taxonomy/build_taxon_payload.rb
@@ -28,6 +28,7 @@ module Taxonomy
           { path: base_path, type: "exact" },
         ],
         update_type: "major",
+        phase: phase,
       }
     end
 
@@ -36,7 +37,7 @@ module Taxonomy
     attr_reader :taxon
     delegate(
       :base_path, :title, :description, :internal_name, :notes_for_editors,
-      :visible_to_departmental_editors,
+      :phase, :visible_to_departmental_editors,
       to: :taxon
     )
   end

--- a/app/services/taxonomy/bulk_publish_taxon.rb
+++ b/app/services/taxonomy/bulk_publish_taxon.rb
@@ -1,5 +1,5 @@
 module Taxonomy
-  class BulkUpdateTaxon
+  class BulkPublishTaxon
     def initialize(root_taxon_content_id)
       @root_taxon_content_id = root_taxon_content_id
     end

--- a/app/services/taxonomy/bulk_update_taxon.rb
+++ b/app/services/taxonomy/bulk_update_taxon.rb
@@ -1,0 +1,34 @@
+module Taxonomy
+  class BulkUpdateTaxon
+    def initialize(root_taxon_content_id, attributes)
+      @root_taxon_content_id = root_taxon_content_id
+      @attributes = attributes
+    end
+
+    def bulk_update
+      nested_tree.each do |taxon|
+        UpdateTaxonWorker.perform_async(taxon.content_id, update_payload(taxon))
+      end
+    end
+
+  private
+
+    def nested_tree
+      GovukTaxonomyHelpers::LinkedContentItem
+        .from_content_id(
+          content_id: @root_taxon_content_id,
+          publishing_api: Services.publishing_api
+        )
+    end
+
+    def update_payload(taxon)
+      {
+        document_type: 'taxon',
+        publishing_app: 'content-tagger',
+        schema_name: 'taxon',
+        title: taxon.title,
+        phase: @attributes.fetch(:phase),
+      }
+    end
+  end
+end

--- a/app/views/taxons/_form_fields.html.erb
+++ b/app/views/taxons/_form_fields.html.erb
@@ -35,6 +35,11 @@
     hint: I18n.t('views.taxons.visible_to_departmental_editors_hint')  %>
 <% end %>
 
+<%= f.input :phase,
+      collection: %w[alpha beta live],
+      selected: page.taxon.phase || 'live',
+      input_html: { class: 'form-control' } %>
+
 <%= f.input :notes_for_editors, as: :text, input_html: { class: 'form-control' } %>
 
 <%= f.input :associated_taxons,

--- a/app/views/taxons/_taxonomy_tree.html.erb
+++ b/app/views/taxons/_taxonomy_tree.html.erb
@@ -1,4 +1,5 @@
 <div class="taxonomy-tree">
+  <% unless local_assigns[:hide_parents] %>
   <div class="taxon-parents">
     <% page.taxonomy_tree.immediate_parents.each do |parent_node| %>
       <div class="parent-expansion">
@@ -18,6 +19,7 @@
       </div>
     <% end %>
   </div>
+  <% end %>
 
   <% has_parents = page.taxonomy_tree.immediate_parents.present? ? "taxon-focus--has-parents" : "" %>
   <% has_children = page.taxonomy_tree.immediate_children.present? ? "taxon-focus--has-children" : "" %>

--- a/app/views/taxons/confirm_bulk_update.html.erb
+++ b/app/views/taxons/confirm_bulk_update.html.erb
@@ -1,0 +1,15 @@
+<%= form_tag(taxon_bulk_update_path, class: 'form-inline confirmation-box') do %>
+  <header class="heading-with-actions">
+    <h1><%= page.title %></h1>
+  </header>
+
+  <div class="lead">
+    You are about to update the phase of this taxon and its children to
+    <%= select_tag 'taxon_phase', options_for_select(%w[alpha beta live], page.taxon.phase), class: 'form-control' %>
+  </div>
+
+  <%= render 'taxonomy_tree', page: page, hide_parents: true %>
+
+  <%= submit_tag "Confirm bulk update", class: 'btn btn-lg btn-success' %>
+  <%= link_to "Cancel", taxon_path(page.taxon_content_id), class: "cancel-link" %>
+<% end %>

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -29,10 +29,16 @@
 
   <div class="panel panel-default top-space">
     <div class="panel-body">
-      State: <%= page.publication_state_name %>
-      <% if page.redirected? %>
-        (redirects to <%= page.redirect_to %>)
-      <% end %>
+      <p>
+        Phase: <%= page.taxon.phase %>
+      </p>
+
+      <p>
+        State: <%= page.publication_state_name %>
+        <% if page.redirected? %>
+          (redirects to <%= page.redirect_to %>)
+        <% end %>
+      </p>
     </div>
 
     <div class="panel-footer">

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -42,6 +42,13 @@
     </div>
 
     <div class="panel-footer">
+      <% if !page.unpublished? %>
+        <p>
+          <%= link_to "Bulk update phase",
+                      taxon_confirm_bulk_update_path(page.taxon_content_id),
+                      class: 'btn btn-default' %>
+        </p>
+      <% end %>
       <% if page.taxon_deletable? && page.published? %>
         <%= link_to "Unpublish",
                     taxon_confirm_delete_path(page.taxon_content_id),

--- a/app/workers/update_taxon_worker.rb
+++ b/app/workers/update_taxon_worker.rb
@@ -1,0 +1,7 @@
+class UpdateTaxonWorker
+  include Sidekiq::Worker
+
+  def perform(content_id, payload)
+    Services.publishing_api.put_content(content_id, payload)
+  end
+end

--- a/app/workers/update_taxon_worker.rb
+++ b/app/workers/update_taxon_worker.rb
@@ -2,6 +2,12 @@ class UpdateTaxonWorker
   include Sidekiq::Worker
 
   def perform(content_id, payload)
+    taxon = Services.publishing_api.get_content(content_id)
+
     Services.publishing_api.put_content(content_id, payload)
+
+    return unless taxon.to_h['publication_state'] == 'published'
+
+    Services.publishing_api.publish(content_id)
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,11 +9,13 @@ Rails.application.routes.draw do
     get :history
     get :confirm_publish
     get :confirm_bulk_publish
+    get :confirm_bulk_update
     get :download_tagged
     get :visualisation_data
     get :download, on: :collection
     post :publish
     post :bulk_publish
+    post :bulk_update
     post :restore
     get :trash, on: :collection
     get :drafts, on: :collection

--- a/spec/controllers/taxons_controller_spec.rb
+++ b/spec/controllers/taxons_controller_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe TaxonsController, type: :controller do
 
   describe '#bulk_publish' do
     it 'bulk publishes content' do
-      expect(Taxonomy::BulkUpdateTaxon).to receive(:call).with('123')
+      expect(Taxonomy::BulkPublishTaxon).to receive(:call).with('123')
       post :bulk_publish, params: { taxon_id: 123 }
       expect(response).to redirect_to(taxon_path(123))
     end

--- a/spec/features/bulk_updating_spec.rb
+++ b/spec/features/bulk_updating_spec.rb
@@ -1,0 +1,99 @@
+require 'rails_helper'
+
+RSpec.feature 'Bulk updating', type: :feature do
+  include ContentItemHelper
+  include PublishingApiHelper
+
+  scenario 'Update the phase of decedent taxons' do
+    given_a_taxon_with_children
+    when_i_visit_the_show_taxon_page
+    then_i_can_see_the_bulk_update_button
+    when_i_click_the_bulk_update_button
+    then_i_see_the_confirmation_page
+    when_i_click_confirm_update
+    then_i_see_the_confirmation_message
+  end
+
+  def given_a_taxon_with_children
+    @parent_content_id = 'PARENT-TAXON-CONTENT-ID'
+    @child_content_id = 'CHILD-TAXON-CONTENT-ID'
+
+    parent_taxon = taxon_with_details(
+      'Parent taxon',
+      other_fields: {
+        content_id: @parent_content_id,
+        phase: 'beta',
+      }
+    )
+
+    child_taxon = taxon_with_details(
+      "Child taxon",
+      other_fields: {
+        content_id: @child_content_id,
+        phase: 'alpha',
+      }
+    )
+
+    stub_requests_for_show_page(parent_taxon)
+
+    publishing_api_has_links(
+      content_id: @parent_content_id,
+      links: {
+        child_taxons: [@child_content_id],
+      }
+    )
+
+    publishing_api_has_expanded_links(
+      content_id: @parent_content_id,
+      expanded_links: {
+        child_taxons: [child_taxon],
+      }
+    )
+
+    publishing_api_has_expanded_links(
+      content_id: @child_content_id,
+      expanded_links: {
+        parent_taxons: [parent_taxon]
+      }
+    )
+  end
+
+  def when_i_visit_the_show_taxon_page
+    visit taxon_path(@parent_content_id)
+  end
+
+  def then_i_can_see_the_bulk_update_button
+    expect(page).to have_link 'Bulk update phase'
+  end
+
+  def when_i_click_the_bulk_update_button
+    click_link 'Bulk update phase'
+  end
+
+  def then_i_see_the_confirmation_page
+    expect(page).to have_text 'You are about to update the phase of this taxon and its children to'
+    expect(page).to have_select('taxon_phase', selected: 'beta')
+  end
+
+  def when_i_click_confirm_update
+    Sidekiq::Testing.inline!
+
+    stub_any_publishing_api_put_content
+
+    click_button 'Confirm bulk update'
+
+    assert_publishing_api_put_content(
+      @parent_content_id,
+      request_json_includes(phase: 'beta')
+    )
+
+    assert_publishing_api_put_content(
+      @child_content_id,
+      request_json_includes(phase: 'beta')
+    )
+  end
+
+  def then_i_see_the_confirmation_message
+    expect(page).to have_text 'The taxons will be updated shortly'
+  end
+end

--- a/spec/features/move_content_between_taxons_spec.rb
+++ b/spec/features/move_content_between_taxons_spec.rb
@@ -35,7 +35,7 @@ RSpec.feature "Move content between Taxons", type: :feature do
   end
 
   def given_there_are_taxons
-    @source_taxon = content_item_with_details(
+    @source_taxon = taxon_with_details(
       "Source taxon",
       other_fields: {
         document_type: 'taxon'
@@ -46,7 +46,7 @@ RSpec.feature "Move content between Taxons", type: :feature do
       'content_id' => @source_taxon['content_id'],
       'publication_state' => 'live'
     }
-    @dest_taxon = content_item_with_details(
+    @dest_taxon = taxon_with_details(
       "Destination taxon",
       other_fields: {
         document_type: 'taxon'

--- a/spec/features/taxonomy_editing_spec.rb
+++ b/spec/features/taxonomy_editing_spec.rb
@@ -258,6 +258,7 @@ RSpec.feature "Taxonomy editing" do
         document_type: "taxon",
         details: { internal_name: "Newly created taxon" },
         publication_state: "published",
+        phase: 'live',
         title: "Newly created taxon",
       }.to_json)
     stub_request(:get, %r{https://publishing-api.test.gov.uk/v2/links/*})

--- a/spec/features/viewing_taxons_spec.rb
+++ b/spec/features/viewing_taxons_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Viewing taxons" do
   include ContentItemHelper
 
   let(:fruits) do
-    content_item_with_details(
+    taxon_with_details(
       "Fruits",
       other_fields: { document_type: "taxon" }
     )

--- a/spec/services/taxonomy/build_taxon_payload_spec.rb
+++ b/spec/services/taxonomy/build_taxon_payload_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe Taxonomy::BuildTaxonPayload do
       description: "This is a taxon.",
       internal_name: "Internal title",
       notes_for_editors: "Use this taxon wisely.",
-      visible_to_departmental_editors: true
+      visible_to_departmental_editors: true,
+      phase: 'live',
     )
   end
 

--- a/spec/services/taxonomy/bulk_update_taxon_spec.rb
+++ b/spec/services/taxonomy/bulk_update_taxon_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Taxonomy::BulkUpdateTaxon do
+RSpec.describe Taxonomy::BulkPublishTaxon do
   before do
     item = GovukTaxonomyHelpers::LinkedContentItem.new(title: 'item1', base_path: '/item1', content_id: 'id1')
     item << GovukTaxonomyHelpers::LinkedContentItem.new(title: 'item2', base_path: '/item2', content_id: 'id2')
@@ -16,7 +16,7 @@ RSpec.describe Taxonomy::BulkUpdateTaxon do
     it 'spawns a worker for each id' do
       expect(PublishTaxonWorker).to receive(:perform_async).with('id1')
       expect(PublishTaxonWorker).to receive(:perform_async).with('id2')
-      Taxonomy::BulkUpdateTaxon.call(@root_taxon_id)
+      Taxonomy::BulkPublishTaxon.call(@root_taxon_id)
     end
   end
 end

--- a/spec/services/taxonomy/save_taxon_version_spec.rb
+++ b/spec/services/taxonomy/save_taxon_version_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe Taxonomy::SaveTaxonVersion, '.call' do
       path_slug: 'business',
       title: 'Business',
       internal_name: 'Business [internal]',
-      description: 'Business as usual'
+      description: 'Business as usual',
+      phase: 'beta'
     )
 
     publishing_api_does_not_have_item(taxon.content_id)
@@ -25,6 +26,7 @@ RSpec.describe Taxonomy::SaveTaxonVersion, '.call' do
         ["+", "internal_name", "Business [internal]"],
         ["+", "notes_for_editors", ""],
         ["+", "parent", nil],
+        ["+", "phase", "beta"],
         ["+", "title", "Business"]
       ],
     )

--- a/spec/support/content_item_helper.rb
+++ b/spec/support/content_item_helper.rb
@@ -1,5 +1,7 @@
 module ContentItemHelper
   def taxon_with_details(title, other_fields: {}, unpublished: false)
+    other_fields[:phase] = other_fields[:phase] || 'live'
+
     content_item_with_details(
       title,
       other_fields: other_fields.merge(document_type: "taxon"),


### PR DESCRIPTION
- Allow a taxon phase (alpha, beta, live) to be changed from the edit form.
- New action to bulk change the phase for a taxon and all its decedents

Trello: https://trello.com/c/YWruwhl9/137-change-content-tagger-to-include-phases-for-taxons