### PR TITLE
Handle unpublishing taxons without content

### DIFF
--- a/app/services/taxonomy/taxon_unpublisher.rb
+++ b/app/services/taxonomy/taxon_unpublisher.rb
@@ -16,10 +16,12 @@ module Taxonomy
     def tag_to_parent(taxon_content_id, user)
       parent_taxon = Taxonomy::TaxonomyQuery.new.parent(taxon_content_id)
       return if parent_taxon.nil?
+      content_base_paths = tagged_content_base_paths(taxon_content_id)
+      return unless content_base_paths.present?
       tag_migration = BulkTagging::BuildTagMigration.call(
         source_content_item: ContentItem.find!(taxon_content_id),
         taxon_content_ids: [parent_taxon['content_id']],
-        content_base_paths: tagged_content_base_paths(taxon_content_id)
+        content_base_paths: content_base_paths
       )
       tag_migration.save!
       BulkTagging::QueueLinksForPublishing.call(tag_migration, user: user)

--- a/spec/services/taxonomy/taxon_unpublisher_spec.rb
+++ b/spec/services/taxonomy/taxon_unpublisher_spec.rb
@@ -18,46 +18,73 @@ RSpec.describe Taxonomy::TaxonUnpublisher do
 
     # link parent taxon to child taxon
     publishing_api_has_expanded_links(expanded_links(taxon_content_id, parent_taxon_content_id))
-
-    # content items are tagged to child taxon
-    publishing_api_has_linked_items(
-      [{ 'base_path' => '/base/path1' },
-       { 'base_path' => '/base/path2' }],
-      content_id: taxon_content_id,
-      link_type: 'taxons',
-      fields: ['base_path']
-    )
-    publishing_api_has_lookups('/base/path1' => tagged_content_id1, '/base/path2' => tagged_content_id2)
-
-    # each content item has links to child taxon
-    publishing_api_has_links(content_id: tagged_content_id1, links: { taxons: [taxon_content_id] }, version: version)
-    publishing_api_has_links(content_id: tagged_content_id2, links: { taxons: [taxon_content_id] }, version: version)
-
     stub_any_publishing_api_unpublish
   end
 
-  it 'unpublishes a level one taxon with a redirect' do
-    publishing_api_has_expanded_links('content_id' => taxon_content_id, 'expanded_links' => {})
-    unpublish(taxon_content_id, redirect_content_id)
-    assert_publishing_api_unpublish(taxon_content_id, type: 'redirect', alternative_path: '/path/to/redirect')
+  context 'the taxon is not tagged to any content items' do
+    before :each do
+      # no content items are tagged to child taxon
+      publishing_api_has_linked_items(
+        [],
+        content_id: taxon_content_id,
+        link_type: 'taxons',
+        fields: ['base_path']
+      )
+    end
+    it 'does not perform a tag migration' do
+      expect(BulkTagging::BuildTagMigration).to receive(:call).never
+      unpublish(taxon_content_id, redirect_content_id)
+    end
   end
 
-  describe 'tag to parent' do
+  context 'the taxon is tagged to two content items' do
     before :each do
-      stub_any_publishing_api_unpublish
-    end
-    it 'retags content to the parent' do
-      patch_request1 = stub_publishing_api_patch_links(tagged_content_id1, hash_including(links: { taxons: [taxon_content_id, parent_taxon_content_id] }, previous_version: version))
-      patch_request2 = stub_publishing_api_patch_links(tagged_content_id2, hash_including(links: { taxons: [taxon_content_id, parent_taxon_content_id] }, previous_version: version))
-      unpublish(taxon_content_id, redirect_content_id)
-      expect(patch_request1).to have_been_made
-      expect(patch_request2).to have_been_made
+      # content items are tagged to child taxon
+      publishing_api_has_linked_items(
+        [{ 'base_path' => '/base/path1' },
+         { 'base_path' => '/base/path2' }],
+        content_id: taxon_content_id,
+        link_type: 'taxons',
+        fields: ['base_path']
+      )
+      publishing_api_has_lookups('/base/path1' => tagged_content_id1, '/base/path2' => tagged_content_id2)
+
+      # each content item has links to child taxon
+      publishing_api_has_links(content_id: tagged_content_id1, links: { taxons: [taxon_content_id] }, version: version)
+      publishing_api_has_links(content_id: tagged_content_id2, links: { taxons: [taxon_content_id] }, version: version)
     end
 
-    it 'does not retag content' do
-      patch_request = stub_any_publishing_api_patch_links
-      unpublish(taxon_content_id, redirect_content_id, false)
-      expect(patch_request).to_not have_been_made
+    it 'unpublishes a level one taxon with a redirect' do
+      publishing_api_has_expanded_links('content_id' => taxon_content_id, 'expanded_links' => {})
+      unpublish(taxon_content_id, redirect_content_id)
+      assert_publishing_api_unpublish(taxon_content_id, type: 'redirect', alternative_path: '/path/to/redirect')
+    end
+
+    describe 'tag to parent' do
+      before :each do
+        stub_any_publishing_api_unpublish
+      end
+      it 'retags content to the parent' do
+        patch_request1 = stub_publishing_api_patch_links(tagged_content_id1, hash_including(links: { taxons: [taxon_content_id, parent_taxon_content_id] }, previous_version: version))
+        patch_request2 = stub_publishing_api_patch_links(tagged_content_id2, hash_including(links: { taxons: [taxon_content_id, parent_taxon_content_id] }, previous_version: version))
+        unpublish(taxon_content_id, redirect_content_id)
+        expect(patch_request1).to have_been_made
+        expect(patch_request2).to have_been_made
+      end
+
+      it 'retags content to the parent' do
+        patch_request1 = stub_publishing_api_patch_links(tagged_content_id1, hash_including(links: { taxons: [taxon_content_id, parent_taxon_content_id] }, previous_version: version))
+        patch_request2 = stub_publishing_api_patch_links(tagged_content_id2, hash_including(links: { taxons: [taxon_content_id, parent_taxon_content_id] }, previous_version: version))
+        unpublish(taxon_content_id, redirect_content_id)
+        expect(patch_request1).to have_been_made
+        expect(patch_request2).to have_been_made
+      end
+
+      it 'does not retag content' do
+        patch_request = stub_any_publishing_api_patch_links
+        unpublish(taxon_content_id, redirect_content_id, false)
+        expect(patch_request).to_not have_been_made
+      end
     end
   end
 


### PR DESCRIPTION
Previously, unpublishing a taxon without any associated content
would raise an exception which would show up in Sentry.

This handles this case and prevents the error from being raised.

Trello: https://trello.com/c/qS25zZcO/172-fix-unpublishing-taxons-where-there-is-no-content-to-untag

See Also: https://trello.com/c/YrANYCMo/126-improve-the-unpublish-feature-in-content-tagger-to-also-handle-content