### PR TITLE
Add published with new draft state

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -67,6 +67,10 @@ $red: #b10e1e;
   background-color: $gray-light;
 }
 
+.state-label--published_with_new_draft  {
+  background-color: #2B8CC4;
+}
+
 .field-with-error {
   border: 2px solid $state-danger-text;
 }

--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -6,6 +6,7 @@ class Taxon
     :description,
     :parent_content_id,
     :publication_state,
+    :state_history,
     :phase,
     :document_type,
     :redirect_to,

--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -38,6 +38,14 @@ class Taxon
     publication_state == "unpublished" && !redirect_to.nil?
   end
 
+  def ordered_publication_state_history
+    state_history.sort_by(&:first).map(&:second)
+  end
+
+  def lastest_two_publication_states
+    ordered_publication_state_history.last(2)
+  end
+
   def level_one_taxon?
     parent_content_id.present? &&
       parent_content_id == GovukTaxonomy::ROOT_CONTENT_ID

--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -38,6 +38,11 @@ class Taxon
     publication_state == "unpublished" && !redirect_to.nil?
   end
 
+  def draft_and_published_editions_exist?
+    previous_state, latest_state = lastest_two_publication_states
+    previous_state && latest_state == "draft"
+  end
+
   def ordered_publication_state_history
     state_history.sort_by(&:first).map(&:second)
   end

--- a/app/services/taxonomy/build_taxon.rb
+++ b/app/services/taxonomy/build_taxon.rb
@@ -22,6 +22,7 @@ module Taxonomy
         description: content_item["description"],
         base_path: content_item["base_path"],
         publication_state: content_item['publication_state'],
+        state_history: content_item['state_history'],
         phase: content_item['phase'],
         internal_name: content_item['details']['internal_name'],
         notes_for_editors: content_item['details']['notes_for_editors'],

--- a/app/services/taxonomy/show_page.rb
+++ b/app/services/taxonomy/show_page.rb
@@ -14,6 +14,10 @@ module Taxonomy
       taxon.internal_name
     end
 
+    def publication_state_display_name
+      publication_state_name.humanize.downcase
+    end
+
     def publication_state_name
       return "published_with_new_draft" if draft_and_published_editions_exist?
 

--- a/app/services/taxonomy/show_page.rb
+++ b/app/services/taxonomy/show_page.rb
@@ -14,6 +14,14 @@ module Taxonomy
       taxon.internal_name
     end
 
+    def show_preview_link?
+      draft? || draft_and_published_editions_exist?
+    end
+
+    def show_production_link?
+      published? || draft_and_published_editions_exist?
+    end
+
     def publication_state_display_name
       publication_state_name.humanize.downcase
     end

--- a/app/services/taxonomy/show_page.rb
+++ b/app/services/taxonomy/show_page.rb
@@ -1,7 +1,7 @@
 module Taxonomy
   class ShowPage
     delegate :content_id, :draft?, :published?, :unpublished?, :redirected?,
-             :redirect_to, :base_path, to: :taxon
+             :draft_and_published_editions_exist?, :redirect_to, :base_path, to: :taxon
 
     attr_reader :taxon, :visualisation
 
@@ -15,6 +15,8 @@ module Taxonomy
     end
 
     def publication_state_name
+      return "published_with_new_draft" if draft_and_published_editions_exist?
+
       {
         "draft" => "draft",
         "published" => "published",

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -45,16 +45,19 @@
 
 <hr>
 
-<p>
-  <% if page.published? %>
-    <%= link_to "View on GOV.UK", website_url(page.base_path) %>
-  <% elsif page.draft? %>
-    <%= link_to "View on GOV.UK", website_url(page.base_path, draft: true) %>
-  <% end %>
- <% unless page.unpublished? %>
+<% if page.show_preview_link? %>
+  <p>
+    <%= link_to "Preview changes on GOV.UK", website_url(page.base_path, draft: true) %>
     (<%= page.base_path %>)
-  <% end %>
-</p>
+  </p>
+<% end %>
+
+<% if page.show_production_link? %>
+  <p>
+    <%= link_to "View on GOV.UK", website_url(page.base_path) %>
+    (<%= page.base_path %>)
+  </p>
+<% end %>
 
 <% unless page.unpublished? %>
   <p>

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -21,7 +21,7 @@
     <tr>
       <td>
         <span class="label add-right-margin state-label--<%= page.publication_state_name %>">
-          <%= page.publication_state_name %>
+          <%= page.publication_state_display_name %>
         </span>
       </td>
       <td>

--- a/spec/factories/taxon.rb
+++ b/spec/factories/taxon.rb
@@ -8,5 +8,11 @@ FactoryBot.define do
     base_path '/level-one/taxon-base-path'
     publication_state 'published'
     internal_name 'An internal name'
+
+    trait :draft do
+      publication_state 'draft'
+    end
+
+    factory :draft_taxon, traits: [:draft]
   end
 end

--- a/spec/factories/taxon.rb
+++ b/spec/factories/taxon.rb
@@ -13,6 +13,17 @@ FactoryBot.define do
       publication_state 'draft'
     end
 
+    trait :previously_published_draft do
+      publication_state 'draft'
+      state_history do
+        {
+          "2" => "draft",
+          "1" => "published"
+        }
+      end
+    end
+
     factory :draft_taxon, traits: [:draft]
+    factory :previously_published_draft_taxon, traits: [:previously_published_draft]
   end
 end

--- a/spec/features/bulk_publishing_spec.rb
+++ b/spec/features/bulk_publishing_spec.rb
@@ -19,7 +19,10 @@ RSpec.feature 'Bulk publishing', type: :feature do
       'Foo',
       other_fields: {
         content_id: 'single-taxon-content-id',
-        publication_state: 'draft'
+        publication_state: 'draft',
+        state_history: {
+          "1" => "draft"
+        }
       }
     )
     stub_requests_for_show_page(taxon)

--- a/spec/features/bulk_updating_spec.rb
+++ b/spec/features/bulk_updating_spec.rb
@@ -24,6 +24,9 @@ RSpec.feature 'Bulk updating', type: :feature do
         content_id: @parent_content_id,
         phase: 'beta',
         publication_state: 'published',
+        state_history: {
+          "1" => "published"
+        }
       }
     )
 
@@ -33,6 +36,9 @@ RSpec.feature 'Bulk updating', type: :feature do
         content_id: @child_content_id,
         phase: 'alpha',
         publication_state: 'draft',
+        state_history: {
+          "1" => "draft"
+        }
       }
     )
 

--- a/spec/features/delete_taxon_spec.rb
+++ b/spec/features/delete_taxon_spec.rb
@@ -82,7 +82,12 @@ RSpec.feature "Delete Taxon", type: :feature do
     @taxon_content_id = SecureRandom.uuid
     @taxon = taxon_with_details(
       "Taxon 1",
-      other_fields: { content_id: @taxon_content_id }
+      other_fields: {
+        content_id: @taxon_content_id,
+        state_history: {
+          "1" => "published"
+        }
+      }
     )
 
     stub_requests_for_show_page(@taxon)
@@ -113,7 +118,10 @@ RSpec.feature "Delete Taxon", type: :feature do
       other_fields: {
         base_path: "/level-one/taxon-2",
         content_id: @taxon_content_id,
-        description: 'A description of Taxon 2.'
+        description: 'A description of Taxon 2.',
+        state_history: {
+          "1" => "unpublished"
+        }
       },
       unpublished: true
     )

--- a/spec/features/draft_taxons_spec.rb
+++ b/spec/features/draft_taxons_spec.rb
@@ -79,6 +79,9 @@ RSpec.feature "Draft taxonomy" do
         content_id: @taxon_content_id,
         description: 'A description of Taxon 2.',
         publication_state: 'draft',
+        state_history: {
+          "1" => "draft"
+        }
       },
     )
 

--- a/spec/features/move_content_between_taxons_spec.rb
+++ b/spec/features/move_content_between_taxons_spec.rb
@@ -39,24 +39,36 @@ RSpec.feature "Move content between Taxons", type: :feature do
     @source_taxon = taxon_with_details(
       "Source taxon",
       other_fields: {
-        document_type: 'taxon'
+        document_type: 'taxon',
+        state_history: {
+          "1" => "published"
+        }
       }
     )
     @source_taxon_for_select = {
       'internal_name' => @source_taxon['details']['internal_name'],
       'content_id' => @source_taxon['content_id'],
-      'publication_state' => 'published'
+      'publication_state' => 'published',
+      'state_history' => {
+        "1" => "published"
+      }
     }
     @dest_taxon = taxon_with_details(
       "Destination taxon",
       other_fields: {
-        document_type: 'taxon'
+        document_type: 'taxon',
+        state_history: {
+          "1" => "published"
+        }
       }
     )
     @dest_taxon_for_select = {
       'internal_name' => @dest_taxon['details']['internal_name'],
       'content_id' => @dest_taxon['content_id'],
-      'publication_state' => 'published'
+      'publication_state' => 'published',
+      'state_history' => {
+        "1" => "published"
+      }
     }
 
     @document_1 = basic_content_item("Tagged content 1")

--- a/spec/features/taxon_history_spec.rb
+++ b/spec/features/taxon_history_spec.rb
@@ -17,7 +17,14 @@ RSpec.feature 'Taxon history' do
   def given_a_taxon_exists
     title = 'Business'
 
-    @taxon = taxon_with_details(title, other_fields: { description: '...' })
+    @taxon = taxon_with_details(
+      title, other_fields: {
+        description: '...',
+        state_history: {
+          "1" => "published"
+        }
+      }
+    )
   end
 
   def when_i_visit_the_taxon_edit_form

--- a/spec/features/taxonomy_editing_spec.rb
+++ b/spec/features/taxonomy_editing_spec.rb
@@ -11,7 +11,10 @@ RSpec.feature "Taxonomy editing" do
       other_fields: {
         content_id: "ID-1",
         base_path: "/education/1",
-        publication_state: 'published'
+        publication_state: 'published',
+        state_history: {
+          "1" => "published"
+        }
       }
     )
     @taxon_2 = taxon_with_details(
@@ -19,7 +22,10 @@ RSpec.feature "Taxonomy editing" do
       other_fields: {
         content_id: "ID-2",
         base_path: "/education/2",
-        publication_state: 'draft'
+        publication_state: 'draft',
+        state_history: {
+          "1" => "draft"
+        }
       }
     )
     @taxon_3 = taxon_with_details(
@@ -27,7 +33,10 @@ RSpec.feature "Taxonomy editing" do
       other_fields: {
         content_id: "ID-3",
         base_path: "/transport/rail",
-        publication_state: 'published'
+        publication_state: 'published',
+        state_history: {
+          "1" => "published"
+        }
       }
     )
     @linkable_taxon_1 = {
@@ -35,21 +44,30 @@ RSpec.feature "Taxonomy editing" do
       content_id: "ID-1",
       base_path: "/education/1",
       internal_name: "School planning",
-      publication_state: 'published'
+      publication_state: 'published',
+      state_history: {
+        "1" => "published"
+      }
     }
     @linkable_taxon_2 = {
       title: "Starting and attending school (draft)",
       content_id: "ID-2",
       base_path: "/education/2",
       internal_name: "Starting and attending school (draft)",
-      publication_state: 'draft'
+      publication_state: 'draft',
+      state_history: {
+        "1" => "draft"
+      }
     }
     @linkable_taxon_3 = {
       title: "Rail",
       content_id: "ID-3",
       base_path: "/transport/rail",
       internal_name: "Rail",
-      publication_state: 'published'
+      publication_state: 'published',
+      state_history: {
+        "1" => "published"
+      }
     }
 
     @dummy_editor_notes = "Some usage notes for this taxon."
@@ -327,6 +345,9 @@ RSpec.feature "Taxonomy editing" do
         publication_state: "published",
         phase: 'live',
         title: "Newly created taxon",
+        state_history: {
+          "1" => "published"
+        }
       }.to_json)
     stub_request(:get, %r{https://publishing-api.test.gov.uk/v2/links/*})
       .to_return(body: {}.to_json)

--- a/spec/features/viewing_taxons_spec.rb
+++ b/spec/features/viewing_taxons_spec.rb
@@ -7,13 +7,52 @@ RSpec.describe "Viewing taxons" do
   let(:fruits) do
     taxon_with_details(
       "Fruits",
-      other_fields: { document_type: "taxon" }
+      other_fields: {
+        document_type: "taxon",
+        state_history: { "1" => "published" },
+      }
     )
   end
-  let(:apples) { taxon_with_details("Apples") }
-  let(:pears) { taxon_with_details("Pears") }
-  let(:oranges) { taxon_with_details("Oranges") }
-  let(:cox) { taxon_with_details("Cox") }
+
+  let(:apples) do
+    taxon_with_details(
+      "Apples",
+      other_fields: {
+        document_type: "taxon",
+        state_history: { "1" => "published" },
+      }
+    )
+  end
+
+  let(:pears) do
+    taxon_with_details(
+      "Pears",
+      other_fields: {
+        document_type: "taxon",
+        state_history: { "1" => "published" },
+      }
+    )
+  end
+
+  let(:oranges) do
+    taxon_with_details(
+      "Oranges",
+      other_fields: {
+        document_type: "taxon",
+        state_history: { "1" => "published" },
+      }
+    )
+  end
+
+  let(:cox) do
+    taxon_with_details(
+      "Cox",
+      other_fields: {
+        document_type: "taxon",
+        state_history: { "1" => "published" },
+      }
+    )
+  end
 
   scenario "Viewing the taxonomy from the homepage" do
     given_a_taxonomy

--- a/spec/features/viewing_taxons_spec.rb
+++ b/spec/features/viewing_taxons_spec.rb
@@ -54,6 +54,19 @@ RSpec.describe "Viewing taxons" do
     )
   end
 
+  let(:previously_published) do
+    taxon_with_details(
+      "Previously published",
+      other_fields: {
+        document_type: "taxon",
+        state_history: {
+          "1" => "published",
+          "2" => "draft"
+        },
+      }
+    )
+  end
+
   scenario "Viewing the taxonomy from the homepage" do
     given_a_taxonomy
     given_im_ignoring_tagged_content_for_now
@@ -99,6 +112,13 @@ RSpec.describe "Viewing taxons" do
     given_email_alert_api_is_inaccessible
     when_i_view_the_lowest_level_taxon
     then_i_do_not_see_the_number_of_email_subscribers
+  end
+
+  scenario "Viewing a previously published taxon" do
+    given_a_previously_published_draft_taxon
+    given_im_ignoring_tagged_content_for_now
+    when_i_view_the_previously_published_draft_taxon
+    then_i_see_links_to_view_topic_pages
   end
 
   def given_a_taxonomy
@@ -149,6 +169,18 @@ RSpec.describe "Viewing taxons" do
       expanded_links: {
         parent_taxons: [fruits],
         associated_taxons: [pears, oranges],
+      }
+    )
+
+    stub_email_requests_for_show_page
+  end
+
+  def given_a_previously_published_draft_taxon
+    publishing_api_has_item(previously_published)
+    publishing_api_has_expanded_links(
+      content_id: previously_published["content_id"],
+      expanded_links: {
+        parent_taxons: [fruits],
       }
     )
 
@@ -227,6 +259,13 @@ RSpec.describe "Viewing taxons" do
     visit taxon_path(cox["content_id"])
   end
 
+  def when_i_view_the_previously_published_draft_taxon
+    stub_request(:get, %r{https://publishing-api.test.gov.uk/v2/expanded-links/fruits})
+      .to_return(status: 200, body: {}.to_json)
+
+    visit taxon_path(previously_published["content_id"])
+  end
+
   def then_i_see_the_entire_taxonomy
     expected_titles = [
       fruits["title"],
@@ -295,5 +334,10 @@ RSpec.describe "Viewing taxons" do
       expect(page).to have_content("Pears")
       expect(page).to have_content("Oranges")
     end
+  end
+
+  def then_i_see_links_to_view_topic_pages
+    expect(page).to have_link("Preview changes on GOV.UK")
+    expect(page).to have_link("View on GOV.UK")
   end
 end

--- a/spec/models/taxon_spec.rb
+++ b/spec/models/taxon_spec.rb
@@ -131,7 +131,8 @@ RSpec.describe Taxon do
 
       @taxon = Taxon.new(
         visible_to_departmental_editors: "true",
-        state_history: state_history
+        state_history: state_history,
+        publication_state: "published"
       )
     end
 
@@ -156,6 +157,43 @@ RSpec.describe Taxon do
       ]
 
       expect(@taxon.lastest_two_publication_states).to eq(expected_states)
+    end
+
+    describe "#draft_and_published_editions_exist?" do
+      it "returns true if a draft taxon has been previously published" do
+        expect(@taxon.draft_and_published_editions_exist?).to eq(true)
+      end
+
+      it "returns false the taxon is published" do
+        state_history = {
+          "4" => "superseded",
+          "5" => "superseded",
+          "2" => "superseded",
+          "3" => "superseded",
+          "6" => "published",
+          "1" => "superseded",
+        }
+
+        taxon = Taxon.new(
+          visible_to_departmental_editors: "true",
+          state_history: state_history,
+          publication_state: "published"
+        )
+        expect(taxon.draft_and_published_editions_exist?).to eq(false)
+      end
+
+      it "returns false if a taxon has never been published" do
+        state_history = {
+          "1" => "draft",
+        }
+
+        taxon = Taxon.new(
+          visible_to_departmental_editors: "true",
+          state_history: state_history,
+          publication_state: "draft"
+        )
+        expect(taxon.draft_and_published_editions_exist?).to eq(false)
+      end
     end
   end
 end

--- a/spec/models/taxon_spec.rb
+++ b/spec/models/taxon_spec.rb
@@ -116,4 +116,46 @@ RSpec.describe Taxon do
       expect(taxon.visible_to_departmental_editors).to be true
     end
   end
+
+  describe "publishing history of taxon" do
+    before do
+      state_history = {
+        "4" => "superseded",
+        "5" => "superseded",
+        "2" => "superseded",
+        "7" => "draft",
+        "3" => "superseded",
+        "6" => "published",
+        "1" => "superseded",
+      }
+
+      @taxon = Taxon.new(
+        visible_to_departmental_editors: "true",
+        state_history: state_history
+      )
+    end
+
+    it "orders state history" do
+      expected_order = %w[
+        superseded
+        superseded
+        superseded
+        superseded
+        superseded
+        published
+        draft
+      ]
+
+      expect(@taxon.ordered_publication_state_history).to eq(expected_order)
+    end
+
+    it "gets the lastest two publication states" do
+      expected_states = %w[
+        published
+        draft
+      ]
+
+      expect(@taxon.lastest_two_publication_states).to eq(expected_states)
+    end
+  end
 end

--- a/spec/services/taxonomy/build_taxon_spec.rb
+++ b/spec/services/taxonomy/build_taxon_spec.rb
@@ -12,6 +12,15 @@ RSpec.describe Taxonomy::BuildTaxon do
         document_type: document_type,
         base_path: '/foo/bar',
         publication_state: 'State',
+        state_history: {
+          "4" => "superseded",
+          "5" => "superseded",
+          "2" => "superseded",
+          "7" => "published",
+          "3" => "superseded",
+          "6" => "superseded",
+          "1" => "superseded"
+        },
         details: {
           internal_name: 'Internal name',
           notes_for_editors: 'Notes for editors',
@@ -58,6 +67,10 @@ RSpec.describe Taxonomy::BuildTaxon do
 
     it 'assigns the publication state correctly' do
       expect(taxon.publication_state).to eq(content[:publication_state])
+    end
+
+    it 'assigns state history correctly' do
+      expect(taxon.state_history).to eq(content[:state_history])
     end
 
     it 'assigns the internal_name correctly' do

--- a/spec/services/taxonomy/show_page_spec.rb
+++ b/spec/services/taxonomy/show_page_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe Taxonomy::ShowPage do
+  describe "#publication_state_name" do
+    it "shows when a taxon is published" do
+      taxon = build(:taxon)
+      show_page = Taxonomy::ShowPage.new(taxon)
+
+      expect(show_page.publication_state_name).to eq("published")
+    end
+
+    it "shows when a taxon is in draft" do
+      taxon = build(:draft_taxon)
+      show_page = Taxonomy::ShowPage.new(taxon)
+
+      expect(show_page.publication_state_name).to eq("draft")
+    end
+  end
+end

--- a/spec/services/taxonomy/show_page_spec.rb
+++ b/spec/services/taxonomy/show_page_spec.rb
@@ -5,15 +5,29 @@ RSpec.describe Taxonomy::ShowPage do
     it "shows when a taxon is published" do
       taxon = build(:taxon)
       show_page = Taxonomy::ShowPage.new(taxon)
+      taxon.state_history = {
+        "1" => "superseded",
+        "2" => "published"
+      }
 
       expect(show_page.publication_state_name).to eq("published")
     end
 
     it "shows when a taxon is in draft" do
       taxon = build(:draft_taxon)
+      taxon.state_history = {
+        "1" => "draft"
+      }
       show_page = Taxonomy::ShowPage.new(taxon)
 
       expect(show_page.publication_state_name).to eq("draft")
+    end
+
+    it "shows when a draft taxon has been previously published" do
+      taxon = build(:previously_published_draft_taxon)
+      show_page = Taxonomy::ShowPage.new(taxon)
+
+      expect(show_page.publication_state_name).to eq("published_with_new_draft")
     end
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/8PzlTDxX

Run `publishing_e2e_tests` against https://github.com/alphagov/publishing-e2e-tests/pull/244

## Motivation

Now that the draft edition can be independently maintained, the properties of the draft and published edition can be different. Currently, if there is a published and draft edition, only the details for the draft taxon are displayed, so it is hard to tell if a published version already exists.

## Changes
### Before
![screenshot-content-tagger integration publishing service gov uk-2018 06 26-12-09-19](https://user-images.githubusercontent.com/5793815/41907793-d0b9a1fa-7939-11e8-9c61-e18ffee7b183.png)

![screenshot-content-tagger integration publishing service gov uk-2018 06 26-12-08-12](https://user-images.githubusercontent.com/5793815/41907729-a4c6e51c-7939-11e8-8414-cd8c0f7943a0.png)

### After
#### New state "published with new draft"
* Shows links to "preview" and "published" topic pages
![screenshot-content-tagger dev gov uk-2018 06 26-11-03-19](https://user-images.githubusercontent.com/5793815/41907524-0f4344a4-7939-11e8-80f6-7d50f4692ba9.png)

#### Existing state "published"
* Only shows link to published topic page
![screenshot-content-tagger dev gov uk-2018 06 26-10-57-03](https://user-images.githubusercontent.com/5793815/41907607-50c155ec-7939-11e8-87de-e7d532ae594a.png)

#### Existing state "draft"
* Only shows link to preview topic page
![screenshot-content-tagger dev gov uk-2018 06 26-10-56-33](https://user-images.githubusercontent.com/5793815/41907666-7a70eb8c-7939-11e8-8998-0f7970c9d87c.png)
