### PR TITLE
Refactor TaxonBasePathStructureCheck class

### DIFF
--- a/app/services/taxon_base_path_structure_check.rb
+++ b/app/services/taxon_base_path_structure_check.rb
@@ -1,7 +1,4 @@
 class TaxonBasePathStructureCheck
-  LEVEL_ONE_URL_REGEX = %r{^\/([A-z0-9\-]+)$}
-  PATH_COMPONENTS_REGEX = %r{^\/(?<prefix>[A-z0-9\-]+)(\/(?<slug>[A-z0-9\-]+))?$}
-
   attr_reader :path_validation_output, :invalid_taxons
 
   def initialize(level_one_taxons:)
@@ -11,61 +8,67 @@ class TaxonBasePathStructureCheck
   end
 
   def validate
-    @level_one_taxons.each do |level_one_taxon|
-      base_path = level_one_taxon['base_path']
-
-      if LEVEL_ONE_URL_REGEX.match?(base_path)
-        @path_validation_output << "✅ #{base_path}"
-      else
-        @invalid_taxons << level_one_taxon
-        @path_validation_output << "❌ #{base_path}"
-      end
-
-      level_one_prefix = PATH_COMPONENTS_REGEX.match(base_path)['prefix']
-
-      taxonomy_query
-        .child_taxons(base_path)
-        .each do |level_two_taxon|
-          validate_taxon(
-            level_one_prefix: level_one_prefix,
-            taxon: level_two_taxon
-          )
-        end
-    end
+    @level_one_taxons.each { |level_one_taxon| validate_tree(taxon: level_one_taxon) }
   end
 
 private
+
+  def validate_tree(taxon:, level_one_prefix: nil, n: 0)
+    taxon = Taxon.new(taxon, level_one_prefix: level_one_prefix)
+
+    spacer = n.positive? ? "#{' ' * n * 2} ├── " : ""
+    if taxon.valid?
+      @path_validation_output << "✅ #{spacer}#{taxon.base_path}"
+    else
+      @path_validation_output << "❌ #{spacer}#{taxon.base_path}"
+      @invalid_taxons << taxon
+    end
+
+    next_level_taxons = taxonomy_query.child_taxons(taxon.base_path)
+
+    return unless next_level_taxons.any?
+
+    next_level_taxons.each do |next_level_taxon|
+      validate_tree(taxon: next_level_taxon, level_one_prefix: taxon.level_one_prefix, n: n + 1)
+    end
+  end
 
   def taxonomy_query
     @_taxonomy_query ||= Taxonomy::TaxonomyQuery.new
   end
 
-  def validate_taxon(level_one_prefix:, taxon:, n: 1)
-    base_path = taxon['base_path']
-    path_components = PATH_COMPONENTS_REGEX.match(base_path)
+  class Taxon
+    LEVEL_ONE_URL_REGEX = %r{^\/([A-z0-9\-]+)$}
+    PATH_COMPONENTS_REGEX = %r{^\/(?<prefix>[A-z0-9\-]+)(\/(?<slug>[A-z0-9\-]+))?$}
 
-    if path_components.present?
-      if level_one_prefix == path_components['prefix']
-        @path_validation_output << "✅ #{' ' * n * 2} ├── #{base_path}"
-      else
-        @invalid_taxons << taxon
-        @path_validation_output << "❌ #{' ' * n * 2} ├── #{base_path}"
-      end
-    else
-      @invalid_taxons << taxon
-      @path_validation_output << "❌ #{' ' * n * 2} ├── #{base_path}"
+    def initialize(taxon, level_one_prefix:)
+      @taxon = taxon
+      @level_one_prefix = level_one_prefix
     end
 
-    next_level_taxons = taxonomy_query.child_taxons(base_path)
+    def valid?
+      if level_one_taxon?
+        LEVEL_ONE_URL_REGEX.match? base_path
+      else
+        return false if path_components.blank?
+        level_one_prefix == path_components['prefix']
+      end
+    end
 
-    return unless next_level_taxons.any?
+    def base_path
+      @taxon['base_path']
+    end
 
-    next_level_taxons.each do |next_level_taxon|
-      validate_taxon(
-        level_one_prefix: level_one_prefix,
-        taxon: next_level_taxon,
-        n: n + 1
-      )
+    def level_one_taxon?
+      @level_one_prefix.blank?
+    end
+
+    def level_one_prefix
+      @level_one_prefix || path_components['prefix']
+    end
+
+    def path_components
+      @_path_components ||= PATH_COMPONENTS_REGEX.match base_path
     end
   end
 end

--- a/spec/services/taxon_base_path_structure_check_spec.rb
+++ b/spec/services/taxon_base_path_structure_check_spec.rb
@@ -1,0 +1,207 @@
+require "rails_helper"
+require 'gds_api/test_helpers/content_store'
+
+RSpec.describe TaxonBasePathStructureCheck, '#validate' do
+  include ::GdsApi::TestHelpers::ContentStore
+
+  it 'outputs check as all-valid' do
+    content_store_has_valid_two_level_tree
+
+    checker = TaxonBasePathStructureCheck.new(
+      level_one_taxons: [{ 'base_path' => '/level-one' }]
+    )
+    checker.validate
+
+    expect(checker.invalid_taxons).to be_empty
+    expect(checker.path_validation_output).to all(start_with('✅'))
+  end
+
+  it 'records invalid taxons that do not have the same level one prefix' do
+    content_store_has_tree_with_invalid_level_one_prefix
+
+    checker = TaxonBasePathStructureCheck.new(
+      level_one_taxons: [{ 'base_path' => '/level-one' }]
+    )
+    checker.validate
+
+    expect(checker.invalid_taxons).to eq(
+      [
+        {
+          "base_path" => "/some-other-path/level-two",
+          "content_id" => "CONTENT-ID-LEVEL-TWO",
+          "title" => "Level Two",
+          "parent_content_id" => "CONTENT-ID-LEVEL-ONE"
+        }
+      ]
+    )
+  end
+
+  it 'records invalid taxons that do not follow the base path structure' do
+    content_store_has_tree_with_long_base_path_structure
+
+    checker = TaxonBasePathStructureCheck.new(
+      level_one_taxons: [{ 'base_path' => '/level-one' }]
+    )
+    checker.validate
+
+    expect(checker.invalid_taxons).to eq(
+      [
+        {
+          "base_path" => "/imported-topic/topic/level-one/level-two",
+          "content_id" => "CONTENT-ID-LEVEL-TWO",
+          "title" => "Level Two",
+          "parent_content_id" => "CONTENT-ID-LEVEL-ONE"
+        }
+      ]
+    )
+  end
+
+  it 'validates the whole tree even if the level one base path structure is incorrect' do
+    content_store_has_tree_with_invalid_level_one_base_path
+
+    checker = TaxonBasePathStructureCheck.new(
+      level_one_taxons: [{ 'base_path' => '/level-one/taxon' }]
+    )
+    checker.validate
+
+    expect(checker.invalid_taxons).to eq [{ "base_path" => "/level-one/taxon" }]
+    expect(checker.path_validation_output).to eq(
+      [
+        "❌ /level-one/taxon",
+        "✅    ├── /level-one/level-two"
+      ]
+    )
+  end
+
+  # /level-one
+  #   /level-one/level-two
+  def content_store_has_valid_two_level_tree
+    content_store_has_item(
+      '/level-one',
+      {
+        "base_path" => "/level-one",
+        "content_id" => "CONTENT-ID-LEVEL-ONE",
+        "title" => "Level One",
+        "links" => {
+          "child_taxons" => [
+            {
+              "base_path" => "/level-one/level-two",
+              "content_id" => "CONTENT-ID-LEVEL-TWO",
+              "title" => "Level Two",
+              "links" => {}
+            }
+          ]
+        }
+      }.to_json, draft: true
+    )
+
+    content_store_has_item(
+      '/level-one/level-two',
+      {
+        "base_path" => "/level-one/level-two",
+        "content_id" => "CONTENT-ID-LEVEL-TWO",
+        "title" => "Level Two",
+        "links" => {}
+      }.to_json, draft: true
+    )
+  end
+
+  # /level-one
+  #   /some-other-path/level-two
+  def content_store_has_tree_with_invalid_level_one_prefix
+    content_store_has_item(
+      '/level-one',
+      {
+        "base_path" => "/level-one",
+        "content_id" => "CONTENT-ID-LEVEL-ONE",
+        "title" => "Level One",
+        "links" => {
+          "child_taxons" => [
+            {
+              "base_path" => "/some-other-path/level-two",
+              "content_id" => "CONTENT-ID-LEVEL-TWO",
+              "title" => "Level Two",
+              "links" => {}
+            }
+          ]
+        }
+      }.to_json, draft: true
+    )
+
+    content_store_has_item(
+      '/some-other-path/level-two',
+      {
+        "base_path" => "/some-other-path/level-two",
+        "content_id" => "CONTENT-ID-LEVEL-TWO",
+        "title" => "Level Two",
+        "links" => {}
+      }.to_json, draft: true
+    )
+  end
+
+  # /level-one
+  #   /imported-topic/topic/level-one/level-two
+  def content_store_has_tree_with_long_base_path_structure
+    content_store_has_item(
+      '/level-one',
+      {
+        "base_path" => "/level-one",
+        "content_id" => "CONTENT-ID-LEVEL-ONE",
+        "title" => "Level One",
+        "links" => {
+          "child_taxons" => [
+            {
+              "base_path" => "/imported-topic/topic/level-one/level-two",
+              "content_id" => "CONTENT-ID-LEVEL-TWO",
+              "title" => "Level Two",
+              "links" => {}
+            }
+          ]
+        }
+      }.to_json, draft: true
+    )
+
+    content_store_has_item(
+      '/imported-topic/topic/level-one/level-two',
+      {
+        "base_path" => "/imported-topic/topic/level-one/level-two",
+        "content_id" => "CONTENT-ID-LEVEL-TWO",
+        "title" => "Level Two",
+        "links" => {}
+      }.to_json, draft: true
+    )
+  end
+
+  # /level-one/taxon
+  #   /level-one/level-two
+  def content_store_has_tree_with_invalid_level_one_base_path
+    content_store_has_item(
+      '/level-one/taxon',
+      {
+        "base_path" => "/level-one/taxon",
+        "content_id" => "CONTENT-ID-LEVEL-ONE",
+        "title" => "Level One",
+        "links" => {
+          "child_taxons" => [
+            {
+              "base_path" => "/level-one/level-two",
+              "content_id" => "CONTENT-ID-LEVEL-TWO",
+              "title" => "Level Two",
+              "links" => {}
+            }
+          ]
+        }
+      }.to_json, draft: true
+    )
+
+    content_store_has_item(
+      '/level-one/level-two',
+      {
+        "base_path" => "/level-one/level-two",
+        "content_id" => "CONTENT-ID-LEVEL-TWO",
+        "title" => "Level Two",
+        "links" => {}
+      }.to_json, draft: true
+    )
+  end
+end

--- a/spec/services/taxon_base_path_structure_check_spec.rb
+++ b/spec/services/taxon_base_path_structure_check_spec.rb
@@ -24,16 +24,9 @@ RSpec.describe TaxonBasePathStructureCheck, '#validate' do
     )
     checker.validate
 
-    expect(checker.invalid_taxons).to eq(
-      [
-        {
-          "base_path" => "/some-other-path/level-two",
-          "content_id" => "CONTENT-ID-LEVEL-TWO",
-          "title" => "Level Two",
-          "parent_content_id" => "CONTENT-ID-LEVEL-ONE"
-        }
-      ]
-    )
+    expect(checker.invalid_taxons.size).to eq(1)
+    expect(checker.invalid_taxons.last.base_path)
+      .to eq("/some-other-path/level-two")
   end
 
   it 'records invalid taxons that do not follow the base path structure' do
@@ -44,16 +37,9 @@ RSpec.describe TaxonBasePathStructureCheck, '#validate' do
     )
     checker.validate
 
-    expect(checker.invalid_taxons).to eq(
-      [
-        {
-          "base_path" => "/imported-topic/topic/level-one/level-two",
-          "content_id" => "CONTENT-ID-LEVEL-TWO",
-          "title" => "Level Two",
-          "parent_content_id" => "CONTENT-ID-LEVEL-ONE"
-        }
-      ]
-    )
+    expect(checker.invalid_taxons.size).to eq(1)
+    expect(checker.invalid_taxons.last.base_path)
+      .to eq("/imported-topic/topic/level-one/level-two")
   end
 
   it 'validates the whole tree even if the level one base path structure is incorrect' do
@@ -64,7 +50,8 @@ RSpec.describe TaxonBasePathStructureCheck, '#validate' do
     )
     checker.validate
 
-    expect(checker.invalid_taxons).to eq [{ "base_path" => "/level-one/taxon" }]
+    expect(checker.invalid_taxons.size).to eq(1)
+    expect(checker.invalid_taxons.last.base_path).to eq("/level-one/taxon")
     expect(checker.path_validation_output).to eq(
       [
         "❌ /level-one/taxon",


### PR DESCRIPTION
In preparation for updating the rake task to automatically fix base paths that do not follow the URL structure.

There is no change in functionality, it should be easier to review this PR commit by commit.