### PR TITLE
Unpublishing a taxon tags all its content to its parent.

### DIFF
--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -88,12 +88,14 @@ class TaxonsController < ApplicationController
   def destroy
     if content_id == GovukTaxonomy::ROOT_CONTENT_ID
       redirect_to taxon_path(content_id), danger: t("controllers.taxons.destroy_homepage")
-    elsif params[:taxon][:redirect_to].empty?
+    elsif params[:taxonomy_delete_page][:redirect_to].empty?
       flash.now[:danger] = t("controllers.taxons.destroy_no_redirect")
       render :confirm_delete, locals: { page: Taxonomy::DeletePage.new(taxon) }
     else
-      base_path = Services.publishing_api.get_content(params[:taxon][:redirect_to])['base_path']
-      Services.publishing_api.unpublish(params[:id], type: "redirect", alternative_path: base_path)
+      Taxonomy::TaxonUnpublisher.call(taxon_content_id: params[:id],
+                                      redirect_to_content_id: params[:taxonomy_delete_page][:redirect_to],
+                                      user: current_user,
+                                      retag: params[:taxonomy_delete_page][:do_tag] == '1')
       redirect_to taxon_path(taxon.content_id), success: t("controllers.taxons.destroy_success")
     end
   end

--- a/app/services/taxonomy/delete_page.rb
+++ b/app/services/taxonomy/delete_page.rb
@@ -1,11 +1,14 @@
 module Taxonomy
   class DeletePage
-    delegate :content_id, to: :taxon
+    include ActiveModel::Model
 
+    delegate :content_id, :redirect_to, to: :taxon
+    attr_reader :do_tag
     attr_reader :taxon
 
     def initialize(taxon)
       @taxon = taxon
+      @do_tag = true
     end
 
     def taxonomy_tree

--- a/app/services/taxonomy/taxon_unpublisher.rb
+++ b/app/services/taxonomy/taxon_unpublisher.rb
@@ -1,0 +1,41 @@
+module Taxonomy
+  class TaxonUnpublisher
+    def self.call(taxon_content_id:, redirect_to_content_id:, user:, retag: true)
+      new.unpublish(taxon_content_id: taxon_content_id,
+                    redirect_to_content_id: redirect_to_content_id,
+                    user: user, retag: retag)
+    end
+
+    def unpublish(taxon_content_id:, redirect_to_content_id:, user:, retag:)
+      tag_to_parent(taxon_content_id, user) if retag
+      unpublish_taxon(taxon_content_id, redirect_to_content_id)
+    end
+
+  private
+
+    def tag_to_parent(taxon_content_id, user)
+      parent_taxon = Taxonomy::TaxonomyQuery.new.parent(taxon_content_id)
+      return if parent_taxon.nil?
+      tag_migration = BulkTagging::BuildTagMigration.call(
+        source_content_item: ContentItem.find!(taxon_content_id),
+        taxon_content_ids: [parent_taxon['content_id']],
+        content_base_paths: tagged_content_base_paths(taxon_content_id)
+      )
+      tag_migration.save!
+      BulkTagging::QueueLinksForPublishing.call(tag_migration, user: user)
+    end
+
+    def unpublish_taxon(taxon_content_id, redirect_to_content_id)
+      redirect_to_taxon = Services.publishing_api.get_content(redirect_to_content_id)
+      Services.publishing_api.unpublish(taxon_content_id, type: "redirect", alternative_path: redirect_to_taxon['base_path'])
+    end
+
+    def tagged_content_base_paths(content_id)
+      Services.publishing_api.get_linked_items(
+        content_id,
+        link_type: "taxons",
+        fields: ['base_path']
+      ).map { |content| content['base_path'] }
+    end
+  end
+end

--- a/app/services/taxonomy/taxonomy_query.rb
+++ b/app/services/taxonomy/taxonomy_query.rb
@@ -29,6 +29,12 @@ module Taxonomy
       content_id_hashes.map { |h| h['content_id'] }.uniq
     end
 
+    def parent(content_id)
+      expanded_links = Services.publishing_api.get_expanded_links(content_id).to_h
+      parent_taxon_hash = expanded_links.dig('expanded_links', 'parent_taxons', 0)
+      parent_taxon_hash.nil? ? nil : parent_taxon_hash.slice(*@taxon_fields)
+    end
+
   private
 
     def recursive_child_taxons(taxons, parent_content_id)

--- a/app/views/taxons/confirm_delete.html.erb
+++ b/app/views/taxons/confirm_delete.html.erb
@@ -14,10 +14,10 @@
 </div>
 <% end %>
 
-<%= simple_form_for page.taxon, url: taxon_path(page.taxon.content_id), method: :delete do |f| %>
+<%= simple_form_for page, url: taxon_path(page.taxon.content_id), method: :delete do |f| %>
   <%= f.input :redirect_to, collection: page.taxons_for_select,
     input_html: { class: :select2, multiple: false, include_blank: true } %>
-
+  <%= f.input :do_tag, as: :boolean, value: true, label: 'Tag content to parent?' %>
   <%= f.button :button, class: 'btn btn-md btn-danger' do %>
     <span class="glyphicon glyphicon-trash"></span>
     <span><%= t('views.taxons.confirm_deletion') %></span>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -120,7 +120,7 @@ en:
       import_removed: Tag migration import has been removed.
     taxons:
       create_success: You have sucessfully created a taxon
-      destroy_success: You have sucessfully deleted the taxon
+      destroy_success: You have sucessfully deleted the taxon. This may take a few minutes to take effect.
       destroy_alert: It was not possible to delete the taxon
       destroy_no_redirect: Please select a taxon to redirect to
       destroy_homepage: You cannot delete the homepage

--- a/spec/controllers/taxons_controller_spec.rb
+++ b/spec/controllers/taxons_controller_spec.rb
@@ -70,8 +70,10 @@ RSpec.describe TaxonsController, type: :controller do
 
       publishing_api_has_taxons([taxon])
 
-      delete :destroy, params: { id: foo_content_id, taxon: { redirect_to: bar_content_id } }
-      expect(WebMock).to have_requested(:post, "https://publishing-api.test.gov.uk/v2/content/#{foo_content_id}/unpublish")
+      Sidekiq::Testing.inline! do
+        delete :destroy, params: { id: foo_content_id, taxonomy_delete_page: { redirect_to: bar_content_id } }
+        expect(WebMock).to have_requested(:post, "https://publishing-api.test.gov.uk/v2/content/#{foo_content_id}/unpublish")
+      end
     end
 
     it "does not send a request to Publishing API if a taxon to redirect to is not provided" do
@@ -83,7 +85,7 @@ RSpec.describe TaxonsController, type: :controller do
 
       publishing_api_has_taxons([taxon])
 
-      delete :destroy, params: { id: foo_content_id, taxon: { redirect_to: "" } }
+      delete :destroy, params: { id: foo_content_id, taxonomy_delete_page: { redirect_to: "" } }
       expect(WebMock).to_not have_requested(:post, "https://publishing-api.test.gov.uk/v2/content/#{foo_content_id}/unpublish")
     end
 

--- a/spec/services/taxonomy/taxon_unpublisher_spec.rb
+++ b/spec/services/taxonomy/taxon_unpublisher_spec.rb
@@ -1,0 +1,84 @@
+require "rails_helper"
+
+include ::GdsApi::TestHelpers::PublishingApiV2
+
+RSpec.describe Taxonomy::TaxonUnpublisher do
+  let(:taxon_content_id) { SecureRandom.uuid }
+  let(:parent_taxon_content_id) { SecureRandom.uuid }
+  let(:redirect_content_id) { SecureRandom.uuid }
+  let(:tagged_content_id1) { SecureRandom.uuid }
+  let(:tagged_content_id2) { SecureRandom.uuid }
+  let(:version) { 10 }
+
+  before :each do
+    # parent and child taxon, redirect taxon exist
+    publishing_api_has_item(FactoryBot.build(:taxon_hash, content_id: taxon_content_id))
+    publishing_api_has_item(FactoryBot.build(:taxon_hash, content_id: parent_taxon_content_id))
+    publishing_api_has_item('content_id' => redirect_content_id, 'base_path' => '/path/to/redirect')
+
+    # link parent taxon to child taxon
+    publishing_api_has_expanded_links(expanded_links(taxon_content_id, parent_taxon_content_id))
+
+    # content items are tagged to child taxon
+    publishing_api_has_linked_items(
+      [{ 'base_path' => '/base/path1' },
+       { 'base_path' => '/base/path2' }],
+      content_id: taxon_content_id,
+      link_type: 'taxons',
+      fields: ['base_path']
+    )
+    publishing_api_has_lookups('/base/path1' => tagged_content_id1, '/base/path2' => tagged_content_id2)
+
+    # each content item has links to child taxon
+    publishing_api_has_links(content_id: tagged_content_id1, links: { taxons: [taxon_content_id] }, version: version)
+    publishing_api_has_links(content_id: tagged_content_id2, links: { taxons: [taxon_content_id] }, version: version)
+
+    stub_any_publishing_api_unpublish
+  end
+
+  it 'unpublishes a level one taxon with a redirect' do
+    publishing_api_has_expanded_links('content_id' => taxon_content_id, 'expanded_links' => {})
+    unpublish(taxon_content_id, redirect_content_id)
+    assert_publishing_api_unpublish(taxon_content_id, type: 'redirect', alternative_path: '/path/to/redirect')
+  end
+
+  describe 'tag to parent' do
+    before :each do
+      stub_any_publishing_api_unpublish
+    end
+    it 'retags content to the parent' do
+      patch_request1 = stub_publishing_api_patch_links(tagged_content_id1, hash_including(links: { taxons: [taxon_content_id, parent_taxon_content_id] }, previous_version: version))
+      patch_request2 = stub_publishing_api_patch_links(tagged_content_id2, hash_including(links: { taxons: [taxon_content_id, parent_taxon_content_id] }, previous_version: version))
+      unpublish(taxon_content_id, redirect_content_id)
+      expect(patch_request1).to have_been_made
+      expect(patch_request2).to have_been_made
+    end
+
+    it 'does not retag content' do
+      patch_request = stub_any_publishing_api_patch_links
+      unpublish(taxon_content_id, redirect_content_id, false)
+      expect(patch_request).to_not have_been_made
+    end
+  end
+
+  def unpublish(taxon_content_id, redirect_to_content_id, retag = true)
+    Sidekiq::Testing.inline! do
+      Taxonomy::TaxonUnpublisher.call(taxon_content_id: taxon_content_id, redirect_to_content_id: redirect_to_content_id, user: User.new, retag: retag)
+    end
+  end
+
+  def expanded_links(content_id, parent_content_id)
+    {
+      "content_id" => content_id,
+      "expanded_links" =>
+        {
+          "parent_taxons" =>
+            [
+              {
+                "content_id" => parent_content_id,
+              }
+            ]
+        }
+    }
+  end
+end


### PR DESCRIPTION
When unpublishing a taxon, a checkbox can be checked that automatically tags all its content to
its parent. 

Trello: https://trello.com/c/YrANYCMo/126-improve-the-unpublish-feature-in-content-tagger-to-also-handle-content

![image](https://user-images.githubusercontent.com/6050162/40924088-5399da0a-680e-11e8-8b52-30a57ff54860.png)
