### PR TITLE
Fix how email subscriptions are picked from the JSON response 

### DIFF
--- a/app/services/taxonomy/show_page.rb
+++ b/app/services/taxonomy/show_page.rb
@@ -70,7 +70,7 @@ module Taxonomy
 
     def email_subscribers
       @email_subscribers ||= begin
-        email_lists = []
+        email_lists = {}
 
         begin
           email_lists = Services.email_alert_api.find_subscriber_list(links: { taxon_tree: [taxon.content_id] })
@@ -78,8 +78,7 @@ module Taxonomy
           GovukError.notify(e)
         end
 
-        subscriptions = email_lists.dig(0, "active_subscriptions_count")
-        subscriptions.present? ? subscriptions : "?"
+        email_lists.dig("subscriber_list", "active_subscriptions_count") || "?"
       end
     end
   end

--- a/spec/support/email_alert_api_helper.rb
+++ b/spec/support/email_alert_api_helper.rb
@@ -1,11 +1,13 @@
+require "gds_api/test_helpers/email_alert_api"
+
 module EmailAlertApiHelper
+  include GdsApi::TestHelpers::EmailAlertApi
+
   def stub_email_requests_for_show_page
-    stub_request(:get, "https://email-alert-api.test.gov.uk/subscriber-lists")
-      .to_return(body: [{ active_subscriptions_count: 24_601 }].to_json)
+    email_alert_api_has_subscriber_list(active_subscriptions_count: 24_601)
   end
 
   def stub_email_requests_for_show_page_with_error
-    stub_request(:get, "https://email-alert-api.test.gov.uk/subscriber-lists")
-      .to_raise(SocketError)
+    stub_request(:get, build_subscriber_lists_url).to_raise(SocketError)
   end
 end


### PR DESCRIPTION
Previously we thought it was an array response, but actually it only returns one subscriber list.

I spotted this problem while deploying the app.

[Trello Card](https://trello.com/c/3fxFsB93/201-add-subscriber-list-count-stats-to-taxons-in-content-tagger)