### PR TITLE
Add required fields for PUT content payload

### DIFF
--- a/app/services/taxonomy/bulk_update_taxon.rb
+++ b/app/services/taxonomy/bulk_update_taxon.rb
@@ -7,7 +7,10 @@ module Taxonomy
 
     def bulk_update
       nested_tree.each do |taxon|
-        UpdateTaxonWorker.perform_async(taxon.content_id, update_payload(taxon))
+        UpdateTaxonWorker.perform_async(
+          taxon.content_id,
+          @attributes.slice(:phase)
+        )
       end
     end
 
@@ -19,16 +22,6 @@ module Taxonomy
           content_id: @root_taxon_content_id,
           publishing_api: Services.publishing_api
         )
-    end
-
-    def update_payload(taxon)
-      {
-        document_type: 'taxon',
-        publishing_app: 'content-tagger',
-        schema_name: 'taxon',
-        title: taxon.title,
-        phase: @attributes.fetch(:phase),
-      }
     end
   end
 end

--- a/app/services/taxonomy/bulk_update_taxon.rb
+++ b/app/services/taxonomy/bulk_update_taxon.rb
@@ -7,10 +7,7 @@ module Taxonomy
 
     def bulk_update
       nested_tree.each do |taxon|
-        UpdateTaxonWorker.perform_async(
-          taxon.content_id,
-          @attributes.slice(:phase)
-        )
+        UpdateTaxonWorker.perform_async(taxon.content_id, @attributes)
       end
     end
 

--- a/app/workers/update_taxon_worker.rb
+++ b/app/workers/update_taxon_worker.rb
@@ -1,12 +1,14 @@
 class UpdateTaxonWorker
   include Sidekiq::Worker
 
-  def perform(content_id, payload)
-    taxon = Services.publishing_api.get_content(content_id)
+  def perform(content_id, attributes)
+    taxon = Taxonomy::BuildTaxon.call(content_id: content_id)
+    taxon.phase = attributes.with_indifferent_access.fetch(:phase)
 
+    payload = Taxonomy::BuildTaxonPayload.call(taxon: taxon)
     Services.publishing_api.put_content(content_id, payload)
 
-    return unless taxon.to_h['publication_state'] == 'published'
+    return unless taxon.published?
 
     Services.publishing_api.publish(content_id)
   end

--- a/app/workers/update_taxon_worker.rb
+++ b/app/workers/update_taxon_worker.rb
@@ -3,7 +3,7 @@ class UpdateTaxonWorker
 
   def perform(content_id, attributes)
     taxon = Taxonomy::BuildTaxon.call(content_id: content_id)
-    taxon.phase = attributes.with_indifferent_access.fetch(:phase)
+    taxon.assign_attributes(attributes)
 
     payload = Taxonomy::BuildTaxonPayload.call(taxon: taxon)
     Services.publishing_api.put_content(content_id, payload)

--- a/spec/features/bulk_updating_spec.rb
+++ b/spec/features/bulk_updating_spec.rb
@@ -45,6 +45,13 @@ RSpec.feature 'Bulk updating', type: :feature do
       }
     )
 
+    publishing_api_has_links(
+      content_id: @child_content_id,
+      links: {
+        parent: [@parent_content_id]
+      }
+    )
+
     publishing_api_has_expanded_links(
       content_id: @parent_content_id,
       expanded_links: {


### PR DESCRIPTION
After testing this on integration, I missed a few required fields for the Publishing API request. Sentry error can be seen here: https://sentry.io/govuk/app-content-tagger/issues/361348692/