### PR TITLE
tagged_to_ancestor rake task can now find GdsApi::Base

### DIFF
--- a/lib/tasks/content_tagged_to_ancestors.rake
+++ b/lib/tasks/content_tagged_to_ancestors.rake
@@ -1,3 +1,4 @@
+require 'gds_api/base'
 namespace :content do
   desc "Find all content that is tagged to a taxon and its direct ancestor and optionally removes redundant tagging (option: untag='untag')"
   task :tagged_to_ancestor, [:untag] => :environment do |_, args|


### PR DESCRIPTION
The tagged_to_ancestor rake task could not find the GdsApi::Base
class, so we explicitly require it.