### PR TITLE
Allow redirects to be used in tag migrations

### DIFF
--- a/app/models/bulk_tagging/tag_mapping.rb
+++ b/app/models/bulk_tagging/tag_mapping.rb
@@ -24,7 +24,7 @@ module BulkTagging
 
     def content_id
       @content_id ||=
-        Services.publishing_api.lookup_content_id(base_path: content_base_path)
+        Services.publishing_api.lookup_content_id(base_path: content_base_path, exclude_unpublishing_types: %w[vanish gone], exclude_document_types: ['gone'])
     end
 
     def mark_as_tagged


### PR DESCRIPTION
When unpublishing a Taxon, we expect all content to be copied to its parent.
This allows redirected content to be copied.