### PR TITLE
Make the taxons_path the homepage for most users

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,8 +10,8 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
   def redirect_to_home_page
-    if user_can_administer_taxonomy?
-      redirect_to lookup_taggings_path
+    if user_can_manage_taxonomy?
+      redirect_to taxons_path
     elsif user_can_access_tagathon_tools?
       redirect_to projects_path
     else

--- a/spec/controllers/root_path_request_spec.rb
+++ b/spec/controllers/root_path_request_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Root Path", type: :request do
     it "redirects to 'Edit a page'" do
       login_as create(:user, :gds_editor)
       get root_path
-      expect(response).to redirect_to lookup_taggings_path
+      expect(response).to redirect_to taxons_path
     end
   end
 

--- a/spec/features/project_spec.rb
+++ b/spec/features/project_spec.rb
@@ -223,6 +223,8 @@ RSpec.feature "Projects", type: :feature do
   end
 
   def when_i_visit_the_project_page
+    publishing_api_has_taxons([])
+
     visit root_path
     within 'header nav .nav' do
       click_link 'Projects'

--- a/spec/features/tag_a_page_spec.rb
+++ b/spec/features/tag_a_page_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Tagging content", type: :feature do
       topics: [example_topic]
     )
 
-    when_i_visit_the_homepage
+    when_i_visit_edit_a_page
     and_i_submit_the_url_of_the_content_item
     then_i_am_on_the_page_for_an_item
     and_the_expected_navigation_link_is_highlighted
@@ -62,7 +62,7 @@ RSpec.describe "Tagging content", type: :feature do
   end
 
   scenario "User inputs a URL that is not on GOV.UK" do
-    when_i_visit_the_homepage
+    when_i_visit_edit_a_page
     and_i_fill_a_unknown_base_path_to_my_content_item
     then_i_see_that_the_path_was_not_found
   end
@@ -125,8 +125,8 @@ RSpec.describe "Tagging content", type: :feature do
     end
   end
 
-  def when_i_visit_the_homepage
-    visit root_path
+  def when_i_visit_edit_a_page
+    visit lookup_taggings_path
   end
 
   def when_i_type_its_basepath_in_the_url_directly

--- a/spec/features/tag_importer_spec.rb
+++ b/spec/features/tag_importer_spec.rb
@@ -93,6 +93,8 @@ RSpec.feature "Tag importer", type: :feature do
   end
 
   def when_i_provide_the_public_uri_of_this_spreadsheet
+    publishing_api_has_taxons([])
+
     visit root_path
     click_link I18n.t('navigation.bulk_tag')
 

--- a/spec/features/tagging_during_migration_spec.rb
+++ b/spec/features/tagging_during_migration_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Tagging content during migration", type: :feature do
   scenario "User makes a change to a content item which has had some of its link types disabled" do
     given_there_is_an_item_that_can_have_only_one_link_type
 
-    when_i_visit_the_homepage
+    when_i_visit_edit_a_page
     and_i_submit_the_url_of_the_content_item
 
     when_i_add_an_additional_tag
@@ -59,8 +59,8 @@ RSpec.describe "Tagging content during migration", type: :feature do
       }.to_json)
   end
 
-  def when_i_visit_the_homepage
-    visit root_path
+  def when_i_visit_edit_a_page
+    visit lookup_taggings_path
   end
 
   def and_i_submit_the_url_of_the_content_item


### PR DESCRIPTION
Except those users who only have access to the tagathon tools. This
matches a change in the default function of Content Tagger from
tagging content to managing the Topic Taxonomy.