### PR TITLE
Create Rake task to update content items with suggested related links

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ group :development, :test do
   gem 'rspec-rails'
   gem 'simplecov', require: false
   gem 'simplecov-rcov', require: false
+  gem 'json'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -422,6 +422,7 @@ DEPENDENCIES
   hashdiff (~> 0.3.8)
   headless
   jquery-ui-rails (= 6.0.1)
+  json
   kaminari (~> 1.1)
   pg
   plek (~> 2.1)

--- a/lib/tasks/update_related_links_from_json.rake
+++ b/lib/tasks/update_related_links_from_json.rake
@@ -10,7 +10,13 @@ namespace :content do
 
       puts "Updating related links for content #{content_to_update['source_content_id']} to #{content_to_update['target_content_ids']}"
 
-      Services.publishing_api.patch_links(content_to_update['source_content_id'], links: { suggested_ordered_related_items: content_to_update['target_content_ids'] })
+      Services.publishing_api.patch_links(
+        content_to_update['source_content_id'],
+        links: {
+          suggested_ordered_related_items: content_to_update['target_content_ids']
+        },
+        bulk_publishing: true
+      )
     end
   end
 end

--- a/lib/tasks/update_related_links_from_json.rake
+++ b/lib/tasks/update_related_links_from_json.rake
@@ -4,19 +4,35 @@ namespace :content do
   task :update_related_links_from_json, [:json_path] => :environment do |_, args|
     file = File.read(args[:json_path])
     json = JSON.parse(file)
+    @failed_content_ids = []
 
-    json.fetch('related_links', []).each do |content_to_update|
-      next if content_to_update['target_content_ids'].empty?
-
-      puts "Updating related links for content #{content_to_update['source_content_id']} to #{content_to_update['target_content_ids']}"
-
-      Services.publishing_api.patch_links(
-        content_to_update['source_content_id'],
-        links: {
-          suggested_ordered_related_items: content_to_update['target_content_ids']
-        },
-        bulk_publishing: true
-      )
+    json.each_pair do |source_content_id, related_content_ids|
+      update_content(source_content_id: source_content_id, related_content_ids: related_content_ids)
     end
+
+    puts "Failed content ids: #{@failed_content_ids}"
+    puts "Retrying failed content updates..." if @failed_content_ids.any?
+
+    @failed_content_ids.each do |source_content_id|
+      puts "Retrying content id #{source_content_id} with related #{json[source_content_id]}"
+      update_content(source_content_id: source_content_id, related_content_ids: json[source_content_id], retry_failed: false)
+    end
+  end
+
+  def update_content(source_content_id:, related_content_ids:, retry_failed: true)
+    Services.publishing_api.patch_links(
+      source_content_id,
+      links: {
+        suggested_ordered_related_items: related_content_ids
+      },
+      bulk_publishing: true
+    )
+
+    puts "Updated related links for content #{source_content_id} to #{related_content_ids}"
+  rescue GdsApi::HTTPErrorResponse => e
+    STDERR.puts "Failed to update content id #{source_content_id} - response status #{e.code}"
+  rescue GdsApi::TimedOutException
+    STDERR.puts "Failed to update content id #{source_content_id} - connection to publishing API timed out"
+    @failed_content_ids << source_content_id if retry_failed
   end
 end

--- a/lib/tasks/update_related_links_from_json.rake
+++ b/lib/tasks/update_related_links_from_json.rake
@@ -1,0 +1,16 @@
+require 'gds_api/base'
+namespace :content do
+  desc "Updates suggested related links for content from a JSON file"
+  task :update_related_links_from_json, [:json_path] => :environment do |_, args|
+    file = File.read(args[:json_path])
+    json = JSON.parse(file)
+
+    json.fetch('related_links', []).each do |content_to_update|
+      next if content_to_update['target_content_ids'].empty?
+
+      puts "Updating related links for content #{content_to_update['source_content_id']} to #{content_to_update['target_content_ids']}"
+
+      Services.publishing_api.patch_links(content_to_update['source_content_id'], links: { suggested_ordered_related_items: content_to_update['target_content_ids'] })
+    end
+  end
+end


### PR DESCRIPTION
This PR creates a new Rake task to update `suggested_ordered_related_items` within the `links` of a content item. This is to support the related links A/B test and will be run against a JSON file containing all of the relevant data.

Solo: @karlbaker02