### PR TITLE
Sanitize sql query

### DIFF
--- a/app/models/project_content_item.rb
+++ b/app/models/project_content_item.rb
@@ -28,7 +28,7 @@ class ProjectContentItem < ActiveRecord::Base
   scope :for_taxonomy_branch, (lambda do |branch_id|
     joins(:project).where("projects.taxonomy_branch = ?", branch_id)
   end)
-  scope :matching_search, ->(query) { where("title ILIKE ?", "%#{query}%") }
+  scope :matching_search, ->(query) { where("title ILIKE ?", "%#{sanitize_sql_like(query)}%") }
   scope :todo, -> { where(flag: nil, done: false) }
   scope :with_valid_ids, -> { where.not(content_id: nil) }
 end


### PR DESCRIPTION
Trello: https://trello.com/c/VUhn4ael

## Motivation

The `LIKE` query on the Projects page isn't sanitized.

The hash query notation is fine for most cases, but it doesn't escape `%` characters and injected `%`s can be used for building slow queries for DDOS attacks.

See: https://rorsecurity.info/portfolio/rails-sql-injection-like
