### PR TITLE
Find common ancestors

### DIFF
--- a/app/services/metrics/content_coverage_metrics.rb
+++ b/app/services/metrics/content_coverage_metrics.rb
@@ -40,7 +40,7 @@ module Metrics
     def items_in_scope_count
       @_items_in_scope_count ||= Services.rummager.search(
         count: 0,
-        reject_content_store_document_type: blacklisted_document_types,
+        reject_content_store_document_type: Tagging.blacklisted_document_types,
         debug: 'include_withdrawn'
       ).to_h.fetch("total")
     end
@@ -49,7 +49,7 @@ module Metrics
       @_tagged_items_in_scope_count ||= Services.rummager.search(
         count: 0,
         filter_part_of_taxonomy_tree: root_taxon_content_ids,
-        reject_content_store_document_type: blacklisted_document_types,
+        reject_content_store_document_type: Tagging.blacklisted_document_types,
         debug: 'include_withdrawn'
       ).to_h.fetch("total")
     end
@@ -62,17 +62,6 @@ module Metrics
 
     def gauge(stat, value)
       Metrics.statsd.gauge(stat, value)
-    end
-
-    def blacklisted_document_types
-      @_blacklisted_document_types ||=
-        YAML.load_file(
-          File.join(
-            Rails.root,
-            'config',
-            'document_types_excluded_from_the_topic_taxonomy.yml'
-          )
-        )['document_types']
     end
   end
 end

--- a/app/services/tagging.rb
+++ b/app/services/tagging.rb
@@ -1,0 +1,12 @@
+module Tagging
+  def self.blacklisted_document_types
+    @_blacklisted_document_types ||=
+      YAML.load_file(
+        File.join(
+          Rails.root,
+          'config',
+          'document_types_excluded_from_the_topic_taxonomy.yml'
+        )
+      )['document_types']
+  end
+end

--- a/app/services/tagging/common_ancestor_finder.rb
+++ b/app/services/tagging/common_ancestor_finder.rb
@@ -1,0 +1,55 @@
+module Tagging
+  class CommonAncestorFinder
+    def self.call
+      new.find_all
+    end
+
+    def find_all
+      content_enum = Services.rummager.search_enum({ reject_content_store_document_type: Tagging.blacklisted_document_types,
+                                                     fields: %w[content_id title] }, page_size: 100)
+      filtered_content_enum = content_enum.lazy.select { |c| c.has_key?('content_id') }
+      all_results = filtered_content_enum.map do |content_hash|
+        content_id = content_hash['content_id']
+        title = content_hash['title']
+        expanded_links_hash = Services.publishing_api.get_expanded_links(content_id).to_h
+        {
+          content_id: content_id,
+          title: title,
+          common_ancestors: find_common_ancestors(taxon_paths(expanded_links_hash))
+        }
+      end
+      all_results.select { |result| result[:common_ancestors].present? }
+    end
+
+  private
+
+    def taxon_paths(content_hash)
+      taxon_path = lambda do |taxon_hash|
+        return [] if taxon_hash.nil?
+        taxon_path.call(taxon_hash.dig('links', 'parent_taxons', 0) ||
+                        taxon_hash.dig('links', 'root_taxon', 0)).append(taxon_hash['content_id'])
+      end
+
+      taxon_hashes = content_hash.dig('expanded_links', 'taxons') || []
+      taxon_hashes.map do |taxon_hash|
+        taxon_path.call(taxon_hash)
+      end
+    end
+
+    # Finds the common ancestors from a list of paths of one or more trees
+    # The paths are ordered from the root to leaf
+    def find_common_ancestors(paths, common_ancestors = [])
+      return common_ancestors if paths.empty?
+
+      # Remove paths with a unique root - these cannot have common ancestors
+      paths_grouped_by_root = paths.group_by(&:first)
+      paths_with_common_root = paths_grouped_by_root.select { |_, v| v.length > 1 }.values.flatten(1)
+
+      # Remaining paths with length one have a common ancestor, i.e. the common root
+      paths_with_length_one = paths_with_common_root.select { |v| v.length == 1 }
+      paths_with_length_greater_than_one = paths_with_common_root.select { |n| n.length > 1 }
+
+      find_common_ancestors(paths_with_length_greater_than_one.map { |n| n[1..-1] }, common_ancestors + paths_with_length_one.flatten)
+    end
+  end
+end

--- a/app/services/tagging/untagger.rb
+++ b/app/services/tagging/untagger.rb
@@ -1,0 +1,12 @@
+module Tagging
+  class Untagger
+    def self.call(content_id, taxon_content_ids)
+      new.untag(content_id, taxon_content_ids)
+    end
+
+    def untag(content_id, taxon_content_ids)
+      existing_taxons_ids = Services.publishing_api.get_links(content_id).dig('links', 'taxons')
+      Services.publishing_api.patch_links(content_id, links: { taxons: (existing_taxons_ids - taxon_content_ids) })
+    end
+  end
+end

--- a/lib/tasks/content_tagged_to_ancestors.rake
+++ b/lib/tasks/content_tagged_to_ancestors.rake
@@ -1,0 +1,11 @@
+namespace :content do
+  desc "Find all content that is tagged to a taxon and its direct ancestor and optionally removes redundant tagging (option: untag='untag')"
+  task :tagged_to_ancestor, [:untag] => :environment do |_, args|
+    results = Tagging::CommonAncestorFinder.call
+    results.each do |result|
+      puts "Document #{result[:title]}, content_id: #{result[:content_id]} has common ancestors tagged to: "
+      puts result[:common_ancestors].inspect
+      Tagging::Untagger.call(result[:content_id], result[:common_ancestors]) if args[:untag] == "untag"
+    end
+  end
+end

--- a/spec/services/metrics/content_coverage_metrics_spec.rb
+++ b/spec/services/metrics/content_coverage_metrics_spec.rb
@@ -5,7 +5,7 @@ module Metrics
     describe '#record_all' do
       before do
         blacklist = %w[taxon redirect]
-        allow_any_instance_of(Metrics::ContentCoverageMetrics)
+        allow(Tagging)
           .to receive(:blacklisted_document_types).and_return(blacklist)
 
         stub_request(:get, "#{Plek.find('rummager')}/search.json")

--- a/spec/services/tagging/common_ancestor_finder_spec.rb
+++ b/spec/services/tagging/common_ancestor_finder_spec.rb
@@ -1,0 +1,77 @@
+require 'rails_helper'
+require 'gds_api/test_helpers/rummager'
+include ::GdsApi::TestHelpers::Rummager
+
+RSpec.describe Tagging::CommonAncestorFinder do
+  context 'there is one taxon' do
+    def has_paths(paths)
+      publishing_api_has_expanded_links(Support::TaxonHelper.expanded_link_hash('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', paths))
+    end
+
+    before :each do
+      stub_any_rummager_search.to_return(body: { 'results' => [{ 'content_id' => 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' }] }.to_json)
+    end
+
+    it 'returns nothing' do
+      has_paths []
+      result = Tagging::CommonAncestorFinder.new.find_all.force
+      expect(result).to be_empty
+    end
+    it 'has one path and return nothing' do
+      has_paths [[1, 2, 3, 4]]
+      result = Tagging::CommonAncestorFinder.new.find_all.force
+      expect(result).to be_empty
+    end
+    it 'has two paths, no common ancestor and returns nothing' do
+      has_paths [[1, 2, 3, 4], [1, 2, 3, 5]]
+      result = Tagging::CommonAncestorFinder.new.find_all.force
+      expect(result).to be_empty
+    end
+    it 'has two paths, one common ancestor, returns the common ancestor' do
+      has_paths [[1, 2, 3, 4], [1, 2, 3]]
+      result = Tagging::CommonAncestorFinder.new.find_all
+      expect(result.first[:common_ancestors]).to match_array([3])
+    end
+    it 'has three paths, one common ancestor, returns the common ancestor' do
+      has_paths [[1, 2, 3, 4], [1, 2, 3], [1, 2, 5]]
+      result = Tagging::CommonAncestorFinder.new.find_all
+      expect(result.first[:common_ancestors]).to match_array([3])
+    end
+    it 'has five paths, two common ancestors, returns the common ancestors' do
+      has_paths [[1, 2, 3, 4], [1, 2, 3], [1, 2, 5], [1, 2, 5, 9], [1, 2, 5, 11]]
+      result = Tagging::CommonAncestorFinder.new.find_all
+      expect(result.first[:common_ancestors]).to match_array([3, 5])
+    end
+    it 'has four paths, three common ancestors, returns all ancestors' do
+      has_paths [[1], [1, 2, 3], [1, 2], [1, 2, 3, 4]]
+      result = Tagging::CommonAncestorFinder.new.find_all
+      expect(result.first[:common_ancestors]).to match_array([1, 2, 3])
+    end
+    it 'has separate branches, returns all ancestors' do
+      has_paths [[1], [1, 2, 3], [5, 6], [5, 6, 7]]
+      result = Tagging::CommonAncestorFinder.new.find_all
+      expect(result.first[:common_ancestors]).to match_array([1, 6])
+    end
+  end
+
+  it 'rejects empty content_ids' do
+    stub_any_rummager_search.to_return(body: { 'results' => [{ 'content_id' => 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' }, {}] }.to_json)
+    publishing_api_has_expanded_links(Support::TaxonHelper.expanded_link_hash('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', [[1], [1, 2]]))
+    expect(Tagging::CommonAncestorFinder.new.find_all.force.length).to eq(1)
+  end
+
+  it 'includes title and content_id' do
+    stub_any_rummager_search.to_return(body: { 'results' => [{ 'content_id' => 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+                                                               'title' => 'my title' }] }.to_json)
+    publishing_api_has_expanded_links(Support::TaxonHelper.expanded_link_hash('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', [[1], [1, 2]]))
+    result_hash = Tagging::CommonAncestorFinder.new.find_all.force.first
+    expect(result_hash[:title]).to eq('my title')
+    expect(result_hash[:content_id]).to eq('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
+  end
+
+  it 'rejects empty results' do
+    stub_any_rummager_search.to_return(body: { 'results' => [{ 'content_id' => 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' }] }.to_json)
+    publishing_api_has_expanded_links(Support::TaxonHelper.expanded_link_hash('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', [[]]))
+    expect(Tagging::CommonAncestorFinder.new.find_all.force).to be_empty
+  end
+end

--- a/spec/services/tagging/untagger_spec.rb
+++ b/spec/services/tagging/untagger_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+require 'gds_api/test_helpers/publishing_api_v2'
+include ::GdsApi::TestHelpers::PublishingApiV2
+
+RSpec.describe Tagging::Untagger do
+  it 'untags a taxon' do
+    content_id = "51ac4247-fd92-470a-a207-6b852a97f2db"
+    publishing_api_has_links(
+      "content_id" => content_id,
+      "links" => {
+        "taxons" => ['aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb']
+      },
+    )
+
+    stub_any_publishing_api_patch_links
+    Tagging::Untagger.call(content_id, ['aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'])
+    assert_publishing_api_patch_links(content_id, 'links' => { 'taxons' => ['bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'] })
+  end
+end

--- a/spec/support/taxon_helper.rb
+++ b/spec/support/taxon_helper.rb
@@ -1,0 +1,33 @@
+module Support
+  class TaxonHelper
+    def self.expanded_link_hash(content_id, paths)
+      path_converter = lambda do |path|
+        head, *tail = path
+
+        return {} if head.nil?
+        links_hash =
+          if tail.empty?
+            {}
+          else
+            {
+              "links" =>
+               {
+                 tail.length == 1 ? "root_taxon" : "parent_taxons" => [path_converter.call(tail)]
+               }
+            }
+          end
+        {
+          "content_id" => head
+        }.merge(links_hash)
+      end
+
+      {
+        'content_id' => content_id,
+        'expanded_links' =>
+          {
+            'taxons' => paths.map { |path| path_converter.call(path.reverse) }
+          }
+      }
+    end
+  end
+end

--- a/spec/support/taxon_helper_spec.rb
+++ b/spec/support/taxon_helper_spec.rb
@@ -1,0 +1,45 @@
+require_relative("taxon_helper")
+require 'rails_helper'
+
+RSpec.describe Support::TaxonHelper do
+  describe '#expanded_link_hash' do
+    it 'has a correct helper' do
+      result = Support::TaxonHelper.expanded_link_hash("a", [["b"], %w[f e d c]])
+      expected_hash = {
+        "content_id" => "a",
+        "expanded_links" => {
+          "taxons" => [
+            {
+              "content_id" => "b"
+            },
+            {
+              "content_id" => "c",
+              "links" => {
+                "parent_taxons" => [
+                  {
+                    "content_id" => "d",
+                    "links" => {
+                      "parent_taxons" => [
+                        {
+                          "content_id" => "e",
+                          "links" => {
+                            "root_taxon" => [
+                              {
+                                "content_id" => "f",
+                              }
+                            ]
+                          },
+                        }
+                      ]
+                    },
+                  }
+                ]
+              },
+            }
+          ],
+        },
+      }
+      expect(result).to eq(expected_hash)
+    end
+  end
+end


### PR DESCRIPTION
Untags content items with common ancestors:

Trello: https://trello.com/c/jwol8AXZ/141-remove-superfluous-ancestor-tags

Adds a rake task: `content:content_tagged_to_ancestor` that removes all
redundant common-ancestor taggings

The algorithm gets taxon 'paths' from the taxonomy tree using the expanded 
links method of the publishing api. A 'path' is a sequence of content_ids from 
the 'root taxon' to the taxon the content item is tagged to.

The algorithm recursively searches for paths that are contained in others. For 
example we may have paths:

Root->A->B->C
Root->A->B
Root->A->D

Here, the content item is tagged to taxon 'C' as well as its direct ancestor 'B'.  
Because being tagged to taxon 'C' implies it is also tagged to 'B' (and 'A' and 'Root')
the tagging to taxon 'B' is considered redundant and can be removed. The 
 `CommonAncestorFinder` method will return taxon 'B' as its result.