### PR TITLE
Revert linkables to use internal name

### DIFF
--- a/app/models/linkables.rb
+++ b/app/models/linkables.rb
@@ -54,7 +54,7 @@ private
 
   def present_items(items)
     items = items.map do |item|
-      title = item.fetch('title')
+      title = item.fetch('internal_name')
       title = "#{title} (draft)" if item.fetch("publication_state") == "draft"
 
       [title, item.fetch('content_id')]

--- a/spec/features/bulk_tagging_spec.rb
+++ b/spec/features/bulk_tagging_spec.rb
@@ -89,9 +89,9 @@ RSpec.feature "Bulk tagging", type: :feature do
     # Used in the dropdown
     publishing_api_has_linkables(
       [
-        build_linkable(title: "Taxon 1", content_id: 'taxon-1'),
-        build_linkable(title: "Taxon 2", content_id: 'taxon-2'),
-        build_linkable(title: "Taxon 3", content_id: 'taxon-3'),
+        build_linkable(internal_name: "Taxon 1", content_id: 'taxon-1'),
+        build_linkable(internal_name: "Taxon 2", content_id: 'taxon-2'),
+        build_linkable(internal_name: "Taxon 3", content_id: 'taxon-3'),
       ],
       document_type: "taxon",
     )

--- a/spec/features/tag_a_page_spec.rb
+++ b/spec/features/tag_a_page_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "Tagging content", type: :feature do
     and_the_expected_navigation_link_is_highlighted
     and_i_see_the_taxon_form
 
-    when_i_select_an_additional_topic("Pension scheme administration")
+    when_i_select_an_additional_topic("Business tax / Pension scheme administration")
     and_i_submit_the_form
 
     then_the_publishing_api_is_sent(
@@ -26,7 +26,7 @@ RSpec.describe "Tagging content", type: :feature do
       ordered_related_items: [],
       mainstream_browse_pages: [],
       parent: [],
-      topics: [example_topic['content_id'], "e1d6b771-a692-4812-a4e7-7562214286ef"],
+      topics: ["e1d6b771-a692-4812-a4e7-7562214286ef", example_topic['content_id']],
       organisations: [],
       meets_user_needs: [],
     )
@@ -36,7 +36,7 @@ RSpec.describe "Tagging content", type: :feature do
     given_there_is_a_content_item_with_no_expanded_links
     and_i_am_on_the_page_for_the_item
 
-    when_i_select_an_additional_topic("Pension scheme administration")
+    when_i_select_an_additional_topic("Business tax / Pension scheme administration")
     and_i_submit_the_form
 
     then_the_publishing_api_is_sent(
@@ -54,7 +54,7 @@ RSpec.describe "Tagging content", type: :feature do
     given_there_is_a_content_item_with_expanded_links(topics: [example_topic])
     and_i_am_on_the_page_for_the_item
 
-    when_i_select_an_additional_topic("Pension scheme administration")
+    when_i_select_an_additional_topic("Business tax / Pension scheme administration")
     and_somebody_else_makes_a_change
     and_i_submit_the_form
 

--- a/spec/features/tagging_during_migration_spec.rb
+++ b/spec/features/tagging_during_migration_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe "Tagging content during migration", type: :feature do
   end
 
   def when_i_add_an_additional_tag
-    select "Pension scheme administration", from: "Topics"
+    select "Business tax / Pension scheme administration", from: "Topics"
   end
 
   def and_i_submit_the_form
@@ -82,7 +82,7 @@ RSpec.describe "Tagging content during migration", type: :feature do
   def then_only_that_link_type_is_sent_to_the_publishing_api
     body = {
       links: {
-        topics: ["ID-OF-ALREADY-TAGGED", "e1d6b771-a692-4812-a4e7-7562214286ef"],
+        topics: ["e1d6b771-a692-4812-a4e7-7562214286ef", "ID-OF-ALREADY-TAGGED"],
       },
       previous_version: 54_321,
     }

--- a/spec/services/linkables_spec.rb
+++ b/spec/services/linkables_spec.rb
@@ -20,13 +20,11 @@ RSpec.describe Linkables do
             internal_name: '',
           ),
           build_linkable(
-            title: 'valid-title',
             content_id: 'valid-1',
             publication_state: 'published',
             internal_name: 'Valid-1!',
           ),
           build_linkable(
-            title: 'valid-title-2',
             content_id: 'valid-2',
             publication_state: 'published',
             internal_name: 'Valid-2!',
@@ -38,25 +36,25 @@ RSpec.describe Linkables do
     describe '.taxons' do
       it 'returns an array of hashes with only valid taxons' do
         expect(linkables.taxons).to eq(
-          [%w[valid-title valid-1], %w[valid-title-2 valid-2]]
+          [%w[Valid-1! valid-1], %w[Valid-2! valid-2]]
         )
       end
 
       it 'filters out excluded IDs' do
         expect(linkables.taxons(exclude_ids: 'valid-2')).to eq(
-          [%w[valid-title valid-1]]
+          [%w[Valid-1! valid-1]]
         )
       end
     end
     describe '.taxons_including_root' do
       it 'returns an array of hashes with only valid taxons including root' do
         expect(linkables.taxons_including_root).to eq(
-          [['GOV.UK homepage', GovukTaxonomy::ROOT_CONTENT_ID], %w[valid-title valid-1], %w[valid-title-2 valid-2]]
+          [['GOV.UK homepage', GovukTaxonomy::ROOT_CONTENT_ID], %w[Valid-1! valid-1], %w[Valid-2! valid-2]]
         )
       end
       it 'filters out excluded IDs' do
         expect(linkables.taxons_including_root(exclude_ids: 'valid-2')).to eq(
-          [['GOV.UK homepage', GovukTaxonomy::ROOT_CONTENT_ID], %w[valid-title valid-1]]
+          [['GOV.UK homepage', GovukTaxonomy::ROOT_CONTENT_ID], %w[Valid-1! valid-1]]
         )
       end
     end
@@ -87,8 +85,8 @@ RSpec.describe Linkables do
       )
 
       expected = {
-        "Pension scheme administration" => [
-          ["Pension scheme administration", "e1d6b771-a692-4812-a4e7-7562214286ef"]
+        "Business tax" => [
+          ["Business tax / Pension scheme administration", "e1d6b771-a692-4812-a4e7-7562214286ef"]
         ]
       }
 


### PR DESCRIPTION
The previous change breaks the groupings of the dropdown lists for
(topics) specialist sectors.