### PR TITLE
Use foreman in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM ruby:2.4.2
 RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y build-essential nodejs && apt-get clean
+RUN gem install foreman
 
 ENV DATABASE_URL postgresql://postgres@postgres/content-tagger
 ENV GOVUK_APP_NAME content-tagger
@@ -19,4 +20,4 @@ RUN GOVUK_APP_DOMAIN=www.gov.uk GOVUK_APP_DOMAIN_EXTERNAL=www.gov.uk RAILS_ENV=p
 
 HEALTHCHECK CMD curl --silent --fail localhost:$PORT || exit 1
 
-CMD bash -c "bundle exec unicorn -p $PORT"
+CMD foreman run web

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
+web: bundle exec unicorn -c ./config/unicorn.rb -p ${PORT:-3116}
 worker: bundle exec sidekiq -C ./config/sidekiq.yml


### PR DESCRIPTION
Wider context: https://github.com/alphagov/publishing-e2e-tests/pull/202

This PR adds foreman as a gem dependency of docker (as per [foreman instructions](https://github.com/ddollar/foreman#installation)) as the means to run the processes for this app.

It also adds the web process to the Profile to boot the web server. 