### PR TITLE
Remove tbc in descriptions

### DIFF
--- a/app/lib/services.rb
+++ b/app/lib/services.rb
@@ -12,6 +12,14 @@ module Services
     )
   end
 
+  def self.publishing_api_with_long_timeout
+    @publishing_api_with_low_timeout ||= begin
+      publishing_api.dup.tap do |client|
+        client.options[:timeout] = 15
+      end
+    end
+  end
+
   def self.content_store
     @content_store ||= GdsApi::ContentStore.new(Plek.current.find("draft-content-store"))
   end

--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -16,7 +16,7 @@ class Taxon
 
   include ActiveModel::Model
 
-  validates_presence_of :title, :description, :internal_name, :base_path
+  validates_presence_of :title, :internal_name, :base_path
   validates_with CircularDependencyValidator
   validates :base_path, format: { with: PATH_COMPONENTS_REGEX, message: "must be in the format '/highest-level-taxon-name/taxon-name'" }
   validates_with TaxonPathPrefixValidator

--- a/lib/tasks/taxonomy/clear_descriptions.rake
+++ b/lib/tasks/taxonomy/clear_descriptions.rake
@@ -1,0 +1,9 @@
+require 'taxon_description_updater'
+namespace :taxonomy do
+  desc <<-DESC
+    Clears all descriptions containing '...' or 'tbc'.
+  DESC
+  task clear_descriptions: [:environment] do
+    TaxonDescriptionUpdater.new(%w[... tbc]).call
+  end
+end

--- a/lib/taxon_description_updater.rb
+++ b/lib/taxon_description_updater.rb
@@ -30,6 +30,19 @@ private
     )
     publishing_api.put_content(content_id, payload)
     publishing_api.publish(content_id) unless draft_version_exists
+    log_what_happened(taxon, draft_version_exists)
+  end
+
+  def log_what_happened(taxon, draft_version_exists)
+    if draft_version_exists
+      puts "Draft taxon: #{taxon_details(taxon)} : description cleared but not published"
+    else
+      puts "Published taxon: #{taxon_details(taxon)} : description cleared and published"
+    end
+  end
+
+  def taxon_details(taxon)
+    "title: #{taxon['title']}, content_id: #{taxon['content_id']}"
   end
 
   def draft_version_exists?(taxon)

--- a/lib/taxon_description_updater.rb
+++ b/lib/taxon_description_updater.rb
@@ -1,0 +1,38 @@
+class TaxonDescriptionUpdater
+  def initialize(descriptions_to_remove)
+    @descriptions_to_remove = descriptions_to_remove
+  end
+
+  def call
+    @descriptions_to_remove.each(&method(:replace_description))
+  end
+
+private
+
+  EXCLUDE_ATTRIBUTES = %w[content_store user_facing_version publication_state lock_version updated_at state_history].freeze
+
+  def replace_description(description_to_remove)
+    content_items = publishing_api.get_content_items(
+      per_page: 5000,
+      q: description_to_remove,
+      search_in: ['description']
+    )
+    content_items['results'].select { |item| item['description'] == description_to_remove }.each do |taxon|
+      update_description(taxon)
+    end
+  end
+
+  def update_description(taxon)
+    content_id = taxon['content_id']
+    payload = taxon.except(*EXCLUDE_ATTRIBUTES).merge(
+      'description' => nil,
+      'update_type' => 'minor'
+    )
+    publishing_api.put_content(content_id, payload)
+    publishing_api.publish(content_id)
+  end
+
+  def publishing_api
+    @publishing_api ||= Services.publishing_api_with_long_timeout
+  end
+end

--- a/lib/taxon_description_updater.rb
+++ b/lib/taxon_description_updater.rb
@@ -15,7 +15,8 @@ private
     content_items = publishing_api.get_content_items(
       per_page: 5000,
       q: description_to_remove,
-      search_in: ['description']
+      search_in: ['description'],
+      states: %w[published draft]
     )
     content_items['results'].select { |item| item['description'] == description_to_remove }.each do |taxon|
       update_description(taxon, draft_version_exists?(taxon))

--- a/spec/lib/taxon_description_updater_spec.rb
+++ b/spec/lib/taxon_description_updater_spec.rb
@@ -35,8 +35,8 @@ RSpec.describe TaxonDescriptionUpdater do
   end
 
   before do
-    publishing_api_has_content(with_dots, per_page: 5000, q: '...', search_in: ['description'])
-    publishing_api_has_content(with_tbc, per_page: 5000, q: 'tbc', search_in: ['description'])
+    publishing_api_has_content(with_dots, per_page: 5000, q: '...', search_in: ['description'], states: %w[published draft])
+    publishing_api_has_content(with_tbc, per_page: 5000, q: 'tbc', search_in: ['description'], states: %w[published draft])
     stub_any_publishing_api_put_content
     stub_any_publishing_api_publish
 

--- a/spec/lib/taxon_description_updater_spec.rb
+++ b/spec/lib/taxon_description_updater_spec.rb
@@ -1,0 +1,75 @@
+require 'rails_helper'
+require 'taxon_description_updater'
+
+RSpec.describe TaxonDescriptionUpdater do
+  let(:with_dots) do
+    [
+      create_taxon('content_id' => 'desc-...', 'title' => 'title ...', 'description' => '...', 'phase' => 'live'),
+      create_taxon('content_id' => 'desc-other', 'title' => 'title other', 'description' => 'other...'),
+    ]
+  end
+  let(:with_tbc) do
+    [
+      create_taxon('content_id' => 'desc-tbc', 'title' => 'title2 ...', 'description' => 'tbc', 'phase' => 'beta'),
+      create_taxon('content_id' => 'desc-other-tbc', 'title' => 'title2 other', 'description' => 'other tbc'),
+    ]
+  end
+
+  before do
+    publishing_api_has_content(with_dots, per_page: 5000, q: '...', search_in: ['description'])
+    publishing_api_has_content(with_tbc, per_page: 5000, q: 'tbc', search_in: ['description'])
+    stub_any_publishing_api_put_content
+    stub_any_publishing_api_publish
+
+    TaxonDescriptionUpdater.new(%w[... tbc]).call
+  end
+
+  it 'updated the ... records correctly' do
+    assert_put_content('desc-...', content_id: 'desc-...', title: 'title ...', phase: 'live')
+    assert_publish 'desc-...'
+    assert_no_put_content('desc-other')
+    assert_no_publish('desc-other')
+  end
+
+  it 'updated the tbc records correctly' do
+    assert_put_content('desc-tbc', content_id: 'desc-tbc', title: 'title2 ...', phase: 'beta')
+    assert_publish 'desc-tbc'
+    assert_no_put_content('desc-other-tbc')
+    assert_no_publish('desc-other-tbc')
+  end
+
+private
+
+  def create_taxon(attributes)
+    attributes.merge(
+      'schema_name' => 'taxon',
+      'content_store' => 'live',
+      'user_facing_version' => 4,
+      'publication_state' => 'published',
+      'lock_version' => 3,
+      'updated_at' => Time.now,
+      'state_history' => []
+    )
+  end
+
+  def assert_put_content(content_id, params)
+    param_defaults = {
+      description: nil,
+      schema_name: 'taxon',
+      update_type: 'minor'
+    }
+    assert_publishing_api_put_content(content_id, param_defaults.merge(params), 1)
+  end
+
+  def assert_no_put_content(content_id)
+    assert_publishing_api_put_content(content_id, nil, 0)
+  end
+
+  def assert_publish(content_id)
+    assert_publishing_api_publish content_id
+  end
+
+  def assert_no_publish(content_id)
+    assert_publishing_api_publish content_id, nil, 0
+  end
+end

--- a/spec/lib/taxon_description_updater_spec.rb
+++ b/spec/lib/taxon_description_updater_spec.rb
@@ -4,13 +4,32 @@ require 'taxon_description_updater'
 RSpec.describe TaxonDescriptionUpdater do
   let(:with_dots) do
     [
-      create_taxon('content_id' => 'desc-...', 'title' => 'title ...', 'description' => '...', 'phase' => 'live'),
+      create_taxon('content_id' => 'desc-...', 'title' => 'title ...', 'description' => '...'),
+      create_taxon(
+        'content_id' => 'desc-...-draft',
+        'title' => 'title ...',
+        'description' => '...',
+        'state_history' => {
+          1 => 'superseded',
+          2 => 'published',
+          3 => 'draft'
+        }
+      ),
       create_taxon('content_id' => 'desc-other', 'title' => 'title other', 'description' => 'other...'),
     ]
   end
   let(:with_tbc) do
     [
       create_taxon('content_id' => 'desc-tbc', 'title' => 'title2 ...', 'description' => 'tbc', 'phase' => 'beta'),
+      create_taxon(
+        'content_id' => 'desc-tbc-draft',
+        'title' => 'title2 ...',
+        'description' => 'tbc',
+        'state_history' => {
+          1 => 'published',
+          2 => 'draft'
+        }
+      ),
       create_taxon('content_id' => 'desc-other-tbc', 'title' => 'title2 other', 'description' => 'other tbc'),
     ]
   end
@@ -24,32 +43,43 @@ RSpec.describe TaxonDescriptionUpdater do
     TaxonDescriptionUpdater.new(%w[... tbc]).call
   end
 
-  it 'updated the ... records correctly' do
+  it 'updated the published ... editions correctly' do
     assert_put_content('desc-...', content_id: 'desc-...', title: 'title ...', phase: 'live')
     assert_publish 'desc-...'
     assert_no_put_content('desc-other')
     assert_no_publish('desc-other')
   end
 
-  it 'updated the tbc records correctly' do
+  it 'updated the published tbc editions correctly' do
     assert_put_content('desc-tbc', content_id: 'desc-tbc', title: 'title2 ...', phase: 'beta')
     assert_publish 'desc-tbc'
     assert_no_put_content('desc-other-tbc')
     assert_no_publish('desc-other-tbc')
   end
 
-private
+  it 'updated the draft editions but did not publish' do
+    assert_put_content('desc-...-draft', content_id: 'desc-...-draft', title: 'title ...', phase: 'live')
+    assert_no_publish 'desc-...-draft'
+    assert_put_content('desc-tbc-draft', content_id: 'desc-tbc-draft', title: 'title2 ...', phase: 'live')
+    assert_no_publish 'desc-tbc-draft'
+  end
+
+  private
 
   def create_taxon(attributes)
-    attributes.merge(
+    {
       'schema_name' => 'taxon',
       'content_store' => 'live',
       'user_facing_version' => 4,
       'publication_state' => 'published',
       'lock_version' => 3,
       'updated_at' => Time.now,
-      'state_history' => []
-    )
+      'phase' => 'live',
+      'state_history' => {
+        1 => 'superseded',
+        2 => 'published'
+      }
+    }.merge(attributes)
   end
 
   def assert_put_content(content_id, params)

--- a/spec/models/taxon_spec.rb
+++ b/spec/models/taxon_spec.rb
@@ -8,12 +8,6 @@ RSpec.describe Taxon do
       expect(taxon.errors.keys).to include(:title)
     end
 
-    it 'is not valid without a description' do
-      taxon = described_class.new
-      expect(taxon).to_not be_valid
-      expect(taxon.errors.keys).to include(:description)
-    end
-
     it 'is not valid without a base path' do
       taxon = described_class.new(base_path: '')
 


### PR DESCRIPTION
We want to prevent descriptions like '...' and 'tbc'.

In order to do this - this PR does the following:

* Remove validation of a taxon's description
* Add a rake task taxonomy:clear_descriptions which updates these descriptions ('...' and 'tbc') in the publishing api, setting them to null.

Trello: [Remove the ... / tbc in descriptions](https://trello.com/c/MjF3xk3a/113-remove-the-tbc-in-descriptions-2)