### PR TITLE
Include &debug=include_withdrawn when searching rummager

### DIFF
--- a/app/services/taxonomy/taxons_with_content_count.rb
+++ b/app/services/taxonomy/taxons_with_content_count.rb
@@ -51,6 +51,7 @@ module Taxonomy
           filter_part_of_taxonomy_tree: @root_taxon.content_id,
           facet_taxons: 1_000, # We have to specify a number,
           count: 0,
+          debug: 'include_withdrawn',
         )
 
         # Rummager will return a pretty odd datastructure for this query:

--- a/spec/services/taxonomy/taxons_with_content_count_spec.rb
+++ b/spec/services/taxonomy/taxons_with_content_count_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Taxonomy::TaxonsWithContentCount do
   describe '#nested_tree' do
     it 'returns a nested tree structure' do
-      stub_request(:get, 'https://rummager.test.gov.uk/search.json?count=0&facet_taxons=1000&filter_part_of_taxonomy_tree=b92079ac-f1d9-44c8-bc78-772d54377ee2')
+      stub_request(:get, 'https://rummager.test.gov.uk/search.json?count=0&debug=include_withdrawn&facet_taxons=1000&filter_part_of_taxonomy_tree=b92079ac-f1d9-44c8-bc78-772d54377ee2')
         .to_return(body: SEARCH_RESULT_FIXTURE.to_json)
 
       stub_request(:get, 'https://publishing-api.test.gov.uk/v2/expanded-links/b92079ac-f1d9-44c8-bc78-772d54377ee2')


### PR DESCRIPTION
We are showing incorrect document counts against each taxon in the list view.

This is partly because when we query rummager, we are not including withdrawn content.

This commit is to fix that. It is related to the Trello card [Investigate differences in the number of tagged content items between the list and visualisations in Content Tagger](https://trello.com/c/Mqz848UG/20-investigate-differences-in-the-number-of-tagged-content-items-between-the-list-and-visualisations-in-content-tagger)