### PR TITLE
Rescue bad gateway in common ancestor finder

### DIFF
--- a/app/services/tagging/common_ancestor_finder.rb
+++ b/app/services/tagging/common_ancestor_finder.rb
@@ -21,7 +21,7 @@ module Tagging
         rescue GdsApi::HTTPNotFound
           puts("Cannot find content with id: #{content_id}")
           {}
-        rescue GdsApi::HTTPGatewayTimeout, GdsApi::TimedOutException
+        rescue GdsApi::HTTPGatewayTimeout, GdsApi::TimedOutException, GdsApi::HTTPBadGateway
           retries ||= 0
           raise if retries >= 3
           retries += 1


### PR DESCRIPTION
On production GdsApi::HTTPBadGateway is sometimes thrown and
should be retried.