### PR TITLE
Display the number of email subscribers for a taxon

### DIFF
--- a/app/lib/services.rb
+++ b/app/lib/services.rb
@@ -1,6 +1,7 @@
 require 'gds_api/publishing_api_v2'
 require 'gds_api/rummager'
 require 'gds_api/content_store'
+require 'gds_api/email_alert_api'
 
 module Services
   def self.publishing_api
@@ -26,6 +27,13 @@ module Services
   def self.rummager
     @search ||= GdsApi::Rummager.new(
       Plek.new.find('rummager'),
+    )
+  end
+
+  def self.email_alert_api
+    @email_alert_api ||= GdsApi::EmailAlertApi.new(
+      Plek.new.find('email-alert-api'),
+      bearer_token: ENV.fetch("EMAIL_ALERT_API_BEARER_TOKEN", "placeholder-email-bearer-token")
     )
   end
 end

--- a/app/services/taxonomy/show_page.rb
+++ b/app/services/taxonomy/show_page.rb
@@ -67,5 +67,20 @@ module Taxonomy
     def taxon_deletable?
       taxon.content_id != GovukTaxonomy::ROOT_CONTENT_ID
     end
+
+    def email_subscribers
+      @email_subscribers ||= begin
+        email_lists = []
+
+        begin
+          email_lists = Services.email_alert_api.find_subscriber_list(links: { taxon_tree: [taxon.content_id] })
+        rescue GdsApi::BaseError, SocketError => e
+          GovukError.notify(e)
+        end
+
+        subscriptions = email_lists.dig(0, "active_subscriptions_count")
+        subscriptions.present? ? subscriptions : "?"
+      end
+    end
   end
 end

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -12,6 +12,9 @@
       <th>
         tagged
       </th>
+      <th>
+        email subscribers
+      </th>
     </tr>
   </thead>
   <tbody>
@@ -29,6 +32,11 @@
       <td>
         <span class="label label-default add-right-margin">
           <%= page.tagged.count %>
+        </span>
+      </td>
+      <td>
+        <span class="label label-default add-right-margin">
+          <%= page.email_subscribers %>
         </span>
       </td>
     </tr>

--- a/spec/controllers/taxons_controller_spec.rb
+++ b/spec/controllers/taxons_controller_spec.rb
@@ -121,6 +121,9 @@ RSpec.describe TaxonsController, type: :controller do
 
   describe '#confirm_bulk_publish' do
     it 'renders confirm bulk publish' do
+      stub_request(:get, "https://email-alert-api.test.gov.uk/subscriber-lists")
+        .to_return(body: [].to_json)
+
       expect(Taxonomy::BuildTaxon).to receive(:call).with(content_id: '123').and_return FactoryBot.build(:taxon)
       get :confirm_bulk_publish, params: { taxon_id: 123 }
       expect(response.code).to eql "200"

--- a/spec/controllers/taxons_controller_spec.rb
+++ b/spec/controllers/taxons_controller_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe TaxonsController, type: :controller do
+  include EmailAlertApiHelper
   include PublishingApiHelper
   include ContentItemHelper
 
@@ -121,9 +122,7 @@ RSpec.describe TaxonsController, type: :controller do
 
   describe '#confirm_bulk_publish' do
     it 'renders confirm bulk publish' do
-      stub_request(:get, "https://email-alert-api.test.gov.uk/subscriber-lists")
-        .to_return(body: [].to_json)
-
+      stub_email_requests_for_show_page
       expect(Taxonomy::BuildTaxon).to receive(:call).with(content_id: '123').and_return FactoryBot.build(:taxon)
       get :confirm_bulk_publish, params: { taxon_id: 123 }
       expect(response.code).to eql "200"

--- a/spec/features/move_content_between_taxons_spec.rb
+++ b/spec/features/move_content_between_taxons_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.feature "Move content between Taxons", type: :feature do
   include ContentItemHelper
+  include EmailAlertApiHelper
   include PublishingApiHelper
 
   before { Sidekiq::Testing.inline! }
@@ -93,9 +94,7 @@ RSpec.feature "Move content between Taxons", type: :feature do
   end
 
   def and_view_the_first_taxon
-    stub_request(:get, "https://email-alert-api.test.gov.uk/subscriber-lists")
-      .to_return(body: [].to_json)
-
+    stub_email_requests_for_show_page
     first_row = first('table tbody tr')
     view_taxon_link = first_row.find('a', text: 'View taxon')
 

--- a/spec/features/move_content_between_taxons_spec.rb
+++ b/spec/features/move_content_between_taxons_spec.rb
@@ -93,6 +93,9 @@ RSpec.feature "Move content between Taxons", type: :feature do
   end
 
   def and_view_the_first_taxon
+    stub_request(:get, "https://email-alert-api.test.gov.uk/subscriber-lists")
+      .to_return(body: [].to_json)
+
     first_row = first('table tbody tr')
     view_taxon_link = first_row.find('a', text: 'View taxon')
 

--- a/spec/features/taxon_history_spec.rb
+++ b/spec/features/taxon_history_spec.rb
@@ -51,6 +51,8 @@ RSpec.feature 'Taxon history' do
       .to_return(body: {}.to_json)
     stub_request(:get, "https://publishing-api.test.gov.uk/v2/expanded-links/#{@taxon['content_id']}")
       .to_return(body: { content_id: @taxon['content_id'], expanded_links: {} }.to_json)
+    stub_request(:get, "https://email-alert-api.test.gov.uk/subscriber-lists")
+      .to_return(body: [].to_json)
 
     click_on 'Save draft'
   end

--- a/spec/features/taxon_history_spec.rb
+++ b/spec/features/taxon_history_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.feature 'Taxon history' do
   include ContentItemHelper
+  include EmailAlertApiHelper
   include PublishingApiHelper
 
   scenario 'leaving a version note when updating the taxon' do
@@ -51,8 +52,7 @@ RSpec.feature 'Taxon history' do
       .to_return(body: {}.to_json)
     stub_request(:get, "https://publishing-api.test.gov.uk/v2/expanded-links/#{@taxon['content_id']}")
       .to_return(body: { content_id: @taxon['content_id'], expanded_links: {} }.to_json)
-    stub_request(:get, "https://email-alert-api.test.gov.uk/subscriber-lists")
-      .to_return(body: [].to_json)
+    stub_email_requests_for_show_page
 
     click_on 'Save draft'
   end

--- a/spec/features/taxonomy_editing_spec.rb
+++ b/spec/features/taxonomy_editing_spec.rb
@@ -217,6 +217,8 @@ RSpec.feature "Taxonomy editing" do
 
     stub_request(:get, %r{https://publishing-api.test.gov.uk/v2/linked/*})
       .to_return(status: 200, body: {}.to_json)
+    stub_request(:get, "https://email-alert-api.test.gov.uk/subscriber-lists")
+      .to_return(body: [].to_json)
 
     visit taxon_path("ID-1")
   end
@@ -229,11 +231,16 @@ RSpec.feature "Taxonomy editing" do
 
     stub_request(:get, %r{https://publishing-api.test.gov.uk/v2/linked/*})
       .to_return(status: 200, body: {}.to_json)
+    stub_request(:get, "https://email-alert-api.test.gov.uk/subscriber-lists")
+      .to_return(body: [].to_json)
 
     visit taxon_path("ID-2")
   end
 
   def when_i_visit_the_taxonomy_page
+    stub_request(:get, "https://email-alert-api.test.gov.uk/subscriber-lists")
+      .to_return(body: [].to_json)
+
     visit taxons_path
   end
 
@@ -242,6 +249,9 @@ RSpec.feature "Taxonomy editing" do
   end
 
   def and_i_click_on_the_edit_taxon_button
+    stub_request(:get, "https://email-alert-api.test.gov.uk/subscriber-lists")
+      .to_return(body: [].to_json)
+
     click_on I18n.t('views.taxons.edit')
   end
 
@@ -327,6 +337,8 @@ RSpec.feature "Taxonomy editing" do
       .to_return(body: { expanded_links: {} }.to_json)
     stub_request(:get, %r{https://publishing-api.test.gov.uk/v2/linked/*})
       .to_return(body: {}.to_json)
+    stub_request(:get, "https://email-alert-api.test.gov.uk/subscriber-lists")
+      .to_return(body: [].to_json)
 
     click_on I18n.t('views.taxons.new_button')
   end

--- a/spec/features/taxonomy_editing_spec.rb
+++ b/spec/features/taxonomy_editing_spec.rb
@@ -1,6 +1,7 @@
 require "rails_helper"
 
 RSpec.feature "Taxonomy editing" do
+  include EmailAlertApiHelper
   include PublishingApiHelper
   include ContentItemHelper
 
@@ -217,8 +218,7 @@ RSpec.feature "Taxonomy editing" do
 
     stub_request(:get, %r{https://publishing-api.test.gov.uk/v2/linked/*})
       .to_return(status: 200, body: {}.to_json)
-    stub_request(:get, "https://email-alert-api.test.gov.uk/subscriber-lists")
-      .to_return(body: [].to_json)
+    stub_email_requests_for_show_page
 
     visit taxon_path("ID-1")
   end
@@ -231,15 +231,13 @@ RSpec.feature "Taxonomy editing" do
 
     stub_request(:get, %r{https://publishing-api.test.gov.uk/v2/linked/*})
       .to_return(status: 200, body: {}.to_json)
-    stub_request(:get, "https://email-alert-api.test.gov.uk/subscriber-lists")
-      .to_return(body: [].to_json)
+    stub_email_requests_for_show_page
 
     visit taxon_path("ID-2")
   end
 
   def when_i_visit_the_taxonomy_page
-    stub_request(:get, "https://email-alert-api.test.gov.uk/subscriber-lists")
-      .to_return(body: [].to_json)
+    stub_email_requests_for_show_page
 
     visit taxons_path
   end
@@ -249,8 +247,7 @@ RSpec.feature "Taxonomy editing" do
   end
 
   def and_i_click_on_the_edit_taxon_button
-    stub_request(:get, "https://email-alert-api.test.gov.uk/subscriber-lists")
-      .to_return(body: [].to_json)
+    stub_email_requests_for_show_page
 
     click_on I18n.t('views.taxons.edit')
   end
@@ -337,8 +334,7 @@ RSpec.feature "Taxonomy editing" do
       .to_return(body: { expanded_links: {} }.to_json)
     stub_request(:get, %r{https://publishing-api.test.gov.uk/v2/linked/*})
       .to_return(body: {}.to_json)
-    stub_request(:get, "https://email-alert-api.test.gov.uk/subscriber-lists")
-      .to_return(body: [].to_json)
+    stub_email_requests_for_show_page
 
     click_on I18n.t('views.taxons.new_button')
   end

--- a/spec/features/viewing_taxons_spec.rb
+++ b/spec/features/viewing_taxons_spec.rb
@@ -46,6 +46,13 @@ RSpec.describe "Viewing taxons" do
     then_i_see_the_taxon_hierarchy_in_chevrons
   end
 
+  scenario "Checking the number of email subscribers" do
+    given_a_taxonomy
+    given_im_ignoring_tagged_content_for_now
+    when_i_view_the_lowest_level_taxon
+    then_i_see_the_number_of_email_subscribers
+  end
+
   def given_a_taxonomy
     publishing_api_has_item(fruits)
     publishing_api_has_expanded_links(
@@ -163,7 +170,7 @@ RSpec.describe "Viewing taxons" do
     stub_request(:get, %r{https://publishing-api.test.gov.uk/v2/links/cox})
       .to_return(status: 200, body: {}.to_json)
     stub_request(:get, "https://email-alert-api.test.gov.uk/subscriber-lists")
-      .to_return(body: [].to_json)
+      .to_return(body: [{ active_subscriptions_count: 24_601 }].to_json)
 
     visit taxon_path(cox["content_id"])
   end
@@ -209,6 +216,11 @@ RSpec.describe "Viewing taxons" do
 
   def then_i_see_the_taxon_hierarchy_in_chevrons
     expect(page).to have_content "Fruits > Apples > Cox"
+  end
+
+  def then_i_see_the_number_of_email_subscribers
+    expect(page).to have_content "email subscribers"
+    expect(page).to have_content "24601"
   end
 
   def and_i_can_download_the_taxonomy_in_csv_form

--- a/spec/features/viewing_taxons_spec.rb
+++ b/spec/features/viewing_taxons_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.describe "Viewing taxons" do
   include ContentItemHelper
+  include EmailAlertApiHelper
 
   let(:fruits) do
     taxon_with_details(
@@ -86,8 +87,7 @@ RSpec.describe "Viewing taxons" do
       }
     )
 
-    stub_request(:get, "https://email-alert-api.test.gov.uk/subscriber-lists")
-      .to_return(body: [{ active_subscriptions_count: 24_601 }].to_json)
+    stub_email_requests_for_show_page
   end
 
   def given_a_taxonomy_with_associated_taxons
@@ -113,8 +113,7 @@ RSpec.describe "Viewing taxons" do
       }
     )
 
-    stub_request(:get, "https://email-alert-api.test.gov.uk/subscriber-lists")
-      .to_return(body: [{ active_subscriptions_count: 24_601 }].to_json)
+    stub_email_requests_for_show_page
   end
 
   def given_im_ignoring_tagged_content_for_now
@@ -133,8 +132,7 @@ RSpec.describe "Viewing taxons" do
   end
 
   def given_email_alert_api_is_inaccessible
-    stub_request(:get, "https://email-alert-api.test.gov.uk/subscriber-lists")
-      .to_raise(SocketError)
+    stub_email_requests_for_show_page_with_error
   end
 
   def then_i_see_the_count_of_tagged_content

--- a/spec/features/viewing_taxons_spec.rb
+++ b/spec/features/viewing_taxons_spec.rb
@@ -123,6 +123,8 @@ RSpec.describe "Viewing taxons" do
   def when_i_view_the_root_taxon
     stub_request(:get, %r{https://publishing-api.test.gov.uk/v2/links/apples})
       .to_return(status: 200, body: {}.to_json)
+    stub_request(:get, "https://email-alert-api.test.gov.uk/subscriber-lists")
+      .to_return(body: [].to_json)
 
     visit taxon_path(apples["content_id"])
   end
@@ -160,6 +162,8 @@ RSpec.describe "Viewing taxons" do
 
     stub_request(:get, %r{https://publishing-api.test.gov.uk/v2/links/cox})
       .to_return(status: 200, body: {}.to_json)
+    stub_request(:get, "https://email-alert-api.test.gov.uk/subscriber-lists")
+      .to_return(body: [].to_json)
 
     visit taxon_path(cox["content_id"])
   end

--- a/spec/support/email_alert_api_helper.rb
+++ b/spec/support/email_alert_api_helper.rb
@@ -1,0 +1,11 @@
+module EmailAlertApiHelper
+  def stub_email_requests_for_show_page
+    stub_request(:get, "https://email-alert-api.test.gov.uk/subscriber-lists")
+      .to_return(body: [{ active_subscriptions_count: 24_601 }].to_json)
+  end
+
+  def stub_email_requests_for_show_page_with_error
+    stub_request(:get, "https://email-alert-api.test.gov.uk/subscriber-lists")
+      .to_raise(SocketError)
+  end
+end

--- a/spec/support/publishing_api_helper.rb
+++ b/spec/support/publishing_api_helper.rb
@@ -20,6 +20,9 @@ module PublishingApiHelper
     publishing_api_has_links(content_id: content_id, links: {})
     publishing_api_has_expanded_links(content_id: content_id, expanded_links: {})
     publishing_api_has_linked_items([], content_id: content_id, link_type: "taxons")
+
+    stub_request(:get, "https://email-alert-api.test.gov.uk/subscriber-lists")
+      .to_return(body: [].to_json)
   end
 
   def publishing_api_has_content_items(items, options = {})

--- a/spec/support/publishing_api_helper.rb
+++ b/spec/support/publishing_api_helper.rb
@@ -1,4 +1,6 @@
 module PublishingApiHelper
+  include EmailAlertApiHelper
+
   def stub_empty_bulk_taxons_lookup
     url = Plek.current.find('publishing-api') + "/v2/links/by-content-id"
     stub_request(:post, url).to_return(body: {}.to_json)
@@ -20,9 +22,7 @@ module PublishingApiHelper
     publishing_api_has_links(content_id: content_id, links: {})
     publishing_api_has_expanded_links(content_id: content_id, expanded_links: {})
     publishing_api_has_linked_items([], content_id: content_id, link_type: "taxons")
-
-    stub_request(:get, "https://email-alert-api.test.gov.uk/subscriber-lists")
-      .to_return(body: [].to_json)
+    stub_email_requests_for_show_page
   end
 
   def publishing_api_has_content_items(items, options = {})


### PR DESCRIPTION
This depends on https://github.com/alphagov/email-alert-api/pull/604.  it won't break without it, but it won't work either (and Sentry will fill up with useless errors).  Also needs a bearer token for the email-alert-api set in `EMAIL_ALERT_API_BEARER_TOKEN`.

---

[Trello card](https://trello.com/c/3fxFsB93/201-add-subscriber-list-count-stats-to-taxons-in-content-tagger)