### PR TITLE
Make bulk tagging lower priority than content publishing

### DIFF
--- a/app/services/bulk_tagging/publish_links.rb
+++ b/app/services/bulk_tagging/publish_links.rb
@@ -14,7 +14,8 @@ module BulkTagging
       Services.publishing_api.patch_links(
         tag_mapping.content_id,
         links: updated_links,
-        previous_version: previous_version
+        previous_version: previous_version,
+        bulk_publishing: true,
       )
     end
 

--- a/spec/features/bulk_tagging_spec.rb
+++ b/spec/features/bulk_tagging_spec.rb
@@ -276,6 +276,7 @@ RSpec.feature "Bulk tagging", type: :feature do
       links: {
         taxons: [tag_mapping.link_content_id]
       },
+      bulk_publishing: true,
       previous_version: 0
     )
   end

--- a/spec/features/bulk_tagging_spec.rb
+++ b/spec/features/bulk_tagging_spec.rb
@@ -167,19 +167,23 @@ RSpec.feature "Bulk tagging", type: :feature do
     )
     stub_publishing_api_patch_links(
       "tax-doc-1",
-      links: { taxons: ["taxon-1"] }
+      links: { taxons: ["taxon-1"] },
+      bulk_publishing: true,
     )
     stub_publishing_api_patch_links(
       "tax-doc-1",
-      links: { taxons: ["taxon-2"] }
+      links: { taxons: ["taxon-2"] },
+      bulk_publishing: true,
     )
     stub_publishing_api_patch_links(
       "tax-doc-2",
-      links: { taxons: ["taxon-1"] }
+      links: { taxons: ["taxon-1"] },
+      bulk_publishing: true,
     )
     stub_publishing_api_patch_links(
       "tax-doc-2",
-      links: { taxons: ["taxon-2"] }
+      links: { taxons: ["taxon-2"] },
+      bulk_publishing: true,
     )
 
     Sidekiq::Testing.inline!

--- a/spec/features/delete_taxon_spec.rb
+++ b/spec/features/delete_taxon_spec.rb
@@ -327,7 +327,8 @@ RSpec.feature "Delete Taxon", type: :feature do
     @patch_links_request = stub_publishing_api_patch_links(
       'tagged-content',
       links: { taxons: [@taxon_content_id, @parent_taxon_content_id] },
-      previous_version: 10
+      previous_version: 10,
+      bulk_publishing: true,
     )
   end
 end

--- a/spec/features/move_content_between_taxons_spec.rb
+++ b/spec/features/move_content_between_taxons_spec.rb
@@ -202,7 +202,8 @@ private
     stub_publishing_api_patch_links(
       document[:content_id],
       links: { taxons: [dest[:content_id]] },
-      previous_version: 1
+      previous_version: 1,
+      bulk_publishing: true,
     )
   end
 end

--- a/spec/features/tag_importer_spec.rb
+++ b/spec/features/tag_importer_spec.rb
@@ -174,13 +174,15 @@ RSpec.feature "Tag importer", type: :feature do
       "content-1-cid",
       links: {
         taxons: ["education-content-id"],
-      }
+      },
+      bulk_publishing: true,
     )
     link_update_2 = stub_publishing_api_patch_links(
       "content-2-cid",
       links: {
         taxons: ["early-years-content-id"],
-      }
+      },
+      bulk_publishing: true,
     )
     taxon_1 = { title: 'Early Years', content_id: 'early-years-content-id' }
     taxon_2 = { title: 'Education', content_id: 'education-content-id' }
@@ -200,7 +202,8 @@ RSpec.feature "Tag importer", type: :feature do
       "content-1-cid",
       links: {
         taxons: ["education-content-id"],
-      }
+      },
+      bulk_publishing: true,
     )
 
     taxon_1 = { title: 'Early Years', content_id: 'early-years-content-id' }

--- a/spec/services/bulk_tagging/publish_links_spec.rb
+++ b/spec/services/bulk_tagging/publish_links_spec.rb
@@ -28,7 +28,8 @@ module BulkTagging
         expect(Services.publishing_api).to have_received(:patch_links).with(
           tag_mapping.content_id,
           links: { 'taxons' => ['existing-content-id', tag_mapping.link_content_id] },
-          previous_version: 10
+          previous_version: 10,
+          bulk_publishing: true,
         )
       end
 
@@ -44,7 +45,8 @@ module BulkTagging
         expect(Services.publishing_api).to have_received(:patch_links).with(
           tag_mapping.content_id,
           links: { 'taxons' => [tag_mapping.link_content_id] },
-          previous_version: 10
+          previous_version: 10,
+          bulk_publishing: true,
         )
       end
 
@@ -60,7 +62,8 @@ module BulkTagging
         expect(Services.publishing_api).to have_received(:patch_links).with(
           tag_mapping.content_id,
           links: { tag_mapping.link_type => [tag_mapping.link_content_id] },
-          previous_version: 10
+          previous_version: 10,
+          bulk_publishing: true,
         )
       end
 
@@ -80,7 +83,8 @@ module BulkTagging
         expect(Services.publishing_api).to have_received(:patch_links).with(
           tag_mapping.content_id,
           links: { tag_mapping.link_type => [tag_mapping.link_content_id] },
-          previous_version: 10
+          previous_version: 10,
+          bulk_publishing: true,
         )
       end
     end


### PR DESCRIPTION
When we bulk tag things, we can set a `bulk_publishing` flag on the call to the Publishing API's Patch Links method. This makes Publishing API treat this action as lower priority and put it on the correct internal queue (`downstream_low`). We should always do this for bulk retagging due to the potential volumes involved. If a large bulk retagging was to be given a high priority, it would delay real time publishing, including travel advice and drug safety alerts.