### PR TITLE
Show all L1 taxons when creating a project

### DIFF
--- a/app/forms/new_project_form.rb
+++ b/app/forms/new_project_form.rb
@@ -12,7 +12,6 @@ class NewProjectForm
 
   def taxonomy_branches_for_select
     GovukTaxonomy::Branches.new.all
-      .select { |branch| branch['status'] == 'draft' }
       .reduce({}) { |memo, branch| memo.merge(branch['title'] => branch['content_id']) }
   end
 

--- a/app/models/govuk_taxonomy/branches.rb
+++ b/app/models/govuk_taxonomy/branches.rb
@@ -5,16 +5,8 @@ module GovukTaxonomy
     end
 
     def all
-      published.map { |taxon| transform(taxon, 'published') } +
-        draft.map { |taxon| transform(taxon, 'draft') }
-    end
-
-    def published
-      @_published_branches ||= ::Taxonomy::LevelOneTaxonsRetrieval.new.get(with_drafts: false)
-    end
-
-    def draft
-      @_draft_branches ||= ::Taxonomy::LevelOneTaxonsRetrieval.new.get(with_drafts: true) - published
+      Taxonomy::LevelOneTaxonsRetrieval.new.get(with_drafts: true)
+        .map { |taxon| taxon.slice("content_id", "title", "base_path") }
     end
 
     def taxons_for_branch(content_id)
@@ -24,10 +16,6 @@ module GovukTaxonomy
     end
 
   private
-
-    def transform(taxon, status)
-      taxon.slice("content_id", "title", "base_path").merge("status" => status)
-    end
 
     def get_expanded_links_hash(content_id, with_drafts:)
       Services.publishing_api

--- a/spec/forms/new_project_form_spec.rb
+++ b/spec/forms/new_project_form_spec.rb
@@ -77,14 +77,8 @@ RSpec.describe NewProjectForm, '#taxonomy_branches_for_select' do
       .and_return(
         [
           {
-            'status' => 'published',
-            'title' => 'Published Title',
-            'content_id' => 'published_id'
-          },
-          {
-            'status' => 'draft',
-            'title' => 'Draft Title',
-            'content_id' => 'draft_id'
+            'title' => 'Title',
+            'content_id' => 'content_id'
           }
         ]
       )
@@ -92,11 +86,6 @@ RSpec.describe NewProjectForm, '#taxonomy_branches_for_select' do
 
   it 'returns a hash of title => id' do
     result = NewProjectForm.new.taxonomy_branches_for_select
-    expect(result['Draft Title']).to eq 'draft_id'
-  end
-
-  it 'only returns draft root taxons' do
-    result = NewProjectForm.new.taxonomy_branches_for_select
-    expect(result.size).to eq 1
+    expect(result['Title']).to eq 'content_id'
   end
 end


### PR DESCRIPTION
The new project form previously limited the taxon selector to L1
draft taxons, which is no longer appropriate as we've published
the taxonony.