### PR TITLE
Change Plek(rummager) to Plek(search)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,7 +100,7 @@ GEM
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.25)
-    gds-api-adapters (57.4.1)
+    gds-api-adapters (57.4.2)
       addressable
       link_header
       null_logger
@@ -239,7 +239,7 @@ GEM
     public_suffix (3.0.3)
     puma (3.12.0)
     rack (2.0.6)
-    rack-cache (1.8.0)
+    rack-cache (1.9.0)
       rack (>= 0.4)
     rack-protection (2.0.3)
       rack

--- a/app/lib/services.rb
+++ b/app/lib/services.rb
@@ -38,7 +38,7 @@ module Services
 
   def self.rummager
     @rummager ||= GdsApi::Rummager.new(
-      Plek.new.find('rummager'),
+      Plek.new.find('search'),
     )
   end
 

--- a/spec/services/data_export/content_export_spec.rb
+++ b/spec/services/data_export/content_export_spec.rb
@@ -59,7 +59,7 @@ module DataExport
 
     describe '#content_links_enum' do
       it 'returns content links in an enumerator' do
-        stub_request(:get, Regexp.new(Plek.new.find('rummager')))
+        stub_request(:get, Regexp.new(Plek.new.find('search')))
           .to_return(body: { 'results' => [{ 'link' => '/first/path' }, { 'link' => '/second/path' }] }.to_json)
         expect(ContentExport.new.content_links_enum.to_a).to eq(['/first/path', '/second/path'])
       end
@@ -93,7 +93,7 @@ module DataExport
             }
           }
         }
-        stub_request(:get, Regexp.new(Plek.new.find('rummager')))
+        stub_request(:get, Regexp.new(Plek.new.find('search')))
           .with(query: hash_including('aggregate_content_store_document_type' => '10000'))
           .to_return(body: result_hash.to_json)
 

--- a/spec/services/metrics/content_coverage_metrics_spec.rb
+++ b/spec/services/metrics/content_coverage_metrics_spec.rb
@@ -8,7 +8,7 @@ module Metrics
         allow(Tagging)
           .to receive(:blacklisted_document_types).and_return(blacklist)
 
-        stub_request(:get, "#{Plek.find('rummager')}/search.json")
+        stub_request(:get, "#{Plek.find('search')}/search.json")
           .with(
             query: {
               count: 0,
@@ -17,7 +17,7 @@ module Metrics
           )
           .to_return(body: JSON.dump(total: 1000))
 
-        stub_request(:get, "#{Plek.find('rummager')}/search.json")
+        stub_request(:get, "#{Plek.find('search')}/search.json")
           .with(
             query: {
               count: 0,
@@ -28,7 +28,7 @@ module Metrics
 
         level_one_taxons = FactoryBot.build_list(:linkable_taxon_hash, 2)
 
-        stub_request(:get, "#{Plek.find('rummager')}/search.json")
+        stub_request(:get, "#{Plek.find('search')}/search.json")
           .with(
             query: {
               count: 0,

--- a/spec/services/taxonomy/organisation_count_spec.rb
+++ b/spec/services/taxonomy/organisation_count_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Taxonomy::OrganisationCount do
     end
 
     def stub_rummager(query_hash, json_body)
-      stub_request(:get, Regexp.new(Plek.new.find('rummager')))
+      stub_request(:get, Regexp.new(Plek.new.find('search')))
         .with(query: hash_including(query_hash))
         .to_return(body: json_body.to_json)
     end

--- a/spec/services/taxonomy/taxonomy_query_spec.rb
+++ b/spec/services/taxonomy/taxonomy_query_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe Taxonomy::TaxonomyQuery do
     end
 
     def stub_rummager(query_hash, return_values)
-      stub_request(:get, Regexp.new(Plek.new.find('rummager')))
+      stub_request(:get, Regexp.new(Plek.new.find('search')))
         .with(query: hash_including(query_hash))
         .to_return(body: { 'results' => return_values }.to_json)
     end

--- a/spec/services/taxonomy/taxons_with_content_count_spec.rb
+++ b/spec/services/taxonomy/taxons_with_content_count_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Taxonomy::TaxonsWithContentCount do
   describe '#nested_tree' do
     it 'returns a nested tree structure' do
-      stub_request(:get, 'https://rummager.test.gov.uk/search.json?count=0&debug=include_withdrawn&facet_taxons=1000&filter_part_of_taxonomy_tree=b92079ac-f1d9-44c8-bc78-772d54377ee2')
+      stub_request(:get, 'https://search.test.gov.uk/search.json?count=0&debug=include_withdrawn&facet_taxons=1000&filter_part_of_taxonomy_tree=b92079ac-f1d9-44c8-bc78-772d54377ee2')
         .to_return(body: SEARCH_RESULT_FIXTURE.to_json)
 
       stub_request(:get, 'https://publishing-api.test.gov.uk/v2/expanded-links/b92079ac-f1d9-44c8-bc78-772d54377ee2')

--- a/spec/support/taxonomy_helper.rb
+++ b/spec/support/taxonomy_helper.rb
@@ -53,7 +53,7 @@ module TaxonomyHelper
 private
 
   def rummager_url_for_all_document_counts_url
-    "https://rummager.test.gov.uk/search.json?aggregate_primary_publishing_organisation=0,scope:all_filters&count=0&filter_primary_publishing_organisation%5B%5D=department-for-transport&filter_primary_publishing_organisation%5B%5D=high-speed-two-limited&filter_primary_publishing_organisation%5B%5D=home-office&filter_primary_publishing_organisation%5B%5D=maritime-and-coastguard-agency&start=0"
+    "https://search.test.gov.uk/search.json?aggregate_primary_publishing_organisation=0,scope:all_filters&count=0&filter_primary_publishing_organisation%5B%5D=department-for-transport&filter_primary_publishing_organisation%5B%5D=high-speed-two-limited&filter_primary_publishing_organisation%5B%5D=home-office&filter_primary_publishing_organisation%5B%5D=maritime-and-coastguard-agency&start=0"
   end
 
   def all_document_counts_response
@@ -80,7 +80,7 @@ private
   end
 
   def rummager_url_for_tagged_document_counts_url
-    "https://rummager.test.gov.uk/search.json?aggregate_primary_publishing_organisation=0,scope:all_filters&count=0&filter_part_of_taxonomy_tree%5B%5D=aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa&filter_primary_publishing_organisation%5B%5D=department-for-transport&filter_primary_publishing_organisation%5B%5D=high-speed-two-limited&filter_primary_publishing_organisation%5B%5D=home-office&filter_primary_publishing_organisation%5B%5D=maritime-and-coastguard-agency&start=0"
+    "https://search.test.gov.uk/search.json?aggregate_primary_publishing_organisation=0,scope:all_filters&count=0&filter_part_of_taxonomy_tree%5B%5D=aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa&filter_primary_publishing_organisation%5B%5D=department-for-transport&filter_primary_publishing_organisation%5B%5D=high-speed-two-limited&filter_primary_publishing_organisation%5B%5D=home-office&filter_primary_publishing_organisation%5B%5D=maritime-and-coastguard-agency&start=0"
   end
 
   def tagged_documents_counts_response


### PR DESCRIPTION
For the migration to search-api we're going to re-target the 'search'
alias to search-api.

---

[Trello card](https://trello.com/c/yrq9hZmU/77-point-the-search-alias-to-search-api-if-rummager-is-disabled)