### PR TITLE
Update visible_to_departmental_editors checkbox

### DIFF
--- a/app/services/taxonomy/edit_page.rb
+++ b/app/services/taxonomy/edit_page.rb
@@ -21,7 +21,7 @@ module Taxonomy
     end
 
     def show_visibilty_checkbox?
-      taxon.draft? && taxon.parent.nil?
+      taxon.parent == GovukTaxonomy::ROOT_CONTENT_ID
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -104,7 +104,7 @@ en:
       displayed_on_govuk: 'Displayed on GOV.UK'
       view_similar: 'More like this'
       visible_to_departmental_editors: 'Visible to departmental editors?'
-      visible_to_departmental_editors_hint: 'Affects the visiblity of draft taxonomy root nodes only'
+      visible_to_departmental_editors_hint: 'Affects the visiblity of level one taxons only'
       associated_taxons: Associated taxons
       metadata: Taxon metadata
     projects:

--- a/spec/services/taxonomy/edit_page_spec.rb
+++ b/spec/services/taxonomy/edit_page_spec.rb
@@ -2,25 +2,19 @@ require 'rails_helper'
 
 RSpec.describe Taxonomy::EditPage do
   describe "#show_visibilty_checkbox?" do
-    it "is true when Taxon is in Draft state and has no parent" do
-      taxon = instance_double(Taxon, draft?: true, parent: nil)
+    it "is true when Taxon is a level one taxon" do
+      taxon = instance_double(Taxon, parent: GovukTaxonomy::ROOT_CONTENT_ID)
       result = Taxonomy::EditPage.new(taxon).show_visibilty_checkbox?
 
       expect(result).to be true
     end
 
-    it "is false when Taxon is in Draft state and has a parent" do
-      taxon = instance_double(Taxon, draft?: true, parent: double)
+    it "is false when Taxon is not level one taxon" do
+      taxon = instance_double(Taxon, parent: double)
       result = Taxonomy::EditPage.new(taxon).show_visibilty_checkbox?
 
       expect(result).to be false
     end
 
-    it "is false when Taxon is not in Draft state and has a parent" do
-      taxon = instance_double(Taxon, draft?: false, parent: double)
-      result = Taxonomy::EditPage.new(taxon).show_visibilty_checkbox?
-
-      expect(result).to be false
-    end
   end
 end


### PR DESCRIPTION
The visible_to_departmental_editors checkbox in the taxon edit page
are now visible when the direct parent is the root taxon.

Trello: https://trello.com/c/J8smE6ql/163-visibletodepartmentaleditors-flag-does-not-show-in-content-tagger