### PR TITLE
Always show a link to the navigation page

### DIFF
--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -37,19 +37,16 @@
 
 <hr>
 
-<% if user_can_administer_taxonomy? %>
-  <p>
-    <% if page.published? %>
-      <%= link_to "View on GOV.UK", website_url(page.base_path) %>
-    <% elsif page.draft? %>
-      <%= link_to "View on GOV.UK", website_url(page.base_path, draft: true) %>
-    <% end %>
-
-    <% unless page.unpublished? %>
-      (<%= page.base_path %>)
-    <% end %>
-  </p>
-<% end %>
+<p>
+  <% if page.published? %>
+    <%= link_to "View on GOV.UK", website_url(page.base_path) %>
+  <% elsif page.draft? %>
+    <%= link_to "View on GOV.UK", website_url(page.base_path, draft: true) %>
+  <% end %>
+ <% unless page.unpublished? %>
+    (<%= page.base_path %>)
+  <% end %>
+</p>
 
 <% unless page.unpublished? %>
   <p>


### PR DESCRIPTION
Even if you don't have access to change the taxonomy, as this is still
a useful thing to have access to.

![view-on-govuk-link](https://user-images.githubusercontent.com/1130010/37205690-9883a576-238d-11e8-9f04-b5541b88e890.png)