### PR TITLE
Add task to check taxon base path structure

### DIFF
--- a/app/services/taxon_base_path_structure_check.rb
+++ b/app/services/taxon_base_path_structure_check.rb
@@ -1,0 +1,71 @@
+class TaxonBasePathStructureCheck
+  LEVEL_ONE_URL_REGEX = %r{^\/([A-z0-9\-]+)$}
+  PATH_COMPONENTS_REGEX = %r{^\/(?<prefix>[A-z0-9\-]+)(\/(?<slug>[A-z0-9\-]+))?$}
+
+  attr_reader :path_validation_output, :invalid_taxons
+
+  def initialize(level_one_taxons:)
+    @level_one_taxons = level_one_taxons
+    @path_validation_output = []
+    @invalid_taxons = []
+  end
+
+  def validate
+    @level_one_taxons.each do |level_one_taxon|
+      base_path = level_one_taxon['base_path']
+
+      if LEVEL_ONE_URL_REGEX.match?(base_path)
+        @path_validation_output << "✅ #{base_path}"
+      else
+        @invalid_taxons << level_one_taxon
+        @path_validation_output << "❌ #{base_path}"
+      end
+
+      level_one_prefix = PATH_COMPONENTS_REGEX.match(base_path)['prefix']
+
+      taxonomy_query
+        .child_taxons(base_path)
+        .each do |level_two_taxon|
+          validate_taxon(
+            level_one_prefix: level_one_prefix,
+            taxon: level_two_taxon
+          )
+        end
+    end
+  end
+
+private
+
+  def taxonomy_query
+    @_taxonomy_query ||= Taxonomy::TaxonomyQuery.new
+  end
+
+  def validate_taxon(level_one_prefix:, taxon:, n: 1)
+    base_path = taxon['base_path']
+    path_components = PATH_COMPONENTS_REGEX.match(base_path)
+
+    if path_components.present?
+      if level_one_prefix == path_components['prefix']
+        @path_validation_output << "✅ #{' ' * n * 2} ├── #{base_path}"
+      else
+        @invalid_taxons << taxon
+        @path_validation_output << "❌ #{' ' * n * 2} ├── #{base_path}"
+      end
+    else
+      @invalid_taxons << taxon
+      @path_validation_output << "❌ #{' ' * n * 2} ├── #{base_path}"
+    end
+
+    next_level_taxons = taxonomy_query.child_taxons(base_path)
+
+    return unless next_level_taxons.any?
+
+    next_level_taxons.each do |next_level_taxon|
+      validate_taxon(
+        level_one_prefix: level_one_prefix,
+        taxon: next_level_taxon,
+        n: n + 1
+      )
+    end
+  end
+end

--- a/lib/tasks/taxonomy/analysis/taxons_with_incorrect_base_paths.rake
+++ b/lib/tasks/taxonomy/analysis/taxons_with_incorrect_base_paths.rake
@@ -1,0 +1,26 @@
+namespace :taxonomy do
+  namespace :analysis do
+    desc "Outputs taxons that do not follow the defined taxon URL structure"
+    task taxons_with_incorrect_base_paths: :environment do
+      # [
+      #   { "content_id"=>"91b8ef20-74e7-4552-880c-50e6d73c2ff9",
+      #     "base_path"=>"/world/all",
+      #     "title"=>"World" },
+      #   ...
+      # ]
+      level_one_taxons = Taxonomy::TaxonomyQuery.new.level_one_taxons
+
+      base_path_checker = TaxonBasePathStructureCheck.new(level_one_taxons: level_one_taxons)
+      base_path_checker.validate
+
+      puts base_path_checker.path_validation_output.join("\n")
+
+      puts "-" * 36
+
+      puts "The following taxons do not follow the taxon URL structure:"
+      base_path_checker.invalid_taxons.each do |taxon|
+        puts taxon.slice('content_id', 'base_path').values.join(' ')
+      end
+    end
+  end
+end


### PR DESCRIPTION
The task iterates down the taxonomy and checks against each taxon that
it is following the defined taxon URL structure [1].

[1] https://gov-uk.atlassian.net/wiki/spaces/FS/pages/127664172/URL+structure+for+the+new+navigation+pages