### PR TITLE
Remove legacy internal_name notation

### DIFF
--- a/app/models/linkables.rb
+++ b/app/models/linkables.rb
@@ -54,7 +54,7 @@ private
 
   def present_items(items)
     items = items.map do |item|
-      title = item.fetch('internal_name')
+      title = item.fetch('title')
       title = "#{title} (draft)" if item.fetch("publication_state") == "draft"
 
       [title, item.fetch('content_id')]

--- a/app/services/taxonomy/edit_page.rb
+++ b/app/services/taxonomy/edit_page.rb
@@ -13,7 +13,7 @@ module Taxonomy
     end
 
     def title
-      taxon.internal_name
+      taxon.title
     end
 
     def taxons_for_select

--- a/app/services/taxonomy/show_page.rb
+++ b/app/services/taxonomy/show_page.rb
@@ -11,7 +11,7 @@ module Taxonomy
     end
 
     def title
-      taxon.internal_name
+      taxon.title
     end
 
     def show_preview_link?

--- a/app/views/taxonomy/health_warnings/index.html.erb
+++ b/app/views/taxonomy/health_warnings/index.html.erb
@@ -48,7 +48,7 @@
     <% @taxonomy_health_warnings.order(value: :desc).each do |taxonomy_health_warning| %>
       <tr>
         <td><%= time_ago_in_words(taxonomy_health_warning.created_at) %></td>
-        <td><%= link_to taxonomy_health_warning.internal_name,
+        <td><%= link_to taxonomy_health_warning.title,
                     taxon_path(taxonomy_health_warning.content_id) %>
           <br>
           <span class="text-muted"><%= taxonomy_health_warning.path %></span>

--- a/app/views/taxons/_taxonomy_tree.html.erb
+++ b/app/views/taxons/_taxonomy_tree.html.erb
@@ -5,14 +5,14 @@
       <div class="parent-expansion">
         <div class="taxon-level taxon-depth-1">
           <span class="taxon-level-title">
-            <%= link_to parent_node.internal_name, taxon_path(parent_node.content_id) %>
+            <%= link_to parent_node.title, taxon_path(parent_node.content_id) %>
           </span>
         </div>
         <% parent_node.each do |parent_ancestor| %>
           <% next if parent_ancestor.depth == 1 %>
           <div class="taxon-level taxon-depth-<%= parent_ancestor.depth %>">
             <span class="taxon-level-title">
-              <%= link_to parent_ancestor.internal_name, taxon_path(parent_ancestor.content_id) %>
+              <%= link_to parent_ancestor.title, taxon_path(parent_ancestor.content_id) %>
             </span>
           </div>
         <% end %>
@@ -29,7 +29,7 @@
   <div class="taxon-focus <%= has_parents %> <%= has_children %> <%= multiple_parents %> <%= multiple_children %>">
     <div class="taxon-level taxon-depth-0">
        <span class="taxon-level-title">
-         <%= page.taxonomy_tree.root_node.internal_name %>
+         <%= page.taxonomy_tree.root_node.title %>
        </span>
     </div>
   </div>
@@ -39,14 +39,14 @@
       <div class="child-expansion">
         <div class="taxon-level taxon-depth-1">
           <span class="taxon-level-title">
-            <%= link_to child_node.internal_name, taxon_path(child_node.content_id) %>
+            <%= link_to child_node.title, taxon_path(child_node.content_id) %>
           </span>
         </div>
         <% child_node.each do |child_successor| %>
           <% next if child_successor.depth == 1 %>
           <div class="taxon-level taxon-depth-<%= child_successor.depth %>">
             <span class="taxon-level-title">
-              <%= link_to child_successor.internal_name, taxon_path(child_successor.content_id) %>
+              <%= link_to child_successor.title, taxon_path(child_successor.content_id) %>
             </span>
           </div>
         <% end %>

--- a/app/views/taxons/confirm_delete.html.erb
+++ b/app/views/taxons/confirm_delete.html.erb
@@ -1,4 +1,4 @@
-<h1><%= t('views.taxons.confirm_deletion_title') %> "<%= page.taxon.internal_name %>"</h1>
+<h1><%= t('views.taxons.confirm_deletion_title') %> "<%= page.taxon.title %>"</h1>
 
 <div class="lead"><%= t('views.taxons.confirm_deletion_restore') %></div>
 
@@ -44,7 +44,7 @@
    <tbody>
      <% page.children.each do |child| %>
        <tr>
-         <td><%= link_to child.internal_name, taxon_path(child.content_id) %></td>
+         <td><%= link_to child.title, taxon_path(child.content_id) %></td>
        </tr>
      <% end %>
    </tbody>

--- a/app/views/taxons/confirm_discard.html.erb
+++ b/app/views/taxons/confirm_discard.html.erb
@@ -1,5 +1,5 @@
 <header class="heading-with-actions">
-  <h1><%= taxon.internal_name %></h1>
+  <h1><%= taxon.title %></h1>
 </header>
 
 <div class="lead">

--- a/app/views/taxons/confirm_publish.html.erb
+++ b/app/views/taxons/confirm_publish.html.erb
@@ -1,5 +1,5 @@
 <header class="heading-with-actions">
-  <h1><%= taxon.internal_name %></h1>
+  <h1><%= taxon.title %></h1>
 </header>
 
 <div class="lead">

--- a/app/views/taxons/edit.html.erb
+++ b/app/views/taxons/edit.html.erb
@@ -1,5 +1,5 @@
 <%= display_header title: page.title,
-  breadcrumbs: [:taxons, link_to(page.taxon.internal_name, taxon_path(page.taxon_content_id)), "Edit"] %>
+  breadcrumbs: [:taxons, link_to(page.taxon.title, taxon_path(page.taxon_content_id)), "Edit"] %>
 
 <%= simple_form_for page.taxon, url: taxon_path(page.taxon_content_id), method: :patch do |f| %>
   <%= f.hidden_field :content_id, value: page.taxon_content_id %>

--- a/app/views/taxons/index.html.erb
+++ b/app/views/taxons/index.html.erb
@@ -50,7 +50,7 @@
     <% page.taxons.each do |taxon| %>
       <tr>
         <td>
-          <%= taxon.internal_name %>
+          <%= taxon.title %>
           <br>
           <span class="text-muted"><%= taxon.base_path %></span>
         </td>

--- a/app/views/taxons/tagged_content_page.html.erb
+++ b/app/views/taxons/tagged_content_page.html.erb
@@ -1,6 +1,6 @@
 <%= display_header(
-  title: "Pages tagged to #{link_to page.taxon.internal_name, taxon_path(page.content_id)}",
-  page_title: "Pages tagged to #{page.taxon.internal_name}",
+  title: "Pages tagged to #{link_to page.taxon.title, taxon_path(page.content_id)}",
+  page_title: "Pages tagged to #{page.taxon.title}",
   breadcrumbs: [:taxons, page.taxon]) %>
 
 <% unless page.unpublished? %>

--- a/spec/features/bulk_tagging_spec.rb
+++ b/spec/features/bulk_tagging_spec.rb
@@ -89,9 +89,9 @@ RSpec.feature "Bulk tagging", type: :feature do
     # Used in the dropdown
     publishing_api_has_linkables(
       [
-        build_linkable(internal_name: "Taxon 1", content_id: 'taxon-1'),
-        build_linkable(internal_name: "Taxon 2", content_id: 'taxon-2'),
-        build_linkable(internal_name: "Taxon 3", content_id: 'taxon-3'),
+        build_linkable(title: "Taxon 1", content_id: 'taxon-1'),
+        build_linkable(title: "Taxon 2", content_id: 'taxon-2'),
+        build_linkable(title: "Taxon 3", content_id: 'taxon-3'),
       ],
       document_type: "taxon",
     )

--- a/spec/features/delete_taxon_spec.rb
+++ b/spec/features/delete_taxon_spec.rb
@@ -162,7 +162,7 @@ RSpec.feature "Delete Taxon", type: :feature do
   end
 
   def then_i_see_a_basic_prompt_to_delete
-    expect(page).to have_text('You are about to delete "internal name for Taxon 1"')
+    expect(page).to have_text('You are about to delete "Taxon 1"')
     expect(page).to_not have_text("Before you delete this taxon, make sure you've")
     expect(page).to have_link('Cancel')
     expect(page).to have_button('Delete and redirect')
@@ -224,7 +224,7 @@ RSpec.feature "Delete Taxon", type: :feature do
   end
 
   def then_i_see_a_prompt_to_delete_with_a_warning_message
-    expect(page).to have_text('You are about to delete "internal name for Taxon 1"')
+    expect(page).to have_text('You are about to delete "Taxon 1"')
     expect(page).to have_text("Before you delete this taxon, make sure you've")
     expect(page).to have_link('Cancel')
     expect(page).to have_button('Delete and redirect')

--- a/spec/features/move_content_between_taxons_spec.rb
+++ b/spec/features/move_content_between_taxons_spec.rb
@@ -46,6 +46,7 @@ RSpec.feature "Move content between Taxons", type: :feature do
       }
     )
     @source_taxon_for_select = {
+      'title' => @source_taxon['title'],
       'internal_name' => @source_taxon['details']['internal_name'],
       'content_id' => @source_taxon['content_id'],
       'publication_state' => 'published',
@@ -63,6 +64,7 @@ RSpec.feature "Move content between Taxons", type: :feature do
       }
     )
     @dest_taxon_for_select = {
+      'title' => @dest_taxon['title'],
       'internal_name' => @dest_taxon['details']['internal_name'],
       'content_id' => @dest_taxon['content_id'],
       'publication_state' => 'published',
@@ -119,7 +121,7 @@ RSpec.feature "Move content between Taxons", type: :feature do
   end
 
   def and_select_a_taxon_to_move_content_to
-    select @dest_taxon_for_select['internal_name']
+    select @dest_taxon_for_select['title']
   end
 
   def and_select_all_content

--- a/spec/features/tag_a_page_spec.rb
+++ b/spec/features/tag_a_page_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "Tagging content", type: :feature do
     and_the_expected_navigation_link_is_highlighted
     and_i_see_the_taxon_form
 
-    when_i_select_an_additional_topic("Business tax / Pension scheme administration")
+    when_i_select_an_additional_topic("Pension scheme administration")
     and_i_submit_the_form
 
     then_the_publishing_api_is_sent(
@@ -26,7 +26,7 @@ RSpec.describe "Tagging content", type: :feature do
       ordered_related_items: [],
       mainstream_browse_pages: [],
       parent: [],
-      topics: ["e1d6b771-a692-4812-a4e7-7562214286ef", example_topic['content_id']],
+      topics: [example_topic['content_id'], "e1d6b771-a692-4812-a4e7-7562214286ef"],
       organisations: [],
       meets_user_needs: [],
     )
@@ -36,7 +36,7 @@ RSpec.describe "Tagging content", type: :feature do
     given_there_is_a_content_item_with_no_expanded_links
     and_i_am_on_the_page_for_the_item
 
-    when_i_select_an_additional_topic("Business tax / Pension scheme administration")
+    when_i_select_an_additional_topic("Pension scheme administration")
     and_i_submit_the_form
 
     then_the_publishing_api_is_sent(
@@ -54,7 +54,7 @@ RSpec.describe "Tagging content", type: :feature do
     given_there_is_a_content_item_with_expanded_links(topics: [example_topic])
     and_i_am_on_the_page_for_the_item
 
-    when_i_select_an_additional_topic("Business tax / Pension scheme administration")
+    when_i_select_an_additional_topic("Pension scheme administration")
     and_somebody_else_makes_a_change
     and_i_submit_the_form
 

--- a/spec/features/tagging_during_migration_spec.rb
+++ b/spec/features/tagging_during_migration_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe "Tagging content during migration", type: :feature do
   end
 
   def when_i_add_an_additional_tag
-    select "Business tax / Pension scheme administration", from: "Topics"
+    select "Pension scheme administration", from: "Topics"
   end
 
   def and_i_submit_the_form
@@ -82,7 +82,7 @@ RSpec.describe "Tagging content during migration", type: :feature do
   def then_only_that_link_type_is_sent_to_the_publishing_api
     body = {
       links: {
-        topics: ["e1d6b771-a692-4812-a4e7-7562214286ef", "ID-OF-ALREADY-TAGGED"],
+        topics: ["ID-OF-ALREADY-TAGGED", "e1d6b771-a692-4812-a4e7-7562214286ef"],
       },
       previous_version: 54_321,
     }

--- a/spec/features/taxonomy_health_warnings_spec.rb
+++ b/spec/features/taxonomy_health_warnings_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "Taxonomy Health Warnings" do
   def then_i_see_the_health_warning
     expect(page).to have_text('/path/to/taxon')
     expect(page).to have_text('Taxon fails metric')
-    expect(page).to have_link('internal name', href: taxon_path(@taxon_content_id))
+    expect(page).to have_link('title', href: taxon_path(@taxon_content_id))
   end
 
   def then_i_see_a_link_to_the_metrics_dashboard

--- a/spec/services/linkables_spec.rb
+++ b/spec/services/linkables_spec.rb
@@ -20,11 +20,13 @@ RSpec.describe Linkables do
             internal_name: '',
           ),
           build_linkable(
+            title: 'valid-title',
             content_id: 'valid-1',
             publication_state: 'published',
             internal_name: 'Valid-1!',
           ),
           build_linkable(
+            title: 'valid-title-2',
             content_id: 'valid-2',
             publication_state: 'published',
             internal_name: 'Valid-2!',
@@ -36,25 +38,25 @@ RSpec.describe Linkables do
     describe '.taxons' do
       it 'returns an array of hashes with only valid taxons' do
         expect(linkables.taxons).to eq(
-          [%w[Valid-1! valid-1], %w[Valid-2! valid-2]]
+          [%w[valid-title valid-1], %w[valid-title-2 valid-2]]
         )
       end
 
       it 'filters out excluded IDs' do
         expect(linkables.taxons(exclude_ids: 'valid-2')).to eq(
-          [%w[Valid-1! valid-1]]
+          [%w[valid-title valid-1]]
         )
       end
     end
     describe '.taxons_including_root' do
       it 'returns an array of hashes with only valid taxons including root' do
         expect(linkables.taxons_including_root).to eq(
-          [['GOV.UK homepage', GovukTaxonomy::ROOT_CONTENT_ID], %w[Valid-1! valid-1], %w[Valid-2! valid-2]]
+          [['GOV.UK homepage', GovukTaxonomy::ROOT_CONTENT_ID], %w[valid-title valid-1], %w[valid-title-2 valid-2]]
         )
       end
       it 'filters out excluded IDs' do
         expect(linkables.taxons_including_root(exclude_ids: 'valid-2')).to eq(
-          [['GOV.UK homepage', GovukTaxonomy::ROOT_CONTENT_ID], %w[Valid-1! valid-1]]
+          [['GOV.UK homepage', GovukTaxonomy::ROOT_CONTENT_ID], %w[valid-title valid-1]]
         )
       end
     end
@@ -85,8 +87,8 @@ RSpec.describe Linkables do
       )
 
       expected = {
-        "Business tax" => [
-          ["Business tax / Pension scheme administration", "e1d6b771-a692-4812-a4e7-7562214286ef"]
+        "Pension scheme administration" => [
+          ["Pension scheme administration", "e1d6b771-a692-4812-a4e7-7562214286ef"]
         ]
       }
 


### PR DESCRIPTION
Previously content-tagger displayed taxon's `internal name` which includes confusing notation from the past. These changes use the `external_name` instead which is the title of the taxon.

Trello:
https://trello.com/c/5sVsaG18/180-m-legacy-notation-p-m-pa-t-are-removed-from-content-tagger-and-the-use-of-internal-taxon-names-is-retired