### PR TITLE
Add rake task to untag all content from a taxon

### DIFF
--- a/lib/tasks/taxonomy/untag.rake
+++ b/lib/tasks/taxonomy/untag.rake
@@ -1,0 +1,20 @@
+require 'gds_api/base'
+namespace :taxonomy do
+  desc "Untag all content tagged to a given taxon. (options: content_id of the taxon, 'untag' to untag)"
+  task :untag, %i[content_id untag] => :environment do |_, args|
+    taxon_content_id = args[:content_id]
+    if taxon_content_id.nil?
+      puts "Please supply the content id of the taxon to untag."
+      return
+    end
+
+    GdsApi::Base.default_options = { timeout: 30 }
+
+    content_list = Services.publishing_api.get_linked_items(args[:content_id], link_type: 'taxons', fields: %w[content_id title]).to_a
+    unique_content_list = content_list.uniq { |c| c['content_id'] }
+    unique_content_list.each do |content|
+      puts "Title #{content['title']}, content_id: #{content['content_id']}"
+      Tagging::Untagger.call(content['content_id'], [taxon_content_id]) if args[:untag] == "untag"
+    end
+  end
+end


### PR DESCRIPTION
Example: bundle exec rake taxonomy:untag[91b8ef20-74e7-4552-880c-50e6d73c2ff9,untag]
to untag all content items from the world/all taxon

Zendesk: https://govuk.zendesk.com/agent/tickets/2699989