### PR TITLE
Modify confirm delete draft message.

### DIFF
--- a/app/views/taxons/confirm_discard.html.erb
+++ b/app/views/taxons/confirm_discard.html.erb
@@ -3,8 +3,7 @@
 </header>
 
 <div class="lead">
-  You are about to <strong>delete</strong> this topic - this will remove the
-  topic from the system, and cannot be undone.
+  You are about to <strong>delete</strong> the draft version of this topic.
 </div>
 
 <div class="confirmation-box">


### PR DESCRIPTION
The 'Delete draft' message implied it would delete the taxon,
even though it will only delete the draft version. This change
clarifies this.

https://trello.com/c/OLoVUuaI/180-introduce-separate-save-and-publish-buttons-to-content-tagger