### PR TITLE
Rename 'Root of the Taxonomy' to 'GOV.UK'

### DIFF
--- a/app/models/govuk_taxonomy.rb
+++ b/app/models/govuk_taxonomy.rb
@@ -1,3 +1,4 @@
 module GovukTaxonomy
+  TITLE = 'GOV.UK homepage'.freeze
   ROOT_CONTENT_ID = "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a".freeze
 end

--- a/app/models/linkables.rb
+++ b/app/models/linkables.rb
@@ -13,7 +13,7 @@ class Linkables
   end
 
   def taxons_including_root(exclude_ids: [])
-    [['Root of the taxonomy', GovukTaxonomy::ROOT_CONTENT_ID]] + taxons(exclude_ids: exclude_ids)
+    [[GovukTaxonomy::TITLE, GovukTaxonomy::ROOT_CONTENT_ID]] + taxons(exclude_ids: exclude_ids)
   end
 
   def organisations

--- a/app/models/taxonomy/expanded_taxonomy.rb
+++ b/app/models/taxonomy/expanded_taxonomy.rb
@@ -96,8 +96,8 @@ module Taxonomy
 
     def home_page_linked_content_item
       GovukTaxonomyHelpers::LinkedContentItem.new(
-        internal_name: 'Root of the taxonomy',
-        title: 'Root Taxon',
+        internal_name: GovukTaxonomy::TITLE,
+        title: GovukTaxonomy::TITLE,
         base_path: '/',
         content_id: GovukTaxonomy::ROOT_CONTENT_ID
       )

--- a/spec/features/viewing_taxons_spec.rb
+++ b/spec/features/viewing_taxons_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe "Viewing taxons" do
   def then_i_see_the_entire_taxonomy
     expected_titles = [
       fruits["title"],
-      'Root of the taxonomy',
+      'GOV.UK homepage',
       apples["title"],
       cox["title"],
     ]

--- a/spec/models/taxonomy/expanded_taxonomy_spec.rb
+++ b/spec/models/taxonomy/expanded_taxonomy_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe Taxonomy::ExpandedTaxonomy do
       expect(@taxonomy.child_expansion.children.first.children.map(&:internal_name)).to match_array(%w[i-Bramley i-Cox])
     end
     it 'has the correct name for the home page taxon' do
-      expect(@taxonomy.root_node.internal_name).to eq('Root of the taxonomy')
+      expect(@taxonomy.root_node.internal_name).to eq('GOV.UK homepage')
     end
   end
 
@@ -151,7 +151,7 @@ RSpec.describe Taxonomy::ExpandedTaxonomy do
         'i-Apples',
         'i-Fruits',
         'i-Food',
-        'Root of the taxonomy'
+        'GOV.UK homepage'
       ]
       expect(taxonomy.parent_expansion.map(&:depth)).to eq [0, 1, 2, 3]
       expect(taxonomy.child_expansion.map(&:internal_name)).to eq %w[
@@ -243,7 +243,7 @@ RSpec.describe Taxonomy::ExpandedTaxonomy do
       it "returns the expansion" do
         taxonomy.build
 
-        expect(taxonomy.parent_expansion.map(&:internal_name)).to eq ['i-Apples', 'i-Fruits', 'i-Food', 'Root of the taxonomy']
+        expect(taxonomy.parent_expansion.map(&:internal_name)).to eq ['i-Apples', 'i-Fruits', 'i-Food', 'GOV.UK homepage']
         expect(taxonomy.parent_expansion.map(&:depth)).to eq [0, 1, 2, 3]
       end
     end

--- a/spec/services/linkables_spec.rb
+++ b/spec/services/linkables_spec.rb
@@ -49,12 +49,12 @@ RSpec.describe Linkables do
     describe '.taxons_including_root' do
       it 'returns an array of hashes with only valid taxons including root' do
         expect(linkables.taxons_including_root).to eq(
-          [['Root of the taxonomy', GovukTaxonomy::ROOT_CONTENT_ID], %w[Valid-1! valid-1], %w[Valid-2! valid-2]]
+          [['GOV.UK homepage', GovukTaxonomy::ROOT_CONTENT_ID], %w[Valid-1! valid-1], %w[Valid-2! valid-2]]
         )
       end
       it 'filters out excluded IDs' do
         expect(linkables.taxons_including_root(exclude_ids: 'valid-2')).to eq(
-          [['Root of the taxonomy', GovukTaxonomy::ROOT_CONTENT_ID], %w[Valid-1! valid-1]]
+          [['GOV.UK homepage', GovukTaxonomy::ROOT_CONTENT_ID], %w[Valid-1! valid-1]]
         )
       end
     end


### PR DESCRIPTION
Trello: https://trello.com/c/yX4GkBIg/149-be-able-to-copy-the-full-basepath-of-a-level-3-4-taxon-from-a-view-taxon-page-in-content-tagger#comment-5aabb9138c3b7f0146e5e747