### PR TITLE
Remove sortable handler from path fields

### DIFF
--- a/app/assets/javascripts/path-lookup-select.js
+++ b/app/assets/javascripts/path-lookup-select.js
@@ -12,10 +12,7 @@
       var $inputFields = moduleEl.find("input");
       $inputFields.prop('readonly', true);
       $inputFields.wrap('<div class="input-group"></div>');
-      $inputFields.before('<span class="input-group-addon vertical-drag">&updownarrow;</span>');
       $inputFields.after(buildRemoveRelaltedItemEl());
-
-      $('.js-list-sortable').sortable();
 
       moduleEl.append(buildAddRelatedItemEl())
     }
@@ -62,7 +59,6 @@
     var buildInputGroupEl = function(path) {
       var $listItemEl = $('<li></li>');
       var $inputGroupEl = $('<div class="input-group"></div>');
-      var $dragEl = $('<span class="input-group-addon">↕</span>');
       var $inputEl = $('<input />', {
         type: 'text',
         name: formFieldName,
@@ -72,7 +68,6 @@
       });
 
       $listItemEl.append($inputGroupEl);
-      $inputGroupEl.append($dragEl);
       $inputGroupEl.append($inputEl);
       $inputGroupEl.append(buildRemoveRelaltedItemEl());
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -78,10 +78,6 @@ $red: #b10e1e;
   color: $state-danger-text;
 }
 
-.vertical-drag {
-  cursor: ns-resize;
-}
-
 // taxons page
 
 .nav.nav-tabs {


### PR DESCRIPTION
Currently, only the legacy taxon field is using this path lookup field,
but the sortable component is redundant as the order of these paths are
not important.

Originally the field was introduced and planned to be used for the
related content items, where the order is important. However, this field
is currently not used for that input interface.

Trello: https://trello.com/c/E4Fv5sFr/187-add-a-field-to-manually-capture-legacy-new-link#comment-5aabc774099ef552464a8f5a