### PR TITLE
Add fields for the tagged content csv download

### DIFF
--- a/app/services/taxonomy/taxonomy_export.rb
+++ b/app/services/taxonomy/taxonomy_export.rb
@@ -2,7 +2,9 @@ require 'csv'
 
 module Taxonomy
   class TaxonomyExport
-    COLUMNS = %w[title description content_id base_path document_type].freeze
+    COLUMNS = %w[
+      title description content_id base_path document_type first_published_at public_updated_at
+    ].freeze
 
     def initialize(content_id)
       @content_id = content_id

--- a/app/services/taxonomy/taxonomy_export.rb
+++ b/app/services/taxonomy/taxonomy_export.rb
@@ -3,8 +3,16 @@ require 'csv'
 module Taxonomy
   class TaxonomyExport
     COLUMNS = %w[
-      title description content_id base_path document_type first_published_at public_updated_at
+      title
+      description
+      content_id
+      base_path
+      document_type
+      first_published_at
+      public_updated_at
     ].freeze
+
+    CSV_COLUMNS = COLUMNS + ['primary_publishing_organisation']
 
     def initialize(content_id)
       @content_id = content_id
@@ -12,9 +20,9 @@ module Taxonomy
 
     def to_csv
       CSV.generate(headers: true) do |csv|
-        csv << COLUMNS
+        csv << CSV_COLUMNS
         tagged_content.each do |tagged_item|
-          csv << tagged_item.slice(*COLUMNS)
+          csv << tagged_item.slice(*CSV_COLUMNS)
         end
       end
     end
@@ -22,11 +30,60 @@ module Taxonomy
   private
 
     def tagged_content
-      Services.publishing_api.get_linked_items(
+      linked_items.map do |item|
+        add_primary_publishing_organisation(item)
+      end
+    end
+
+    def add_primary_publishing_organisation(item)
+      item.merge('primary_publishing_organisation' => primary_publishing_organisation_name(item['content_id']))
+    end
+
+    def linked_items
+      @linked_items ||= Services.publishing_api.get_linked_items(
         @content_id,
         link_type: 'taxons',
         fields: COLUMNS
       )
+    end
+
+    def tagged_content_ids
+      linked_items.map do |content_item|
+        content_item['content_id']
+      end
+    end
+
+    def links_for_tagged_content_ids
+      links_for_content = {}
+      tagged_content_ids.each_slice(1000) do |batch_content_ids|
+        links_for_content.merge!(Services.publishing_api.get_links_for_content_ids(batch_content_ids).to_h)
+      end
+      links_for_content
+    end
+
+    def primary_organisation_ids
+      links_for_tagged_content_ids.each_with_object({}) do |(content_id, links), result|
+        result[content_id] = links.dig('links', 'primary_publishing_organisation', 0)
+      end
+    end
+
+    def primary_publishing_organisation_name(id)
+      @tagged_content_organisation_names_cache ||= primary_organisation_ids.compact.each_with_object({}) do |(content_id, publishing_org_id), result|
+        result[content_id] = organisations_cache[publishing_org_id]
+      end
+      @tagged_content_organisation_names_cache[id]
+    end
+
+    def all_organisations
+      Services.publishing_api.get_content_items_enum(
+        document_type: 'organisation',
+        fields: %w[content_id title],
+        per_page: 600
+      )
+    end
+
+    def organisations_cache
+      @organisations_cache ||= Hash[all_organisations.map { |org| [org['content_id'], org['title']] }]
     end
   end
 end

--- a/spec/features/download_tagged_content_spec.rb
+++ b/spec/features/download_tagged_content_spec.rb
@@ -48,8 +48,8 @@ RSpec.feature "Download taggings", type: :feature do
 
   def then_i_should_receive_a_csv_with_tagged_content
     expect(page.body).to eql <<~DOC
-      title,description,content_id,base_path,document_type
-      tagged content,,tagged-content,/level-one/tagged-content,guidance
+      title,description,content_id,base_path,document_type,first_published_at,public_updated_at
+      tagged content,,tagged-content,/level-one/tagged-content,guidance,,
     DOC
   end
 end


### PR DESCRIPTION
Add fields when downloading a csv for pages tagged to a taxon.

Trello;
https://trello.com/c/E1wPjCRo/51-add-first-published-last-updated-and-published-by-fields-to-view-tagged-content-view-and-download-csv-of-tagged-content