### PR TITLE
Count content-tags per organisation in the taxonomy

### DIFF
--- a/app/services/taxonomy/organisation_count.rb
+++ b/app/services/taxonomy/organisation_count.rb
@@ -1,0 +1,55 @@
+module Taxonomy
+  class OrganisationCount
+    def all_taggings_per_organisation
+      level_one_taxons = taxonomy_query.level_one_taxons
+      level_one_taxons.map do |level_one_taxon|
+        { title: level_one_taxon['title'], sheet: taggings_per_organisation(level_one_taxon) }
+      end
+    end
+
+  private
+
+    def headers
+      %w[organisation total taxon_base_path_1 taxon_count_1 taxon_base_path_2 taxon_count_2]
+    end
+
+    def taggings_per_organisation(level_one_taxon)
+      taxons_in_branch = child_taxons(level_one_taxon)
+      results_per_organisation = tagging_count_per_organisation(taxons_in_branch)
+      results_per_organisation.each_with_object([headers]) do |(organisation, countings), sheet|
+        total_count = countings.sum { |(count, _)| count }
+        row = [organisation, total_count]
+        countings.sort_by { |(count, _)| -count }.each_with_object(row) do |(count, base_path), result_row|
+          result_row << base_path << count
+        end
+        sheet << row
+      end
+    end
+
+    # {organisation -> [count, base_path]}
+    def tagging_count_per_organisation(taxons)
+      taxons.each_with_object(Hash.new { |h, k| h[k] = [] }) do |taxon, result|
+        tagging_count_per_organisation_for_taxon(taxon).each do |organisation, count|
+          result[organisation] << [count, taxon['base_path']]
+        end
+      end
+    end
+
+    def tagging_count_per_organisation_for_taxon(taxon)
+      rummager_result = Services.rummager.search(aggregate_primary_publishing_organisation: 100_000, count: 0, filter_taxons: [taxon['content_id']])
+      rummager_result
+        .dig('aggregates', 'primary_publishing_organisation', 'options')
+        .each_with_object({}) do |result, total|
+        total[result.dig('value', 'slug')] = result['documents']
+      end
+    end
+
+    def child_taxons(level_one_taxon)
+      taxonomy_query.child_taxons(level_one_taxon['base_path']) << level_one_taxon
+    end
+
+    def taxonomy_query
+      @taxonomy_query ||= Taxonomy::TaxonomyQuery.new(%i[base_path content_id title])
+    end
+  end
+end

--- a/lib/tasks/taxonomy/tags_per_organisation.rake
+++ b/lib/tasks/taxonomy/tags_per_organisation.rake
@@ -1,0 +1,19 @@
+require 'csv'
+require_relative Rails.root.join('lib', 'tagged_content_exporter')
+
+namespace :taxonomy do
+  desc <<-DESC
+    saves the number of tags to taxons per organisation in a set of CSV files.
+  DESC
+  task :tags_per_organisation, %i[path] => :environment do |_, args|
+    path = args[:path]
+    FileUtils.mkdir_p path
+    Taxonomy::OrganisationCount.new.all_taggings_per_organisation.each do |result|
+      csv_file_path = "#{path}/#{result[:title].parameterize}.csv"
+      puts csv_file_path
+      CSV.open(csv_file_path, "wb") do |csv|
+        result[:sheet].each { |row| csv << row }
+      end
+    end
+  end
+end

--- a/spec/services/taxonomy/organisation_count_spec.rb
+++ b/spec/services/taxonomy/organisation_count_spec.rb
@@ -1,0 +1,89 @@
+require 'rails_helper'
+require 'gds_api/test_helpers/rummager'
+require 'gds_api/test_helpers/content_store'
+
+include ::GdsApi::TestHelpers::Rummager
+include ::GdsApi::TestHelpers::ContentStore
+
+RSpec.describe Taxonomy::OrganisationCount do
+  describe "#organisation_counts" do
+    let(:taxon_ids) { [SecureRandom.uuid, SecureRandom.uuid] }
+
+    before :each do
+      content_store_has_item('/', level_one_taxons.to_json, draft: true)
+      content_store_has_item('/taxons/level_one', single_level_child_taxons.to_json, draft: true)
+      stub_rummager({ 'aggregate_primary_publishing_organisation' => %r{\d+},  'filter_taxons' => [taxon_ids.first] },
+                    rummager_body([{ slug: 'organisation1', count: 1 },
+                                   { slug: 'organisation2', count: 2 },
+                                   { slug: 'organisation3', count: 3 }]))
+      stub_rummager({ 'aggregate_primary_publishing_organisation' => %r{\d+},  'filter_taxons' => [taxon_ids.second] },
+                    rummager_body([{ slug: 'organisation2', count: 4 },
+                                   { slug: 'organisation1', count: 5 }]))
+    end
+
+    it 'counts all tags to taxons per organisation' do
+      results = Taxonomy::OrganisationCount.new.all_taggings_per_organisation
+      sheet = results.first[:sheet]
+      expected_results = [['organisation1', 6, '/taxons/child', 5, '/taxons/level_one', 1],
+                          ['organisation2', 6, '/taxons/child', 4, '/taxons/level_one', 2],
+                          ['organisation3', 3, '/taxons/level_one', 3]]
+      expect(sheet[1..-1]).to match_array(expected_results)
+      expect(results.first[:title]).to eq('taxon_title')
+    end
+
+    def rummager_body(slug_counts)
+      {
+        'aggregates' => {
+          'primary_publishing_organisation' => {
+            'options' => slug_counts.map do |slug_count|
+              {
+                'value' => {
+                  'slug' => slug_count[:slug],
+                },
+                'documents' => slug_count[:count]
+              }
+            end
+          }
+        }
+      }
+    end
+
+    def stub_rummager(query_hash, json_body)
+      stub_request(:get, Regexp.new(Plek.new.find('rummager')))
+        .with(query: hash_including(query_hash))
+        .to_return(body: json_body.to_json)
+    end
+
+    def single_level_child_taxons
+      {
+        'base_path' => '/taxons/level_one',
+        'content_id' => taxon_ids.first,
+        'links' => {
+          'child_taxons' => [
+            {
+              'base_path' => '/taxons/child',
+              'content_id' => taxon_ids.second,
+              'links' => {}
+            }
+          ]
+        }
+      }
+    end
+
+    def level_one_taxons
+      {
+        'base_path' => '/',
+        'content_id' => 'hhhh',
+        'links' => {
+          'level_one_taxons' => [
+            {
+              'base_path' => '/taxons/level_one',
+              'content_id' => taxon_ids.first,
+              'title' => 'taxon_title'
+            }
+          ],
+        }
+      }
+    end
+  end
+end


### PR DESCRIPTION
Adds a rake task 'taxonomy:tags_per_organisation[path]' that
creates one csv file per branch of the taxonomy. In each spreadsheet
all organisations tagging to taxons within that branch are listed
together with the number of documents tagged to these taxons.


organisation | total | taxon_base_path_1 | taxon_count_1 | taxon_base_path_2 | taxon_count_2 |  
-- | -- | -- | -- | -- | -- | --
government-digital-service | 158 | /crime-justice-and-law/courts-sentencing-tribunals | 48 | /crime-justice-and-law/reporting-crimes-compensation | 37 | /crime-justice-and-law/rights
ministry-of-justice | 2184 | /crime-justice-and-law | 719 | /crime-justice-and-law/justice-system-transparency | 612 | /crime-justice-and-law/reoffending-and-rehabilitation

