### PR TITLE
Improve tagged_content interface

### DIFF
--- a/app/assets/javascripts/filter-table.js
+++ b/app/assets/javascripts/filter-table.js
@@ -1,0 +1,63 @@
+(function(Modules) {
+  "use strict";
+
+  Modules.FilterableTable = function() {
+    var that = this;
+    that.start = function(element) {
+
+      var rows = element.find('tbody tr'),
+          tableInput = element.find('.js-filter-table-input'),
+          filterForm,
+          rowCount,
+          timeout = null;
+
+      element.on('keyup change', '.js-filter-table-input', function() {
+        clearTimeout(timeout);
+        timeout = setTimeout(function() {
+          filterTableBasedOnInput();
+        }, 600);
+        $('.spinner').show();
+      });
+
+      if (element.find('a.js-open-on-submit').length > 0) {
+        filterForm = tableInput.parents('form');
+        if (filterForm && filterForm.length > 0) {
+          filterForm.on('submit', openFirstVisibleLink);
+        }
+      }
+
+      function filterTableBasedOnInput() {
+        $('.spinner').hide();
+        rowCount = 0;
+        var searchString = $.trim(tableInput.val()),
+            regExp = new RegExp(escapeStringForRegexp(searchString), 'i');
+
+        rows.each(function() {
+          var row = $(this);
+          if (row.text().search(regExp) > -1) {
+            row.css({'display':'table-row'});
+            ++rowCount;
+          } else {
+            row.css({'display':'none'});
+          }
+        });
+
+        $("#row-count").text("Filtered results count: " + rowCount);
+      }
+
+      function openFirstVisibleLink(evt) {
+        evt.preventDefault();
+        var link = element.find('a.js-open-on-submit:visible').first();
+        GOVUKAdmin.redirect(link.attr('href'));
+      }
+
+      // http://stackoverflow.com/questions/3446170/escape-string-for-use-in-javascript-regex
+      // https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/regexp
+      // Escape ~!@#$%^&*(){}[]`/=?+\|-_;:'",<.>
+      function escapeStringForRegexp(str) {
+        return str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&");
+      }
+    }
+  };
+
+})(window.GOVUKAdmin.Modules);

--- a/app/assets/javascripts/select-all.js
+++ b/app/assets/javascripts/select-all.js
@@ -5,18 +5,28 @@
     var that = this;
 
     that.start = function(element) {
-      function addEventListener() {
-        var selectAll = element.find('#select_all');
+      var selectAll = element.find('#select_all');
+
+      function selectAllListener() {
         if (selectAll != undefined) {
           selectAll.on('change', function(e) {
-            var checked = selectAll.prop('checked');
-            var checkboxes = $('.select-content-item');
-            checkboxes.prop('checked', checked);
-          });
-        }
+            var checkBoxes = $('.select-content-item:visible'),
+                checked = selectAll.prop('checked');
+
+            checkBoxes.prop('checked', checked);
+          })
+        };
       }
 
-      addEventListener();
+      function tableInputListner() {
+        $('.js-filter-table-input').on('keyup change', function() {
+          selectAll.prop('checked', false);
+          $('.select-content-item').prop('checked', false);
+        })
+      };
+
+      selectAllListener();
+      tableInputListner();
     }
   };
 })(window.GOVUKAdmin.Modules);

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -12,6 +12,7 @@ $red: #b10e1e;
 @import 'views/taxon';
 @import 'views/bubbles';
 @import 'tagathon_project';
+@import 'views/table-filter';
 
 .error-message {
   color: $red;

--- a/app/assets/stylesheets/views/table-filter.scss
+++ b/app/assets/stylesheets/views/table-filter.scss
@@ -1,0 +1,30 @@
+.spinner {
+  -webkit-animation: spinner 2s infinite linear;
+  -moz-animation: spinner 2s infinite linear;
+  -o-animation: spinner 2s infinite linear;
+  animation: spinner 2s infinite linear;
+}
+@-moz-keyframes spinner {
+  from {
+    -moz-transform: rotate(0deg);
+  }
+  to {
+    -moz-transform: rotate(360deg);
+  }
+}
+@-webkit-keyframes spinner {
+  from {
+    -webkit-transform: rotate(0deg);
+  }
+  to {
+    -webkit-transform: rotate(360deg);
+  }
+}
+@keyframes spinner {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/app/views/shared/_table_filter.html.erb
+++ b/app/views/shared/_table_filter.html.erb
@@ -1,7 +1,8 @@
 <tr class="table-header if-no-js-hide table-header-secondary">
   <th colspan='7'>
-    <form class='table-filter'>
+    <form class='table-filter has-feedback'>
       <input id="table-filter" type="text" class="form-control normal js-filter-table-input" placeholder="Filter table">
+      <i class="glyphicon glyphicon-refresh form-control-feedback spinner" style="display: none"></i>
     </form>
   </th>
 </tr>

--- a/app/views/shared/_tag_migration_form.html.erb
+++ b/app/views/shared/_tag_migration_form.html.erb
@@ -11,6 +11,15 @@
   <%= select_tag :taxons, options_for_select(taxons), multiple: true, class: 'select2' %>
 </div>
 
+<div class="panel panel-default add-top-margin">
+  <div class="panel-body">
+    Total tagged pages: <%= expanded_links.count %>
+  </div>
+  <div class="panel-body">
+    <span id="row-count">Filtered results count: <%= expanded_links.count %></span>
+  </div>
+</div>
+
 <% if expanded_links.any? %>
   <%= render 'tag_migrations/items_tagged_to_item', expanded_links: expanded_links %>
 <% else %>

--- a/app/views/tag_migrations/_items_tagged_to_item.html.erb
+++ b/app/views/tag_migrations/_items_tagged_to_item.html.erb
@@ -8,6 +8,8 @@
       <th>Page</th>
       <th></th>
     </tr>
+
+    <%= render partial: 'shared/table_filter' %>
   </thead>
   <tbody>
     <% expanded_links.each do |expanded_link| %>

--- a/app/views/tag_migrations/show.html.erb
+++ b/app/views/tag_migrations/show.html.erb
@@ -9,7 +9,7 @@
   <%= content_tag(
     :p,
     I18n.t('views.tag_migrations.move_message', taxon_name: current_tagged_taxon),
-    class: 'alert alert-warning'
+    class: 'alert alert-danger'
   ) %>
 <% end %>
 

--- a/app/views/taxons/tagged_content_page.html.erb
+++ b/app/views/taxons/tagged_content_page.html.erb
@@ -25,6 +25,9 @@
     <div class="panel-body">
       Total tagged pages: <%= page.tagged.count %>
     </div>
+    <div class="panel-body">
+      <span id="row-count">Filtered results count: <%= page.tagged.count %></span>
+    </div>
   </div>
 
   <% if page.tagged.any? %>


### PR DESCRIPTION
Improvements made:

* Moved the javascript for the filter table from govuk-admin-template
into content tagger as this gem is now depreciated.

* The filter table is now usable when there is high amount of content
tagged to a taxon.

* There is a refreshing icon which tells the user their filtering is in
process.

Trello:
https://trello.com/c/i3UoSjH9/118-l-make-move-content-feature-in-content-tagger-easier-and-safer-for-publishers-to-use