### PR TITLE
Tag content from a remote CSV file

### DIFF
--- a/app/services/tagging/csv_tagger.rb
+++ b/app/services/tagging/csv_tagger.rb
@@ -1,0 +1,13 @@
+module Tagging
+  class CsvTagger
+    def self.do_tagging(url)
+      taggings = RemoteCsv.new(url).rows_with_headers
+      grouped_tags = taggings.group_by { |tagging| tagging['content_id'] }
+      grouped_tags.each do |content_id, grouped_taggings|
+        taxon_ids = grouped_taggings.map { |t| t['taxon_id'] }
+        yield(content_id: content_id, taxon_ids: taxon_ids) if block_given?
+        Tagging::Tagger.add_tags(content_id, grouped_taggings.map { |t| t['taxon_id'] })
+      end
+    end
+  end
+end

--- a/app/services/tagging/tagger.rb
+++ b/app/services/tagging/tagger.rb
@@ -1,0 +1,14 @@
+module Tagging
+  class Tagger
+    def self.add_tags(content_id, taxon_ids)
+      link_content = Services.publishing_api.get_links(content_id)
+      version = link_content['version']
+      taxons = (link_content.dig('links', 'taxons') || []) + taxon_ids
+      Services.publishing_api.patch_links(content_id, links: { taxons: taxons.uniq }, previous_version: version, bulk_publishing: true)
+    rescue GdsApi::HTTPConflict, GdsApi::HTTPGatewayTimeout
+      retries ||= 0
+      retry if (retries += 1) < 3
+      raise
+    end
+  end
+end

--- a/lib/tasks/tag_from_csv.rake
+++ b/lib/tasks/tag_from_csv.rake
@@ -1,0 +1,6 @@
+desc "Perform taggings from a csv file"
+task :tag_from_csv, [:csv_url] => :environment do |_, args|
+  Tagging::CsvTagger.do_tagging(args[:csv_url]) do |tagging|
+    puts "Tagging #{tagging[:content_id]} to [#{tagging[:taxon_ids].join(',')}]"
+  end
+end

--- a/spec/services/tagging/csv_tagger_spec.rb
+++ b/spec/services/tagging/csv_tagger_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe Tagging::Tagger do
+  subject { described_class }
+  before :each do
+    stub_request(:get, 'http://example.com/sheet.csv').to_return(body: <<~CSV)
+      content_id,taxon_id
+      aaa,1
+      bbb,2
+      aaa,3
+    CSV
+  end
+  it 'adds tags from the spreadsheet' do
+    expect(Tagging::Tagger).to receive(:add_tags).with('aaa', %w[1 3])
+    expect(Tagging::Tagger).to receive(:add_tags).with('bbb', ['2'])
+
+    Tagging::CsvTagger.do_tagging('http://example.com/sheet.csv')
+  end
+  it 'returns groups in a block' do
+    allow(Tagging::Tagger).to receive(:add_tags)
+    log = []
+    Tagging::CsvTagger.do_tagging('http://example.com/sheet.csv') do |b|
+      log << b
+    end
+    expect(log).to match_array([{ content_id: 'aaa', taxon_ids: %w[1 3] },
+                                { content_id: 'bbb', taxon_ids: ['2'] }])
+  end
+end

--- a/spec/services/tagging/tagger_spec.rb
+++ b/spec/services/tagging/tagger_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe Tagging::Tagger do
+  subject { described_class }
+
+  before :each do
+    @content_id = '64aadc14-9bca-40d9-abb4-4f21f9792a05'
+  end
+
+  describe '#tag' do
+    it 'tags content to a taxon' do
+      publishing_api_has_links(content_id: @content_id, links: { taxons: %w[aaa bbb] }, version: 5)
+      stub_any_publishing_api_patch_links
+      subject.add_tags(@content_id, %w[ccc ddd])
+      assert_publishing_api_patch_links(@content_id, links: { taxons: %w[aaa bbb ccc ddd] }, previous_version: 5, bulk_publishing: true)
+    end
+
+    it 'retries 3 times' do
+      publishing_api_has_links(content_id: @content_id, links: { taxons: %w[aaa bbb] }, version: 5)
+
+      stub_any_publishing_api_patch_links.and_raise(GdsApi::HTTPConflict).times(2).then.to_return(body: '{}')
+      expect { subject.add_tags(@content_id, ['ccc']) }.to_not raise_error
+
+      stub_any_publishing_api_patch_links.and_raise(GdsApi::HTTPConflict).times(3).then.to_return(body: '{}')
+      expect { subject.add_tags(@content_id, ['ccc']) }.to raise_error(GdsApi::HTTPConflict)
+    end
+  end
+end


### PR DESCRIPTION
Tags content from a remote CSV file, i.e. google sheets.

To access a remote CSV file, go to google sheets and select file->publish to web and copy the link

The rake task is: `rake tag_from_csv[remote_url]`

The task expects the CSV file to have headers and contain the fields 'content_id' and 'taxon_id'

Trello: https://trello.com/c/R3XBQbdz/200-tag-untagged-data