### PR TITLE
Don't prefill the taxon basepath if one is present

### DIFF
--- a/app/assets/javascripts/parent-taxon-prefix-preview.js
+++ b/app/assets/javascripts/parent-taxon-prefix-preview.js
@@ -35,6 +35,10 @@
       }
 
       getParentPathPrefix(function (path_prefix) {
+        if ($taxonBasePathEl.val().length !== 0) {
+          return;
+        }
+
         if (path_prefix) {
           $taxonBasePathEl.val('/'+ path_prefix + '/');
         }


### PR DESCRIPTION
This was an oversight when this was added, as the edit page needs to
deal with editing existing values which will have a value for this
field.