### PR TITLE
Use version number in untagger

### DIFF
--- a/app/services/tagging/untagger.rb
+++ b/app/services/tagging/untagger.rb
@@ -5,8 +5,17 @@ module Tagging
     end
 
     def untag(content_id, taxon_content_ids)
-      existing_taxons_ids = Services.publishing_api.get_links(content_id).dig('links', 'taxons')
-      Services.publishing_api.patch_links(content_id, links: { taxons: (existing_taxons_ids - taxon_content_ids) })
+      response = Services.publishing_api.get_links(content_id)
+      existing_taxons_ids = response.dig('links', 'taxons')
+      version = response['version']
+
+      Services.publishing_api.patch_links(content_id,
+                                          previous_version: version,
+                                          links: { taxons: (existing_taxons_ids - taxon_content_ids) })
+    rescue GdsApi::HTTPConflict, GdsApi::HTTPGatewayTimeout, GdsApi::TimedOutException
+      retries ||= 0
+      retry if (retries += 1) < 3
+      raise
     end
   end
 end

--- a/spec/services/tagging/untagger_spec.rb
+++ b/spec/services/tagging/untagger_spec.rb
@@ -3,17 +3,29 @@ require 'gds_api/test_helpers/publishing_api_v2'
 include ::GdsApi::TestHelpers::PublishingApiV2
 
 RSpec.describe Tagging::Untagger do
+  before :each do
+    @content_id = "51ac4247-fd92-470a-a207-6b852a97f2db"
+  end
   it 'untags a taxon' do
-    content_id = "51ac4247-fd92-470a-a207-6b852a97f2db"
     publishing_api_has_links(
-      "content_id" => content_id,
+      "content_id" => @content_id,
+      "version" => 5,
       "links" => {
         "taxons" => ['aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb']
       },
     )
 
     stub_any_publishing_api_patch_links
-    Tagging::Untagger.call(content_id, ['aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'])
-    assert_publishing_api_patch_links(content_id, 'links' => { 'taxons' => ['bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'] })
+    Tagging::Untagger.call(@content_id, ['aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'])
+    assert_publishing_api_patch_links(@content_id, 'previous_version' => 5, 'links' => { 'taxons' => ['bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'] })
+  end
+  it 'retries 3 times' do
+    publishing_api_has_links(content_id: @content_id, links: { taxons: %w[aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa] }, version: 5)
+
+    stub_any_publishing_api_patch_links.and_raise(GdsApi::HTTPConflict).times(2).then.to_return(body: '{}')
+    expect { Tagging::Untagger.call(@content_id, ['aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa']) }.to_not raise_error
+
+    stub_any_publishing_api_patch_links.and_raise(GdsApi::HTTPConflict).times(3).then.to_return(body: '{}')
+    expect { Tagging::Untagger.call(@content_id, ['aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa']) }.to raise_error(GdsApi::HTTPConflict)
   end
 end


### PR DESCRIPTION
Makes the untagger service more robust by including the version number