### PR TITLE
Always show the publish tree button

### DIFF
--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -137,13 +137,11 @@
           </p>
         <% end %>
 
-        <% if page.draft? %>
-          <p>
-            <%= link_to "Publish tree",
-                        taxon_confirm_bulk_publish_path(page.taxon_content_id),
-                        class: 'btn btn-default' %>
-          </p>
-        <% end %>
+        <p>
+          <%= link_to "Publish tree",
+                      taxon_confirm_bulk_publish_path(page.taxon_content_id),
+                      class: 'btn btn-default' %>
+        </p>
       </li>
       <% end %>
     </ul>


### PR DESCRIPTION
Even if the current taxon is published, you might still want to
publish all the decendants, so keep this available in either case.