### PR TITLE
Fix a couple of issues with fetching email subscriber lists

### DIFF
--- a/app/services/taxonomy/show_page.rb
+++ b/app/services/taxonomy/show_page.rb
@@ -70,15 +70,13 @@ module Taxonomy
 
     def email_subscribers
       @email_subscribers ||= begin
-        email_lists = {}
-
         begin
-          email_lists = Services.email_alert_api.find_subscriber_list(links: { taxon_tree: [taxon.content_id] })
+          email_lists = Services.email_alert_api.find_subscriber_list("links" => { taxon_tree: [taxon.content_id] })
+          email_lists.dig("subscriber_list", "active_subscriptions_count")
         rescue GdsApi::BaseError, SocketError => e
           GovukError.notify(e)
+          "?"
         end
-
-        email_lists.dig("subscriber_list", "active_subscriptions_count") || "?"
       end
     end
   end

--- a/app/services/taxonomy/show_page.rb
+++ b/app/services/taxonomy/show_page.rb
@@ -73,6 +73,8 @@ module Taxonomy
         begin
           email_lists = Services.email_alert_api.find_subscriber_list("links" => { taxon_tree: [taxon.content_id] })
           email_lists.dig("subscriber_list", "active_subscriptions_count")
+        rescue GdsApi::HTTPNotFound
+          "0"
         rescue GdsApi::BaseError, SocketError => e
           GovukError.notify(e)
           "?"

--- a/spec/support/email_alert_api_helper.rb
+++ b/spec/support/email_alert_api_helper.rb
@@ -4,10 +4,17 @@ module EmailAlertApiHelper
   include GdsApi::TestHelpers::EmailAlertApi
 
   def stub_email_requests_for_show_page
-    email_alert_api_has_subscriber_list(active_subscriptions_count: 24_601)
+    stub_request(:get, build_subscriber_lists_url)
+      .with(query: hash_including({}))
+      .to_return(
+        status: 200,
+        body: get_subscriber_list_response(active_subscriptions_count: 24_601).to_json,
+      )
   end
 
   def stub_email_requests_for_show_page_with_error
-    stub_request(:get, build_subscriber_lists_url).to_raise(SocketError)
+    stub_request(:get, build_subscriber_lists_url)
+      .with(query: hash_including({}))
+      .to_raise(SocketError)
   end
 end


### PR DESCRIPTION
1. A missing list just means there are no subscribers, not that there has been an error.
2. The API adapters are silly and use string keys.

---

[Trello card](https://trello.com/c/3fxFsB93/201-add-subscriber-list-count-stats-to-taxons-in-content-tagger)