### PR TITLE
Add textual representation of hierarchy to Taxon page

### DIFF
--- a/app/services/taxonomy/show_page.rb
+++ b/app/services/taxonomy/show_page.rb
@@ -40,6 +40,10 @@ module Taxonomy
       @children ||= taxonomy_tree.child_expansion.children
     end
 
+    def chevron_hierarchy
+      taxonomy_tree.parent_expansion.map(&:title).reverse.join(" > ")
+    end
+
     def tagged
       @tagged ||= begin
         return [] if taxon.unpublished?

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -166,6 +166,10 @@
 
   <h3>Taxonomy view</h3>
 
+  <p>
+    <%= page.chevron_hierarchy %>
+  </p>
+
   <div class="btn-group taxonomy-visualisation-buttons"
        role="group"
        aria-label="Taxonomy visualisations">


### PR DESCRIPTION
A chevron separated list of the taxon hierarchy that allows users to
easily copy the tree 'path'.

Trello: https://trello.com/c/yX4GkBIg/149-be-able-to-copy-the-full-basepath-of-a-level-3-4-taxon-from-a-view-taxon-page-in-content-tagger