### PR TITLE
Add metrics to measure taxonomy health

### DIFF
--- a/app/services/taxonomy/content_counter.rb
+++ b/app/services/taxonomy/content_counter.rb
@@ -1,0 +1,11 @@
+module Taxonomy
+  class ContentCounter
+    def self.count(taxon_content_id)
+      Services.rummager.search(
+        filter_taxons: taxon_content_id,
+        count: 0,
+        reject_content_store_document_type: Tagging.blacklisted_document_types
+      ).to_h.fetch('total', 0)
+    end
+  end
+end

--- a/app/workers/taxonomy_health/child_taxon_count_metric.rb
+++ b/app/workers/taxonomy_health/child_taxon_count_metric.rb
@@ -1,0 +1,34 @@
+module TaxonomyHealth
+  class ChildTaxonCountMetric
+    include Sidekiq::Worker
+    include ActionView::Helpers::TextHelper
+
+    def perform(arguments)
+      maximum = arguments.symbolize_keys[:maximum]
+      minimum = arguments.symbolize_keys[:minimum] || 0
+      taxonomy = Taxonomy::ExpandedTaxonomy.new(GovukTaxonomy::ROOT_CONTENT_ID).build.child_expansion
+      taxon_counts = taxonomy.tree.map do |linked_content_item|
+        { linked_content_item: linked_content_item, count: linked_content_item.children.count }
+      end
+      taxon_counts.select { |item| item[:count] > maximum }.each do |item|
+        message = "Taxon has #{pluralize(item[:count], 'child')}, which exceeds the maximum of #{maximum}"
+        create_health_warning(item[:linked_content_item], message)
+      end
+      taxon_counts.select { |item| item[:count].positive? && item[:count] < minimum }.each do |item|
+        message = "Taxon has #{pluralize(item[:count], 'child')}, which is fewer than the minimum of #{minimum}"
+        create_health_warning(item[:linked_content_item], message)
+      end
+    end
+
+  private
+
+    def create_health_warning(linked_content_item, message)
+      Taxonomy::HealthWarning.create(content_id: linked_content_item.content_id,
+                                     title: linked_content_item.title,
+                                     internal_name: linked_content_item.internal_name,
+                                     path: linked_content_item.base_path,
+                                     metric: self.class.to_s,
+                                     message: message)
+    end
+  end
+end

--- a/app/workers/taxonomy_health/content_count_metric.rb
+++ b/app/workers/taxonomy_health/content_count_metric.rb
@@ -1,0 +1,22 @@
+module TaxonomyHealth
+  class ContentCountMetric
+    include Sidekiq::Worker
+
+    def perform(arguments)
+      maximum = arguments.symbolize_keys[:maximum]
+      taxonomy = Taxonomy::ExpandedTaxonomy.new(GovukTaxonomy::ROOT_CONTENT_ID).build.child_expansion
+      taxon_counts = taxonomy.tree.map do |linked_content_item|
+        { linked_content_item: linked_content_item, count: Taxonomy::ContentCounter.count(linked_content_item.content_id) }
+      end
+      taxon_counts.select { |item| item[:count] > maximum }.each do |item|
+        linked_content_item = item[:linked_content_item]
+        Taxonomy::HealthWarning.create(content_id: linked_content_item.content_id,
+                                       title: linked_content_item.title,
+                                       internal_name: linked_content_item.internal_name,
+                                       path: linked_content_item.base_path,
+                                       metric: self.class.to_s,
+                                       message: "Taxon has #{item[:count]} content items, which exceeds the maximum of #{maximum}")
+      end
+    end
+  end
+end

--- a/config/health_checks.yml
+++ b/config/health_checks.yml
@@ -4,6 +4,10 @@ default: &default
       class: MaximumDepthMetric
       arguments:
         maximum_depth: 5
+    - name: Maximum number of content item tagged to a taxon
+      class: ContentCountMetric
+      arguments:
+        maximum: 100
 
 development:
   <<: *default

--- a/config/health_checks.yml
+++ b/config/health_checks.yml
@@ -8,6 +8,11 @@ default: &default
       class: ContentCountMetric
       arguments:
         maximum: 100
+    - name: Maximum number of child taxons
+      class: ChildTaxonCountMetric
+      arguments:
+        maximum: 12
+        minimum: 2
 
 development:
   <<: *default

--- a/lib/tasks/taxonomy/health_checks.rake
+++ b/lib/tasks/taxonomy/health_checks.rake
@@ -1,5 +1,3 @@
-require_relative '../../../app/workers/taxonomy_health/maximum_depth_metric.rb'
-
 namespace :taxonomy do
   desc <<-DESC
     Performs all taxonomy health checks and reports any problems.

--- a/spec/workers/taxonomy_health/child_taxon_count_metric_spec.rb
+++ b/spec/workers/taxonomy_health/child_taxon_count_metric_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe TaxonomyHealth::ChildTaxonCountMetric do
+  let(:home_page) { FactoryBot.build(:taxon_hash, :home_page, expanded_links: { level_one_taxons: [food] }) }
+  let(:food) do
+    FactoryBot.build(:taxon_hash,
+                     title: 'Food',
+                     expanded_links: {
+                       child_taxons: [fruits, vegetables, meats],
+                       root_taxon: [GovukTaxonomy::ROOT_CONTENT_ID]
+                     })
+  end
+  let(:fruits) { FactoryBot.build(:taxon_hash, title: 'Fruits') }
+  let(:vegetables) { FactoryBot.build(:taxon_hash, title: 'Vegetables') }
+  let(:meats) { FactoryBot.build(:taxon_hash, title: 'Meats') }
+
+  before :each do
+    publishing_api_has_item(home_page)
+    publishing_api_has_item(food)
+    publishing_api_has_item(fruits)
+    publishing_api_has_item(vegetables)
+    publishing_api_has_item(meats)
+
+    publishing_api_has_expanded_links(home_page)
+    publishing_api_has_expanded_links(food)
+  end
+
+  it 'records no failing taxons' do
+    expect { TaxonomyHealth::ChildTaxonCountMetric.new.perform(maximum: 3, minimum: 1) }.to_not(change { Taxonomy::HealthWarning.count })
+  end
+
+  it 'records a failing taxon with too many children' do
+    expect { TaxonomyHealth::ChildTaxonCountMetric.new.perform(maximum: 2) }.to(change { Taxonomy::HealthWarning.count }.by(1))
+    expect(Taxonomy::HealthWarning.last.content_id).to eq(food['content_id'])
+  end
+
+  it 'records a failing taxon with too few children - excluding leaf nodes' do
+    expect { TaxonomyHealth::ChildTaxonCountMetric.new.perform(maximum: 3, minimum: 2) }.to(change { Taxonomy::HealthWarning.count }.by(1))
+    expect(Taxonomy::HealthWarning.last.content_id).to eq(home_page['content_id'])
+  end
+end

--- a/spec/workers/taxonomy_health/content_count_metric_spec.rb
+++ b/spec/workers/taxonomy_health/content_count_metric_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+require 'gds_api/test_helpers/rummager'
+
+RSpec.describe TaxonomyHealth::ContentCountMetric do
+  include GdsApi::TestHelpers::Rummager
+  let(:home_page) { FactoryBot.build(:taxon_hash, :home_page, expanded_links: { level_one_taxons: [food] }) }
+  let(:food) do
+    FactoryBot.build(:taxon_hash,
+                     title: 'Food',
+                     expanded_links: {
+                       root_taxon: [GovukTaxonomy::ROOT_CONTENT_ID]
+                     })
+  end
+  let(:fruits) { FactoryBot.build(:taxon_hash, title: 'Fruits') }
+
+  before :each do
+    publishing_api_has_item(home_page)
+    publishing_api_has_item(food)
+    publishing_api_has_expanded_links(home_page)
+    publishing_api_has_expanded_links(food)
+  end
+
+  it 'records no failing taxons' do
+    allow(Taxonomy::ContentCounter).to receive(:count).with(home_page['content_id']).and_return(0)
+    allow(Taxonomy::ContentCounter).to receive(:count).with(food['content_id']).and_return(1)
+    expect { TaxonomyHealth::ContentCountMetric.new.perform(maximum: 5) }.to_not(change { Taxonomy::HealthWarning.count })
+  end
+
+  it 'records a failing taxon' do
+    allow(Taxonomy::ContentCounter).to receive(:count).with(home_page['content_id']).and_return(0)
+    allow(Taxonomy::ContentCounter).to receive(:count).with(food['content_id']).and_return(10)
+    expect { TaxonomyHealth::ContentCountMetric.new.perform(maximum: 5) }.to(change { Taxonomy::HealthWarning.count }.by(1))
+    expect(Taxonomy::HealthWarning.last.content_id).to eq(food['content_id'])
+  end
+end


### PR DESCRIPTION
Add content count metric - Report taxons with more than a given maximum of content tagged
Add child taxons count metric - Report taxons with fewer than a given minimum of child taxons or taxons with more than a given maximum of child taxons. Leaf taxons without child taxons are never reported.

Trello: https://trello.com/c/yKOh8nuc/58-add-a-reporting-feature-to-content-tagger-to-find-areas-where-the-taxonomy-can-be-improved
