### PR TITLE
Metric fixes

### DIFF
--- a/app/services/metrics/superfluous_taggings_metrics.rb
+++ b/app/services/metrics/superfluous_taggings_metrics.rb
@@ -1,7 +1,7 @@
 require_relative '../metrics'
 
 module Metrics
-  class SuperfluousTagginsMetrics
+  class SuperfluousTaggingsMetrics
     def count
       sum = Tagging::CommonAncestorFinder.call.sum do |ca_result|
         ca_result[:common_ancestors].count

--- a/app/services/tagging/common_ancestor_finder.rb
+++ b/app/services/tagging/common_ancestor_finder.rb
@@ -21,7 +21,7 @@ module Tagging
         rescue GdsApi::HTTPNotFound
           puts("Cannot find content with id: #{content_id}")
           {}
-        rescue GdsApi::HTTPGatewayTimeout
+        rescue GdsApi::HTTPGatewayTimeout, GdsApi::TimedOutException
           retries ||= 0
           raise if retries >= 3
           retries += 1

--- a/lib/tasks/taxonomy_metrics.rake
+++ b/lib/tasks/taxonomy_metrics.rake
@@ -24,10 +24,10 @@ namespace :metrics do
     end
 
     desc "Record number of superfluous taggings"
-    task record_number_of_superfluous_taggins_metrics: :environment do
+    task record_number_of_superfluous_taggings_metrics: :environment do
       Statsd.logger = Logger.new(STDOUT)
 
-      Metrics::SuperfluousTagginsMetrics.new.count
+      Metrics::SuperfluousTaggingsMetrics.new.count
     end
 
     desc "Record all metrics about the Topic Taxonomy"

--- a/lib/tasks/taxonomy_metrics.rake
+++ b/lib/tasks/taxonomy_metrics.rake
@@ -35,7 +35,6 @@ namespace :metrics do
       count_content_per_level
       record_taxons_per_level_metrics
       record_content_coverage_metrics
-      record_number_of_superfluous_taggins_metrics
     ]
   end
 end

--- a/spec/services/metrics/superfluous_taggings_metrics_spec.rb
+++ b/spec/services/metrics/superfluous_taggings_metrics_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 module Metrics
-  RSpec.describe ContentCoverageMetrics do
+  RSpec.describe SuperfluousTaggingsMetrics do
     describe '#count' do
       it "sends the correct values to statsd" do
         allow(Tagging::CommonAncestorFinder).to receive(:call)
@@ -10,7 +10,7 @@ module Metrics
 
         allow(Metrics.statsd).to receive(:gauge)
 
-        Metrics::SuperfluousTagginsMetrics.new.count
+        Metrics::SuperfluousTaggingsMetrics.new.count
 
         expect(Metrics.statsd).to have_received(:gauge)
                                     .with("superfluous_tagging_count", 3)


### PR DESCRIPTION
- remove superfluous taggings metrics from the metrics rake tasks because it takes too long to compute
- Allow for timeouts when computing superfluous taggings 