### PR TITLE
Add a "Add a child taxon" button to the taxon page

### DIFF
--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -20,7 +20,7 @@ class TaxonsController < ApplicationController
   end
 
   def new
-    render :new, locals: { page: Taxonomy::EditPage.new(Taxon.new) }
+    render :new, locals: { page: Taxonomy::EditPage.new(Taxon.new(taxon_params)) }
   end
 
   def create
@@ -188,7 +188,7 @@ class TaxonsController < ApplicationController
 private
 
   def taxon_params
-    params.require(:taxon).permit(
+    params.fetch(:taxon, {}).permit(
       :content_id,
       :base_path,
       :internal_name,

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -90,6 +90,12 @@
           </p>
         <% end %>
 
+        <p>
+          <%= link_to I18n.t('views.taxons.add_child'),
+          new_taxon_path(taxon: { parent_content_id: page.content_id }),
+          class: "btn btn-default" %>
+        </p>
+
         <% if page.taxon_deletable? && page.published? %>
           <p>
             <%= link_to "Unpublish",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -78,6 +78,7 @@ en:
       title: Taxons
       deleted_title: Deleted taxons
       edit: Edit taxon
+      add_child: Add a child taxon
       tagging_history: View tagging history
       view: View taxon
       add_taxon: Add a taxon

--- a/spec/features/taxonomy_editing_spec.rb
+++ b/spec/features/taxonomy_editing_spec.rb
@@ -247,22 +247,19 @@ RSpec.feature "Taxonomy editing" do
     fill_in :taxon_description, with: "Description of my updated taxon."
     fill_in :taxon_notes_for_editors, with: @dummy_editor_notes
 
-    @update_item = stub_request(:put, %r{https://publishing-api.test.gov.uk/v2/content*})
+    @update_item = stub_request(:put, %r{https://publishing-api.test.gov.uk/v2/content})
       .with(body: /details.*#{@dummy_editor_notes}/)
       .to_return(status: 200, body: {}.to_json)
 
-    @publish_item = stub_request(:post, "https://publishing-api.test.gov.uk/v2/content/ID-1/publish")
+    @publish_item = stub_request(:post, %r{https://publishing-api.test.gov.uk/v2/content/.*/publish})
       .to_return(status: 200, body: "", headers: {})
 
-    publishing_api_has_expanded_links(
-      content_id: @taxon_1[:content_id],
-      expanded_links: {},
-    )
-
-    publishing_api_has_expanded_links(
-      content_id: @taxon_2[:content_id],
-      expanded_links: {},
-    )
+    [@taxon_1, @taxon_2].each do |taxon|
+      publishing_api_has_expanded_links(
+        content_id: taxon[:content_id],
+        expanded_links: {},
+      )
+    end
 
     stub_request(:get, %r{https://publishing-api.test.gov.uk/v2/linked/*})
       .to_return(status: 200, body: {}.to_json)

--- a/spec/features/taxonomy_editing_spec.rb
+++ b/spec/features/taxonomy_editing_spec.rb
@@ -86,6 +86,13 @@ RSpec.feature "Taxonomy editing" do
     then_a_taxon_is_created
   end
 
+  scenario "User creates a child taxon from a parent" do
+    given_there_are_taxons
+    when_i_visit_the_taxon_page
+    and_i_click_on_the_add_a_child_taxon_button
+    then_the_parent_is_correctly_prefilled
+  end
+
   scenario "User creates a taxon with associated taxons" do
     given_there_are_taxons
     when_i_visit_the_taxonomy_page
@@ -178,6 +185,18 @@ RSpec.feature "Taxonomy editing" do
       .to_return(body: @taxon_3.to_json)
   end
 
+  def when_i_visit_the_taxon_page
+    publishing_api_has_expanded_links(
+      content_id: @taxon_1[:content_id],
+      expanded_links: {},
+    )
+
+    stub_request(:get, %r{https://publishing-api.test.gov.uk/v2/linked/*})
+      .to_return(status: 200, body: {}.to_json)
+
+    visit taxon_path("ID-1")
+  end
+
   def and_i_visit_the_taxon_edit_page
     visit edit_taxon_path("ID-1")
   end
@@ -192,6 +211,10 @@ RSpec.feature "Taxonomy editing" do
 
   def and_i_click_on_the_new_taxon_button
     click_on I18n.t('views.taxons.add_taxon')
+  end
+
+  def and_i_click_on_the_add_a_child_taxon_button
+    click_on I18n.t('views.taxons.add_child')
   end
 
   def and_i_set_taxon_details
@@ -336,6 +359,10 @@ RSpec.feature "Taxonomy editing" do
   def then_my_taxon_is_updated
     expect(@update_item).to have_been_requested
     expect(@create_links).to have_been_requested
+  end
+
+  def then_the_parent_is_correctly_prefilled
+    expect(find("#taxon_parent_content_id").value).to eq("ID-1")
   end
 
   def and_my_taxon_is_automatically_published


### PR DESCRIPTION
This makes it easier to add a child for a specific taxon, without
having to find the parent by hand on the new taxon page.

To make this possible, support using the taxon_params when rendering
the new page, and don't require :taxon to be present, as this would
break the new page if a parent isn't prefilled.

https://trello.com/c/OcwX17Xe/135-add-child-taxon-to-taxon-page

![add-child-taxon](https://user-images.githubusercontent.com/1130010/37144757-eb9d784a-22b6-11e8-96d9-f5e718e27a01.png)