### PR TITLE
Add 'TBC' and '...tbc' to `clear_descriptions` task

### DIFF
--- a/lib/tasks/taxonomy/clear_descriptions.rake
+++ b/lib/tasks/taxonomy/clear_descriptions.rake
@@ -4,6 +4,6 @@ namespace :taxonomy do
     Clears all descriptions containing '...' or 'tbc'.
   DESC
   task clear_descriptions: [:environment] do
-    TaxonDescriptionUpdater.new(%w[... tbc]).call
+    TaxonDescriptionUpdater.new(%w[... tbc TBC ...tbc]).call
   end
 end


### PR DESCRIPTION
Relates to this pr which sets the description of content to nil if the
description is equal to 'tbc' or '...';
https://github.com/alphagov/content-tagger/pull/756