### PR TITLE
Add task to remove descriptions from certain branches

### DIFF
--- a/lib/description_remover.rb
+++ b/lib/description_remover.rb
@@ -1,0 +1,51 @@
+class DescriptionRemover
+  def initialize(base_path)
+    @base_path = base_path
+  end
+
+  def self.call(*args)
+    new(*args).call
+  end
+
+  def call
+    taxon_ids = child_taxon_ids(base_path)
+    taxons_with_no_draft = published_taxons_with_no_drafts(taxons(taxon_ids))
+
+    clear_descriptions(taxons_with_no_draft)
+  end
+
+private
+
+  attr_reader :base_path
+  EXCLUDE_ATTRIBUTES = %w[content_store user_facing_version publication_state lock_version updated_at state_history].freeze
+
+  def child_taxon_ids(base_path)
+    Taxonomy::TaxonomyQuery.new.child_taxons(base_path).pluck('content_id')
+  end
+
+  def taxons(taxon_ids)
+    taxon_ids.map do |id|
+      Services.publishing_api.get_content(id).to_h
+    end
+  end
+
+  def published_taxons_with_no_drafts(taxons)
+    taxons.reject do |taxon|
+      taxon['state_history'].values.include?('draft')
+    end
+  end
+
+  def clear_descriptions(taxons_with_no_draft)
+    taxons_with_no_draft.each do |taxon|
+      content_id = taxon['content_id']
+      payload = taxon.except(*EXCLUDE_ATTRIBUTES).merge(
+        'description' => nil,
+        'update_type' => 'minor'
+      )
+
+      Services.publishing_api.put_content(content_id, payload)
+      Services.publishing_api.publish(content_id)
+      puts "Description cleared for taxon: #{taxon['title']}"
+    end
+  end
+end

--- a/lib/tasks/taxonomy/clear_descriptions.rake
+++ b/lib/tasks/taxonomy/clear_descriptions.rake
@@ -1,9 +1,18 @@
 require 'taxon_description_updater'
+require 'description_remover'
+
 namespace :taxonomy do
   desc <<-DESC
     Clears all descriptions containing '...' or 'tbc'.
   DESC
   task clear_descriptions: [:environment] do
     TaxonDescriptionUpdater.new(%w[... tbc TBC ...tbc]).call
+  end
+
+  desc <<-DESC
+    Clears description from taxons children recursively.
+  DESC
+  task :clear_descriptions_for_branches, [:base_path] => [:environment] do |_, args|
+    DescriptionRemover.call(args[:base_path])
   end
 end

--- a/spec/lib/description_remover_spec.rb
+++ b/spec/lib/description_remover_spec.rb
@@ -1,0 +1,125 @@
+require 'rails_helper'
+require 'description_remover'
+require 'gds_api/test_helpers/content_store'
+
+include ::GdsApi::TestHelpers::ContentStore
+include ::GdsApi::TestHelpers::PublishingApiV2
+
+RSpec.describe DescriptionRemover do
+  context "appropriate taxons are updated" do
+    before do
+      content_store_has_item("/work", taxon.to_json, draft: true)
+      publishing_api_has_item(published_child_taxon)
+      publishing_api_has_item(published_child_taxon_with_draft)
+      publishing_api_has_item(draft_taxon)
+
+      stub_any_publishing_api_put_content
+      stub_any_publishing_api_publish
+
+      DescriptionRemover.call("/work")
+    end
+
+    it "asserts taxon has draft saved and published" do
+      assert_put_content("pub-taxon", content_id: "pub-taxon", title: "taxon-a", phase: "live", base_path: "/work/taxon_a")
+      assert_publishing_api_publish("pub-taxon")
+    end
+
+    it "asserts taxon is not saved or published as it has a draft" do
+      assert_no_put_content("pub-and-draft-taxon")
+      assert_no_publish("pub-and-draft-taxon")
+    end
+
+    it "asserts taxon is not published as it is only a draft" do
+      assert_no_put_content("draft-taxon")
+      assert_no_publish("draft-taxon")
+    end
+  end
+
+  def taxon
+    {
+      "base_path" => "/work",
+      "content_id" => "rrrr",
+      "links" => {
+        "child_taxons" => [
+          published_child_taxon,
+          published_child_taxon_with_draft,
+          draft_taxon,
+        ]
+      }
+    }
+  end
+
+  def published_child_taxon
+    {
+      'schema_name' => 'taxon',
+      'content_store' => 'live',
+      'user_facing_version' => "4",
+      'publication_state' => 'published',
+      'lock_version' => "3",
+      'updated_at' => Time.now,
+      'phase' => 'live',
+      "title" => "taxon-a",
+      "description" => "taxons-a-description",
+      "base_path" => "/work/taxon_a",
+      "content_id" => "pub-taxon",
+      "state_history" => {
+        "1" => "superseded",
+        "2" => "published"
+      }
+    }
+  end
+
+  def published_child_taxon_with_draft
+    {
+      'schema_name' => 'taxon',
+      'content_store' => 'live',
+      'user_facing_version' => "4",
+      'publication_state' => 'published',
+      'lock_version' => "3",
+      'updated_at' => Time.now,
+      'phase' => 'live',
+      "title" => "taxon-b",
+      "base_path" => "/work/taxon_b",
+      "content_id" => "pub-and-draft-taxon",
+      "state_history" => {
+        "1" => "published",
+        "2" => "draft"
+      }
+    }
+  end
+
+  def draft_taxon
+    {
+      'schema_name' => 'taxon',
+      'content_store' => 'draft',
+      'user_facing_version' => "4",
+      'publication_state' => 'draft',
+      'lock_version' => "3",
+      'updated_at' => Time.now,
+      'phase' => 'live',
+      "title" => "taxon-c",
+      "base_path" => "/work/taxon_c",
+      "content_id" => "draft-taxon",
+      "state_history" => {
+        "1" => "draft"
+      }
+    }
+  end
+
+  def assert_put_content(content_id, params)
+    param_defaults = {
+      description: nil,
+      schema_name: 'taxon',
+      update_type: 'minor'
+    }
+    assert_publishing_api_put_content(content_id, param_defaults.merge(params), 1)
+  end
+
+  def assert_no_put_content(content_id)
+    assert_publishing_api_put_content(content_id, nil, 0)
+  end
+
+  def assert_no_publish(content_id)
+    assert_publishing_api_publish(content_id, nil, 0)
+  end
+end


### PR DESCRIPTION
This will clear the descriptions of the taxons children from the taxons
specified. This is due to the descriptions not being accurate for the
corresponding taxons. 

I will have to manually clear the descriptions for the level one taxons as this code only deals with the children.

Trello;
https://trello.com/c/tYwP644l/156-remove-all-descriptions-for-all-newly-live-branches-of-the-taxonomy