### PR TITLE
Send superfluous tagging counts to statsd

### DIFF
--- a/app/services/metrics/superfluous_taggins_metrics.rb
+++ b/app/services/metrics/superfluous_taggins_metrics.rb
@@ -1,0 +1,18 @@
+require_relative '../metrics'
+
+module Metrics
+  class SuperfluousTagginsMetrics
+    def count
+      sum = Tagging::CommonAncestorFinder.call.sum do |ca_result|
+        ca_result[:common_ancestors].count
+      end
+      gauge("superfluous_tagging_count", sum)
+    end
+
+  private
+
+    def gauge(stat, value)
+      Metrics.statsd.gauge(stat, value)
+    end
+  end
+end

--- a/lib/tasks/taxonomy_metrics.rake
+++ b/lib/tasks/taxonomy_metrics.rake
@@ -23,11 +23,19 @@ namespace :metrics do
       Metrics::TaxonsPerLevelMetrics.new.count_taxons_per_level
     end
 
+    desc "Record number of superfluous taggings"
+    task record_number_of_superfluous_taggins_metrics: :environment do
+      Statsd.logger = Logger.new(STDOUT)
+
+      Metrics::SuperfluousTagginsMetrics.new.count
+    end
+
     desc "Record all metrics about the Topic Taxonomy"
     task record_all: %i[
       count_content_per_level
       record_taxons_per_level_metrics
       record_content_coverage_metrics
+      record_number_of_superfluous_taggins_metrics
     ]
   end
 end

--- a/spec/services/metrics/superfluous_taggings_metrics_spec.rb
+++ b/spec/services/metrics/superfluous_taggings_metrics_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+module Metrics
+  RSpec.describe ContentCoverageMetrics do
+    describe '#count' do
+      it "sends the correct values to statsd" do
+        allow(Tagging::CommonAncestorFinder).to receive(:call)
+                                         .and_return([{ content_id: 'id1', title: 'title1', common_ancestors: [1, 2] },
+                                                      { content_id: 'id2', title: 'title2', common_ancestors: [3] }])
+
+        allow(Metrics.statsd).to receive(:gauge)
+
+        Metrics::SuperfluousTagginsMetrics.new.count
+
+        expect(Metrics.statsd).to have_received(:gauge)
+                                    .with("superfluous_tagging_count", 3)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds a rake task: 

> record_number_of_superfluous_taggins_metrics

 that sends the number of superfluous taggings to statsd for visualisation
in Grafana

Trello: https://trello.com/c/VOLclckO/156-start-tracking-the-number-of-superfluous-tags-to-the-topic-taxonomy