### PR TITLE
Make the user UID available on the tagging history page

### DIFF
--- a/app/views/tagging_history/index.html.erb
+++ b/app/views/tagging_history/index.html.erb
@@ -46,7 +46,9 @@
             <%= link_change[:user_name] %>
             (<%= link_change[:organisation] || "No organisation" %>)
           <% else %>
-            <em>Unknown user</em>
+            <em>
+              Unknown user <!-- UID: <%= link_change[:user_uid] %> -->
+            </em>
           <% end %>
         </td>
       </tr>

--- a/app/views/tagging_history/show.html.erb
+++ b/app/views/tagging_history/show.html.erb
@@ -48,7 +48,9 @@
             <%= link_change[:user_name] %>
             (<%= link_change[:organisation] || "No organisation" %>)
           <% else %>
-            <em>Unknown user</em>
+            <em>
+              Unknown user <!-- UID: <%= link_change[:user_uid] %> -->
+            </em>
           <% end %>
         </td>
       </tr>


### PR DESCRIPTION
Currently, the user details only show if that user has signed in to
Content Tagger. This should be fixable in the future by fetching the
data from Signon, but for now, just put the UID in the HTML as a
comment.