### PR TITLE
Allow managing editors to move content

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,15 +26,21 @@ private
     :website_url,
     :similar_search_results_url,
     :user_can_administer_taxonomy?,
+    :user_can_manage_taxonomy?,
     :user_can_access_tagathon_tools?
   )
 
   delegate :user_can_administer_taxonomy?,
+           :user_can_manage_taxonomy?,
            :user_can_access_tagathon_tools?,
            to: :permission_checker
 
   def ensure_user_can_administer_taxonomy!
     deny_access_to(:feature) unless user_can_administer_taxonomy?
+  end
+
+  def ensure_user_can_manage_taxonomy!
+    deny_access_to(:feature) unless user_can_manage_taxonomy?
   end
 
   def ensure_user_can_access_tagathon_tools!

--- a/app/controllers/tag_migrations_controller.rb
+++ b/app/controllers/tag_migrations_controller.rb
@@ -1,5 +1,5 @@
 class TagMigrationsController < ApplicationController
-  before_action :ensure_user_can_administer_taxonomy!
+  before_action :ensure_user_can_manage_taxonomy!
 
   def index
     render :index, locals: { tag_migrations: presented_tag_migrations }

--- a/app/controllers/taxon_migrations_controller.rb
+++ b/app/controllers/taxon_migrations_controller.rb
@@ -1,5 +1,5 @@
 class TaxonMigrationsController < ApplicationController
-  before_action :ensure_user_can_administer_taxonomy!
+  before_action :ensure_user_can_manage_taxonomy!
 
   def new
     unless params[:source_content_id]

--- a/app/lib/permission_checker.rb
+++ b/app/lib/permission_checker.rb
@@ -1,6 +1,7 @@
 class PermissionChecker
   GDS_EDITOR_PERMISSION = "GDS Editor".freeze
   TAGATHON_PARTICIPANT_PERMISSION = "Tagathon participant".freeze
+  MANAGING_EDITOR_PERMISSION = "Managing Editor".freeze
 
   def initialize(user)
     @user = user
@@ -10,8 +11,12 @@ class PermissionChecker
     gds_editor?
   end
 
+  def user_can_manage_taxonomy?
+    gds_editor? || managing_editor?
+  end
+
   def user_can_access_tagathon_tools?
-    gds_editor? || tagathon_participant?
+    gds_editor? || managing_editor? || tagathon_participant?
   end
 
 private
@@ -20,6 +25,10 @@ private
 
   def gds_editor?
     user.has_permission?(GDS_EDITOR_PERMISSION)
+  end
+
+  def managing_editor?
+    user.has_permission?(MANAGING_EDITOR_PERMISSION)
   end
 
   def tagathon_participant?

--- a/app/views/taxons/tagged_content_page.html.erb
+++ b/app/views/taxons/tagged_content_page.html.erb
@@ -9,7 +9,9 @@
       <i class="glyphicon glyphicon-download-alt"></i>
       Download as CSV
     <% end %>
+  <% end %>
 
+  <% if user_can_manage_taxonomy? %>
     <%= link_to "Move content",
                 new_taxon_migration_path(source_content_id: page.taxon_content_id),
                 class: 'btn btn-md btn-default' %>

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -8,6 +8,10 @@ FactoryBot.define do
       permissions { ["signin", "GDS Editor"] }
     end
 
+    trait :managing_editor do
+      permissions { ["signin", "Managing Editor"] }
+    end
+
     trait :tagathon_participant do
       permissions { ["signin", "Tagathon participant"] }
     end

--- a/spec/features/navigation_spec.rb
+++ b/spec/features/navigation_spec.rb
@@ -16,6 +16,12 @@ RSpec.feature "Navigation", type: :feature do
     then_i_can_only_see_the_tagathon_options_in_the_nav_bar
   end
 
+  scenario "Managing Editors can access Projects and Analytics only" do
+    given_i_am_logged_in_as_a_managing_editor
+    when_i_visit_the_application
+    then_i_can_only_see_the_tagathon_options_in_the_nav_bar
+  end
+
   scenario "GDS Editors can access all areas" do
     given_i_am_logged_in_as_a_gds_editor
     when_i_visit_the_application
@@ -28,6 +34,10 @@ RSpec.feature "Navigation", type: :feature do
 
   def given_i_am_logged_in_as_a_tagathon_participant
     login_as create(:user, :tagathon_participant)
+  end
+
+  def given_i_am_logged_in_as_a_managing_editor
+    login_as create(:user, :managing_editor)
   end
 
   def given_i_am_logged_in_as_a_gds_editor

--- a/spec/lib/permission_checker_spec.rb
+++ b/spec/lib/permission_checker_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe PermissionChecker do
 
   context "when the current_user has no special permissions" do
     it { is_expected.not_to have_permission(:user_can_administer_taxonomy?) }
+    it { is_expected.not_to have_permission(:user_can_manage_taxonomy?) }
     it { is_expected.not_to have_permission(:user_can_access_tagathon_tools?) }
   end
 
@@ -18,6 +19,19 @@ RSpec.describe PermissionChecker do
     end
 
     it { is_expected.to have_permission(:user_can_administer_taxonomy?) }
+    it { is_expected.to have_permission(:user_can_manage_taxonomy?) }
+    it { is_expected.to have_permission(:user_can_access_tagathon_tools?) }
+  end
+
+  context "when the user has the Managing Editor permission" do
+    before do
+      allow(user)
+        .to receive(:has_permission?)
+        .with("Managing Editor")
+        .and_return(true)
+    end
+    it { is_expected.not_to have_permission(:user_can_administer_taxonomy?) }
+    it { is_expected.to have_permission(:user_can_manage_taxonomy?) }
     it { is_expected.to have_permission(:user_can_access_tagathon_tools?) }
   end
 
@@ -30,6 +44,7 @@ RSpec.describe PermissionChecker do
     end
 
     it { is_expected.not_to have_permission(:user_can_administer_taxonomy?) }
+    it { is_expected.not_to have_permission(:user_can_manage_taxonomy?) }
     it { is_expected.to have_permission(:user_can_access_tagathon_tools?) }
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/cgju6KXI

## What's changed

Create a new permission, "Managing Editor" that gives users access to the "Move Content" functionality so they can bulk move content from one taxon to another.

The rest of the functionality and the default view (Projects) is the same as for the "Tagathon participant" permission.