### PR TITLE
Replace the Save&Publish button on 'edit published taxon' with 'save draft' button

### DIFF
--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -75,10 +75,6 @@ class TaxonsController < ApplicationController
     if taxon.valid?
       Taxonomy::UpdateTaxon.call(taxon: taxon, version_note: params[:internal_change_note])
 
-      if params[:publish_taxon_on_save] == "true"
-        Services.publishing_api.publish(taxon.content_id)
-      end
-
       redirect_to taxon_path(taxon.content_id)
     else
       error_messages = taxon.errors.full_messages.join('; ')

--- a/app/views/taxons/edit.html.erb
+++ b/app/views/taxons/edit.html.erb
@@ -6,10 +6,5 @@
 
   <%= render 'form_fields', f: f, page: page %>
 
-  <% if page.published? %>
-    <input type="hidden" name="publish_taxon_on_save" value="true" />
-    <%= f.submit "Save & publish", class: "btn btn-lg btn-success submit-button" %>
-  <% else %>
-    <%= f.submit "Save draft", class: "btn btn-lg btn-success submit-button" %>
-  <% end %>
+  <%= f.submit "Save draft", class: "btn btn-lg btn-success submit-button" %>
 <% end %>

--- a/app/workers/update_taxon_worker.rb
+++ b/app/workers/update_taxon_worker.rb
@@ -10,9 +10,5 @@ class UpdateTaxonWorker
 
     payload = Taxonomy::BuildTaxonPayload.call(taxon: updated_taxon)
     Services.publishing_api.put_content(content_id, payload)
-
-    return unless updated_taxon.published?
-
-    Services.publishing_api.publish(content_id)
   end
 end

--- a/spec/features/bulk_updating_spec.rb
+++ b/spec/features/bulk_updating_spec.rb
@@ -92,7 +92,6 @@ RSpec.feature 'Bulk updating', type: :feature do
     publishing_api_has_item(@parent_taxon)
     publishing_api_has_item(@child_taxon)
     stub_any_publishing_api_put_content
-    stub_any_publishing_api_publish
 
     click_button 'Confirm bulk update'
 
@@ -100,11 +99,6 @@ RSpec.feature 'Bulk updating', type: :feature do
       @parent_content_id,
       request_json_includes(phase: 'beta')
     )
-
-    # When updating a published taxon, a new draft edition is created. We need
-    # to publish this newly created draft edition so that the updates are
-    # reflected in the published state.
-    assert_publishing_api_publish(@parent_content_id)
 
     assert_publishing_api_put_content(
       @child_content_id,

--- a/spec/features/taxon_history_spec.rb
+++ b/spec/features/taxon_history_spec.rb
@@ -52,7 +52,7 @@ RSpec.feature 'Taxon history' do
     stub_request(:get, "https://publishing-api.test.gov.uk/v2/expanded-links/#{@taxon['content_id']}")
       .to_return(body: { content_id: @taxon['content_id'], expanded_links: {} }.to_json)
 
-    click_on 'Save & publish'
+    click_on 'Save Draft'
   end
 
   def and_i_click_view_version_history

--- a/spec/features/taxon_history_spec.rb
+++ b/spec/features/taxon_history_spec.rb
@@ -52,7 +52,7 @@ RSpec.feature 'Taxon history' do
     stub_request(:get, "https://publishing-api.test.gov.uk/v2/expanded-links/#{@taxon['content_id']}")
       .to_return(body: { content_id: @taxon['content_id'], expanded_links: {} }.to_json)
 
-    click_on 'Save Draft'
+    click_on 'Save draft'
   end
 
   def and_i_click_view_version_history

--- a/spec/features/taxonomy_editing_spec.rb
+++ b/spec/features/taxonomy_editing_spec.rb
@@ -134,7 +134,7 @@ RSpec.feature "Taxonomy editing" do
     and_i_click_on_the_edit_taxon_button
     when_i_update_the_taxon
     then_my_taxon_is_updated
-    and_my_taxon_is_automatically_published
+    and_my_taxon_is_not_published
   end
 
   scenario "User edits a draft taxon" do
@@ -362,10 +362,6 @@ RSpec.feature "Taxonomy editing" do
 
   def then_the_parent_is_correctly_prefilled
     expect(find("#taxon_parent_content_id").value).to eq("ID-1")
-  end
-
-  def and_my_taxon_is_automatically_published
-    expect(@publish_item).to have_been_requested
   end
 
   def and_my_taxon_is_not_published


### PR DESCRIPTION
Related e2e PR: https://github.com/alphagov/publishing-e2e-tests/pull/223

Replace the Save&Publish button on the edit published taxon with a 'Save Draft' button that creates a new draft taxon which can optionally be published in the show taxon screen.

Bulk updating of taxons now also saves them as new draft editions, so they should be bulk-published manually after.

![image](https://user-images.githubusercontent.com/6050162/37154689-b13bdcba-22d8-11e8-831e-2e50fadb8176.png)

Trello: https://trello.com/c/OLoVUuaI/180-introduce-separate-save-and-publish-buttons-to-content-tagger

