### PR TITLE
Facet group importer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,3 @@
 spec/examples.txt
 
 .DS_Store
-
-/lib/data

--- a/lib/data/find-eu-exit-guidance-business.yml
+++ b/lib/data/find-eu-exit-guidance-business.yml
@@ -1,0 +1,219 @@
+---
+:content_id: 52435175-82ed-4a04-adef-74c0199d0f46
+:title: "Find EU Exit guidance business"
+:description: "Facets for use with content relating to EU Exit business guidance."
+:facets:
+  - :content_id: b2f525e8-ba7d-4737-a8b2-e4168c138aea
+    :title: "Sector / Business area"
+    :key: sector_business_area
+    :facet_values:
+      - :content_id: 894a7c88-40bb-4ba6-a234-b7e15d8a0c21
+        :title: Accommodation, restaurants and catering services
+        :value: accommodation-restaurants-and-catering-services
+      - :content_id: 24fd50fa-6619-46ca-96cd-8ce90fa076ce
+        :title: Aerospace
+        :value: aerospace
+      - :content_id: 94b3cfe2-af89-4744-b8d7-7fc79edcbc85
+        :title: Agriculture
+        :value: agriculture
+      - :content_id: 43d328b3-59ee-4d5d-bda0-7c7d4bb301be
+        :title: Air transport (aviation)
+        :value: air-transport-aviation
+      - :content_id: 5faa1741-fc55-4110-b342-de92f6324118
+        :title: Ancillary services
+        :value: ancillary-services
+      - :content_id: 05334231-9be3-4670-a2f5-84bef7e3badd
+        :title: Animal health
+        :value: animal-health
+      - :content_id: e53e578a-01d2-4844-b52b-fd375ee4c4b9
+        :title: Automotive
+        :value: automotive
+      - :content_id: 3880f354-3d74-4441-b40f-d808933a14be
+        :title: Banking, markets and infrastructure
+        :value: banking-market-infrastructure
+      - :content_id: 4c7a04d8-02b8-430c-bfec-f1e1f475ff98
+        :title: Broadcasting
+        :value: broadcasting
+      - :content_id: 7620da7a-0427-4b3c-9498-db9dc25209b0
+        :title: Chemicals
+        :value: chemicals
+      - :content_id: 70e6087f-714e-4922-8e06-72cfff997785
+        :title: Computer services
+        :value: computer-services
+      - :content_id: 9eb88205-118b-4f0b-abd9-ac6b469054c5
+        :title: Construction and contracting
+        :value: construction-contracting
+      - :content_id: 7c980b5d-a7ea-4d6e-aad1-e80e882566c4
+        :title: Education
+        :value: education
+      - :content_id: 14d13ea1-db43-4b35-9cc2-3808d4ff731d
+        :title: Electricity
+        :value: electricity
+      - :content_id: 01b51981-1ad6-4e45-9b14-b8a57fcb4204
+        :title: Electronics
+        :value: electronics
+      - :content_id: 3a8f00ff-f098-4fd1-81bc-7914e963f842
+        :title: Environmental services
+        :value: environmental-services
+      - :content_id: c5e26d37-def8-40aa-8b46-d9a23ffaceb1
+        :title: Fisheries
+        :value: fisheries
+      - :content_id: 53f9ce4c-7cbb-447f-bdf1-a9b022896d3a
+        :title: Food and drink
+        :value: food-and-drink
+      - :content_id: '040649fc-4e2c-4028-b846-77fe3eebd1f7'
+        :title: Furniture and other manufacturing
+        :value: furniture-and-other-manufacturing
+      - :content_id: bc7ac405-cc71-4507-9550-57ba5b78bfb2
+        :title: Gas markets
+        :value: gas-markets
+      - :content_id: b38b45c4-48dd-4307-ae45-8acf7d5929a7
+        :title: Imports
+        :value: imports
+      - :content_id: 34f45412-89d0-46fe-8004-b61c0c152d06
+        :title: Imputed rent
+        :value: imputed-rent
+      - :content_id: d6cdac38-eab5-4915-8917-b328c18957d8
+        :title: Insurance
+        :value: insurance
+      - :content_id: b13198f2-775e-4067-858b-93a10b3f9ea1
+        :title: Land transport (excluding rail)
+        :value: land-transport-excl-rail
+      - :content_id: 6e019777-9029-414b-b81e-ccb955669f86
+        :title: Medical services
+        :value: medical-services
+      - :content_id: c366fc8d-03d6-417c-9a23-6f1bce72db5c
+        :title: Motor trades
+        :value: motor-trades
+      - :content_id: 46ad5a1d-fc2d-4065-a34f-3f7b2fea8e81
+        :title: Oil and gas production
+        :value: oil-and-gas-production
+      - :content_id: d9da7c7b-b0c9-4757-aa45-9c70dd78df62
+        :title: Other personal services
+        :value: other-personal-services
+      - :content_id: 9c0d1627-0423-4159-a947-e6abab0d0afd
+        :title: Parts and machinery
+        :value: parts-and-machinery
+      - :content_id: 93f5c156-2449-4e52-9e92-aefc73586ffd
+        :title: Pharmaceuticals
+        :value: pharmaceuticals
+      - :content_id: 16a9ce39-7786-4ae2-8289-93d924c958a5
+        :title: Post
+        :value: post
+      - :content_id: f07527f1-e6de-4fe8-b7d9-b197769e1f1f
+        :title: Professional and business services
+        :value: professional-and-business-services
+      - :content_id: '091c0e83-bb54-4727-9b2c-a919510e1e79'
+        :title: Public administration and defence
+        :value: public-administration-and-defence
+      - :content_id: 53bcfcf0-e22a-416d-91ac-2661e1d6ed04
+        :title: Rail
+        :value: rail
+      - :content_id: dba1b198-1ead-4de4-a961-b11d71fc6f20
+        :title: Real estate (excluding imputed rent)
+        :value: real-estate-excl-imputed-rent
+      - :content_id: 34a6edd0-46ea-4a76-ae80-8c96709d4f59
+        :title: Retail
+        :value: retail
+      - :content_id: a9736af7-4e8b-4b1f-9a4b-9482252f4a4f
+        :title: Social work
+        :value: social-work
+      - :content_id: 99eeb13a-ce9d-49f6-aa5b-68d0e4a45358
+        :title: Steel and other metals or commodities
+        :value: steel-and-other-metals-commodities
+      - :content_id: f4e525fd-3f56-47c7-b4b7-d9c7664027ee
+        :title: Telecoms
+        :value: telecoms
+      - :content_id: 268d0c41-579c-4bc8-9f1c-7deb1f57352a
+        :title: Textiles and clothing
+        :value: textiles-and-clothing
+      - :content_id: 15ad9a45-5536-4323-97f9-ed470cdf1e3b
+        :title: Warehousing and support for transportation
+        :value: warehousing-and-support-for-transportation
+      - :content_id: 66c14974-d67e-4361-a14a-01804351ebd7
+        :title: Water transport including maritime and ports
+        :value: water-transport-maritime-ports
+      - :content_id: a788c432-0daa-4514-ab5b-777d013354d6
+        :title: Wholesale (excluding motor vehicles)
+        :value: wholesale-excl-motor-vehicles
+  - :content_id: e2febfa3-eac9-430b-bc6e-b0dff8876b1f
+    :title: "Business activity"
+    :key: business_activity
+    :facet_values:
+      - :content_id: a55f04df-3877-4c73-bbfe-ad7339cdfccf
+        :title: Sell products or goods in the UK
+        :value: products-or-goods
+      - :content_id: d422aa2e-59ad-4986-8ef0-973959878912
+        :title: Buy products or goods from abroad
+        :value: buying
+      - :content_id: 7283b8e1-840f-49da-967f-c0a512a3f531
+        :title: Sell products or goods abroad
+        :value: selling
+      - :content_id: 7ae8e57c-ea7a-42de-84fc-a084b5f64bca
+        :title: Do other types of business in the EU
+        :value: other-eu
+      - :content_id: '07398027-ee4d-4bda-b53e-2dc655734049'
+        :title: Transport goods abroad
+        :value: transporting
+  - :content_id: b2716a1e-dc24-4566-b8ed-f3ee23a994ec
+    :title: "Who you employ"
+    :key: employ_eu_citizens
+    :facet_values:
+      - :content_id: 5476f0c7-d029-459b-8a17-196374ae3366
+        :title: EU citizens
+        :value: 'yes'
+      - :content_id: bbdbda71-b1ec-46b8-a5b8-931d933288e9
+        :title: No EU citizens
+        :value: 'no'
+  - :content_id: 6cdb57df-3216-423c-9b7a-b1bde6b65d36
+    :title: "Personal data"
+    :key: personal_data
+    :facet_values:
+      - :content_id: c9aa5056-77d7-4bdb-af4f-7679dd1d6a2a
+        :title: Processing personal data from Europe
+        :value: processing-personal-data
+      - :content_id: af6c860e-6d0e-4045-a66a-b14040d63a20
+        :title: Using websites or services hosted in Europe
+        :value: interacting-with-eea-website
+      - :content_id: 855757bc-c578-4b78-9dfa-a75e2ae70eaa
+        :title: Providing digital services available to Europe
+        :value: digital-service-provider
+  - :content_id: a076c93a-cb66-4256-97d3-d038bce60e6a
+    :title: "Intellectual property"
+    :key: intellectual_property
+    :facet_values:
+      - :content_id: c308aa59-c234-48d4-885d-5d964e710bd1
+        :title: Copyright
+        :value: copyright
+      - :content_id: 231e7512-8054-41c6-80c5-9d353c7f1c52
+        :title: Trade marks
+        :value: trademarks
+      - :content_id: 4be67a27-0d5a-444b-9379-9161365206f7
+        :title: Designs
+        :value: designs
+      - :content_id: ed2109a5-5bc1-40f1-af71-3657263fd4e0
+        :title: Patents
+        :value: patents
+      - :content_id: 32282878-5d75-42be-911d-ef7ba102bc7f
+        :title: Exhaustion of rights
+        :value: exhaustion-of-rights
+  - :content_id: 805ab0e4-baf4-49ab-80ff-9ae7e472b074
+    :title: "EU or UK government funding"
+    :key: eu_uk_government_funding
+    :facet_values:
+      - :content_id: c1fcd375-897f-4a57-88e6-49d5b9a6799d
+        :title: EU funding
+        :value: receiving-eu-funding
+      - :content_id: 4dd0faa0-29e0-4be8-bb7d-88dc53bf9682
+        :title: UK government funding
+        :value: receiving-uk-government-funding
+  - :content_id: 8152d139-0ccd-46c2-bdb5-4f0771fd3903
+    :title: "Public sector procurement"
+    :key: public_sector_procurement
+    :facet_values:
+      - :content_id: f165dc7c-7cef-446a-bdfd-8a1ca685d091
+        :title: Civil government contracts
+        :value: civil-government-contracts
+      - :content_id: 33fc20d7-6a45-40c9-b31f-e4678f962ff1
+        :title: Defence contracts
+        :value: defence-contracts

--- a/lib/facet_data_tagger.rb
+++ b/lib/facet_data_tagger.rb
@@ -21,22 +21,10 @@ class FacetDataTagger
     )
   end
 
-  def facet_group_config
-    @facet_group_config ||= YAML.load_file(@facet_config_file_path)
-  end
-
-  def facets_from_config
-    facet_group_config[:facets]
-  end
-
-  def content_id_for_base_path(base_path)
-    paths_mapped_to_content_ids[base_path]
-  end
-
   # Patches facet_values links for each content item denoted by base path
   # in the facet data.
   #
-  def import_facet_data
+  def link_content_to_facet_values
     facet_data.each do |base_path, facet_data|
       content_id = content_id_for_base_path(base_path)
       if content_id
@@ -59,6 +47,16 @@ class FacetDataTagger
     end
   end
 
+private
+
+  def facets_from_config
+    facet_group_config[:facets]
+  end
+
+  def content_id_for_base_path(base_path)
+    paths_mapped_to_content_ids[base_path]
+  end
+
   # Creates a hash of arrays where the key is the facet name
   # and the value is an array of facet_value content_ids
   #
@@ -70,6 +68,10 @@ class FacetDataTagger
       facet_values << stripped_row_data.map { |v| facet[:facet_values].find { |fv| fv[:value] == v } }
     end
     facet_values.flatten.compact.map { |fv| fv[:content_id] }
+  end
+
+  def facet_group_config
+    @facet_group_config ||= YAML.load_file(@facet_config_file_path)
   end
 
   def publishing_api

--- a/lib/facet_data_tagger.rb
+++ b/lib/facet_data_tagger.rb
@@ -1,0 +1,78 @@
+require "csv"
+
+class FacetDataTagger
+  attr_reader :facet_data, :paths_mapped_to_content_ids
+
+  def initialize(data_file_path, facet_config_file_path)
+    @facet_config_file_path = facet_config_file_path
+    @facet_data = {}
+
+    CSV.foreach(data_file_path, converters: ->(v) { v || "" }) do |row|
+      base_path = row[0]
+
+      facet_data_for_path = facet_values_for_row(row)
+
+      @facet_data[base_path] = facet_data_for_path
+    end
+
+    @paths_mapped_to_content_ids = publishing_api.lookup_content_ids(
+      base_paths: @facet_data.keys,
+      with_drafts: true
+    )
+  end
+
+  def facet_group_config
+    @facet_group_config ||= YAML.load_file(@facet_config_file_path)
+  end
+
+  def facets_from_config
+    facet_group_config[:facets]
+  end
+
+  def content_id_for_base_path(base_path)
+    paths_mapped_to_content_ids[base_path]
+  end
+
+  # Patches facet_values links for each content item denoted by base path
+  # in the facet data.
+  #
+  def import_facet_data
+    facet_data.each do |base_path, facet_data|
+      content_id = content_id_for_base_path(base_path)
+      if content_id
+        publishing_api.patch_links(content_id, links: { facet_values: facet_data })
+      end
+    end
+  end
+
+  # Patches empty facet_values links for the content items
+  # at the relevant base paths
+  #
+  def remove_all_facet_data_for_base_paths(base_paths)
+    base_paths = Array(base_paths)
+
+    base_paths.each do |base_path|
+      content_id = content_id_for_base_path(base_path)
+      if content_id
+        publishing_api.patch_links(content_id, links: { facet_values: [] })
+      end
+    end
+  end
+
+  # Creates a hash of arrays where the key is the facet name
+  # and the value is an array of facet_value content_ids
+  #
+  def facet_values_for_row(row)
+    facet_values = []
+    facets_from_config.each_with_index do |facet, index|
+      row_index = index + 1
+      stripped_row_data = row.fetch(row_index, "").split(",").map(&:strip)
+      facet_values << stripped_row_data.map { |v| facet[:facet_values].find { |fv| fv[:value] == v } }
+    end
+    facet_values.flatten.compact.map { |fv| fv[:content_id] }
+  end
+
+  def publishing_api
+    Services.publishing_api_with_long_timeout
+  end
+end

--- a/lib/facet_group_importer.rb
+++ b/lib/facet_group_importer.rb
@@ -1,6 +1,6 @@
 class FacetGroupImporter
-  def initialize(import_file_name)
-    @import_file_name = import_file_name
+  def initialize(import_file_path)
+    @import_file_path = import_file_path
   end
 
   def import
@@ -34,7 +34,7 @@ class FacetGroupImporter
 
 private
 
-  attr_reader :import_file_name
+  attr_reader :import_file_path
 
   def create_draft(type, data)
     publishing_api.put_content(data[:content_id], send("#{type}_payload", data))
@@ -68,7 +68,7 @@ private
   end
 
   def facet_group_data
-    @facet_group_data ||= YAML.load_file(Rails.root.join("lib", "data", import_file_name))
+    @facet_group_data ||= YAML.load_file(import_file_path)
   end
 
   def publishing_api

--- a/lib/facet_group_importer.rb
+++ b/lib/facet_group_importer.rb
@@ -17,6 +17,17 @@ class FacetGroupImporter
     create_facet_group_links
   end
 
+  def publish
+    publishing_api.publish(facet_group_data[:content_id], "minor")
+    facet_group_data[:facets].each do |facet_data|
+      publishing_api.publish(facet_data[:content_id], "minor")
+
+      facet_data[:facet_values].each do |facet_value_data|
+        publishing_api.publish(facet_value_data[:content_id], "minor")
+      end
+    end
+  end
+
   def discard_draft_group
     discard_links(facet_group_data[:content_id], %i[facets])
     discard_draft(facet_group_data[:content_id])

--- a/lib/facet_group_importer.rb
+++ b/lib/facet_group_importer.rb
@@ -1,0 +1,129 @@
+class FacetGroupImporter
+  def initialize(import_file_name)
+    @import_file_name = import_file_name
+  end
+
+  def import
+    create_draft(:facet_group, facet_group_data)
+
+    facet_group_data[:facets].each do |facet_data|
+      create_draft(:facet, facet_data)
+
+      facet_data[:facet_values].each do |facet_value_data|
+        create_draft(:facet_value, facet_value_data)
+      end
+    end
+
+    create_facet_group_links
+  end
+
+  def discard_draft_group
+    discard_draft(facet_group_data[:content_id])
+    facet_group_data[:facets].each do |facet_data|
+      discard_draft(facet_data[:content_id])
+      facet_data[:facet_values].each do |facet_value_data|
+        discard_draft(facet_value_data[:content_id])
+      end
+    end
+
+    # TODO: Remove links?
+  end
+
+private
+  attr_reader :import_file_name
+
+  def create_draft(type, data)
+    publishing_api.put_content(data[:content_id], send("#{type}_payload", data))
+  end
+
+  def discard_draft(content_id)
+    publishing_api.discard_draft(content_id)
+  end
+
+  def create_facet_group_links
+    facets_data = facet_group_data[:facets]
+    # Create the links for the facet group
+    publishing_api.patch_links(facet_group_data[:content_id], facet_group_links_payload(facets_data))
+
+    # Create the links for the facets
+    facets_data.each do |facet|
+      facet_values_data = facet[:facet_values]
+
+      publishing_api.patch_links(facet[:content_id], facet_links_payload(facet_values_data))
+
+      # Create the links for the facet values
+      facet_values_data.each do |facet_value|
+        publishing_api.patch_links(facet_value[:content_id], facet_value_links_payload(facet))
+      end
+    end
+  end
+
+  def facet_group_data
+    @facet_group_data ||= YAML.load_file(Rails.root.join("lib", "data", import_file_name)) #.deep_symbolize_keys
+  end
+
+  def publishing_api
+    Services.publishing_api_with_long_timeout
+  end
+
+  def facet_group_payload(data)
+    {
+      document_type: "facet_group",
+      schema_name: "facet_group",
+      title: data[:title],
+      details: {
+        description: data[:description],
+        name: data[:title],
+      }
+    }.merge(publishing_and_rendering_apps)
+  end
+
+  def facet_payload(data)
+    {
+      document_type: "facet",
+      schema_name: "facet",
+      title: data[:title],
+      details: {
+        filterable: true,
+        key: data[:key],
+        name: data[:title],
+        type: "text",
+      }
+    }.merge(publishing_and_rendering_apps)
+  end
+
+  def facet_value_payload(data)
+    {
+      document_type: "facet_value",
+      schema_name: "facet_value",
+      title: data[:title],
+      details: {
+        label: data[:title],
+        value: data[:value],
+      }
+    }.merge(publishing_and_rendering_apps)
+  end
+
+  def publishing_and_rendering_apps
+    { publishing_app: "content-tagger", rendering_app: "finder-frontend" }
+  end
+
+  def facet_group_links_payload(facets)
+    links_payload(facets: facets.map { |f| f[:content_id] })
+  end
+
+  def facet_links_payload(facet_values)
+    links_payload(
+      facet_values: facet_values.map { |v| v[:content_id] },
+      parent: [facet_group_data[:content_id]],
+    )
+  end
+
+  def facet_value_links_payload(facet)
+    links_payload(parent: [facet[:content_id]])
+  end
+
+  def links_payload(links)
+    { links: links }
+  end
+end

--- a/lib/tasks/facets/facet_group.rake
+++ b/lib/tasks/facets/facet_group.rake
@@ -13,6 +13,14 @@ namespace :facets do
   end
 
   desc <<-DESC
+    Publishes a facet group defined in a YAML file located at `facet_group_file_path`.
+    This publishes a draft facet group created by the `import_facet_group` task.
+  DESC
+  task :publish_facet_group, [:facet_group_file_path] => :environment do |_, args|
+    FacetGroupImporter.new(args[:facet_group_file_path]).publish
+  end
+
+  desc <<-DESC
     Links the content items at the base paths in the tagging CSV file to the facet values
     matching the facet group definitions. This effectively tags content to facets.
   DESC

--- a/lib/tasks/facets/facet_group.rake
+++ b/lib/tasks/facets/facet_group.rake
@@ -1,0 +1,13 @@
+require "facet_group_importer"
+
+namespace :facets do
+  desc <<-DESC
+    Imports a facet group defined in a YAML file located at `facet_group_file_path`.
+    This creates the relevant facet_group, facets and facet_values content items
+    as drafts in the Publishing API. It also links these content items to reflect the
+    shallow tree structure of a facet group.
+  DESC
+  task :import_facet_group, [:facet_group_file_path] => :environment do |_, args|
+    FacetGroupImporter.new(args[:facet_group_file_path]).import
+  end
+end

--- a/lib/tasks/facets/facet_group.rake
+++ b/lib/tasks/facets/facet_group.rake
@@ -1,4 +1,5 @@
 require "facet_group_importer"
+require "facet_data_tagger"
 
 namespace :facets do
   desc <<-DESC
@@ -9,5 +10,13 @@ namespace :facets do
   DESC
   task :import_facet_group, [:facet_group_file_path] => :environment do |_, args|
     FacetGroupImporter.new(args[:facet_group_file_path]).import
+  end
+
+  desc <<-DESC
+    Links the content items at the base paths in the tagging CSV file to the facet values
+    matching the facet group definitions. This effectively tags content to facets.
+  DESC
+  task :tag_content_to_facet_values, %i[tagging_file_path facet_group_file_path] => :environment do |_, args|
+    FacetDataTagger.new(args[:tagging_file_path], args[:facet_group_file_path]).link_content_to_facet_values
   end
 end

--- a/spec/lib/facet_data_tagger_spec.rb
+++ b/spec/lib/facet_data_tagger_spec.rb
@@ -70,8 +70,8 @@ RSpec.describe FacetDataTagger do
     end
   end
 
-  describe "import_facet_data" do
-    before { instance.import_facet_data }
+  describe "link_content_to_facet_values" do
+    before { instance.link_content_to_facet_values }
 
     it "patches links in the Publishing API" do
       expect(publishing_api).to have_received(:patch_links).exactly(3).times

--- a/spec/lib/facet_data_tagger_spec.rb
+++ b/spec/lib/facet_data_tagger_spec.rb
@@ -1,0 +1,87 @@
+require "rails_helper"
+require "facet_data_tagger"
+
+RSpec.describe FacetDataTagger do
+  let(:publishing_api) { Services.publishing_api_with_long_timeout }
+  let(:facet_group) do
+    {
+      content_id: "abc-123-def-456",
+      title: "A facet group",
+      description: "Test data facet group",
+      facets: [
+        {
+          content_id: "bcd-234-efg-567",
+          title: "A facet",
+          key: "a_facet",
+          facet_values: [
+            {
+              content_id: "cde-345-fgh-678",
+              title: "A facet value",
+              value: "a-facet-value",
+            },
+            {
+              content_id: "def-456-ghi-789",
+              title: "Another facet value",
+              value: "another-facet-value",
+            },
+            {
+              content_id: "efg-567-hij-890",
+              title: "Yet another facet value",
+              value: "yet-another-facet-value",
+            },
+          ]
+        }
+      ]
+    }
+  end
+
+  let(:facet) { facet_group[:facets].first }
+  let(:content_ids_for_paths) do
+    {
+      "/foo" => "zyx-987-cba-654",
+      "/bar" => "cba-654-zyx-987",
+      "/meh" => "abc-987-def-654",
+    }
+  end
+
+  subject(:instance) { described_class.new("data.csv", "test-facets.yml") }
+
+  before do
+    allow(YAML).to receive(:load_file).and_return(facet_group)
+    allow(publishing_api).to receive(:patch_links)
+    allow(publishing_api).to receive(:lookup_content_ids).and_return(content_ids_for_paths)
+    allow(CSV).to receive(:foreach)
+      .and_yield(["/foo", "another-facet-value,yet-another-facet-value"])
+      .and_yield(["/bar", "a-facet-value"])
+      .and_yield(["/meh", "an-invalid-facet-value,a-facet-value"])
+      .and_yield(["/derp", "an-invalid-facet-value"])
+  end
+
+  describe "initialize" do
+    it "gets content ids matching paths" do
+      expect(instance.paths_mapped_to_content_ids).to eq(content_ids_for_paths)
+    end
+
+    it "populates facet data" do
+      expect(instance.facet_data["/foo"]).to eq(%w[def-456-ghi-789 efg-567-hij-890])
+      expect(instance.facet_data["/bar"]).to eq(%w[cde-345-fgh-678])
+      expect(instance.facet_data["/meh"]).to eq(%w[cde-345-fgh-678])
+      expect(instance.facet_data["/derp"]).to eq([])
+    end
+  end
+
+  describe "import_facet_data" do
+    before { instance.import_facet_data }
+
+    it "patches links in the Publishing API" do
+      expect(publishing_api).to have_received(:patch_links).exactly(3).times
+
+      expect(publishing_api).to have_received(:patch_links)
+        .with("zyx-987-cba-654", links: { facet_values: %w[def-456-ghi-789 efg-567-hij-890] })
+      expect(publishing_api).to have_received(:patch_links)
+        .with("cba-654-zyx-987", links: { facet_values: %w[cde-345-fgh-678] })
+      expect(publishing_api).to have_received(:patch_links)
+        .with("abc-987-def-654", links: { facet_values: %w[cde-345-fgh-678] })
+    end
+  end
+end

--- a/spec/lib/facet_group_importer_spec.rb
+++ b/spec/lib/facet_group_importer_spec.rb
@@ -30,8 +30,9 @@ RSpec.describe FacetGroupImporter do
     }
   end
   let(:facet) { facet_group[:facets].first }
+  let(:logger) { double(:logger, info: nil, warn: nil) }
 
-  subject(:instance) { described_class.new("/path/to/test-facets.yml") }
+  subject(:instance) { described_class.new("/path/to/test-facets.yml", logger) }
 
   before { allow(YAML).to receive(:load_file).and_return(facet_group) }
 

--- a/spec/lib/facet_group_importer_spec.rb
+++ b/spec/lib/facet_group_importer_spec.rb
@@ -176,4 +176,25 @@ RSpec.describe FacetGroupImporter do
         .with(facet_group[:content_id], links: { facets: [] })
     end
   end
+
+  describe "publish_facet_group" do
+    before do
+      allow(publishing_api).to receive(:publish)
+      instance.publish
+    end
+
+    it "publishes the draft facet group" do
+      expect(publishing_api).to have_received(:publish).with(facet_group[:content_id], "minor")
+    end
+
+    it "publishes the draft facets" do
+      expect(publishing_api).to have_received(:publish).with(facet[:content_id], "minor")
+    end
+
+    it "publishes the draft facet values" do
+      facet[:facet_values].each do |facet_value|
+        expect(publishing_api).to have_received(:publish).with(facet_value[:content_id], "minor")
+      end
+    end
+  end
 end

--- a/spec/lib/facet_group_importer_spec.rb
+++ b/spec/lib/facet_group_importer_spec.rb
@@ -1,0 +1,145 @@
+require 'rails_helper'
+require 'facet_group_importer'
+
+RSpec.describe FacetGroupImporter do
+  let(:publishing_api) { Services.publishing_api_with_long_timeout }
+  let(:facet_group) do
+    {
+      content_id: "abc-123-def-456",
+      title: "A facet group",
+      description: "Test data facet group",
+      facets: [
+        {
+          content_id: "bcd-234-efg-567",
+          title: "A facet",
+          key: "a_facet",
+          facet_values: [
+            {
+              content_id: "cde-345-fgh-678",
+              title: "A facet value",
+              value: "a-facet-value",
+            },
+            {
+              content_id: "def-456-ghi-789",
+              title: "Another facet value",
+              value: "another-facet-value",
+            },
+          ]
+        }
+      ]
+    }
+  end
+  let(:facet) { facet_group[:facets].first }
+
+  subject(:instance) { described_class.new("test-facets.yml") }
+
+  before { allow(YAML).to receive(:load_file).and_return(facet_group) }
+
+  describe "import" do
+    before do
+      allow(publishing_api).to receive(:put_content)
+      allow(publishing_api).to receive(:patch_links)
+      instance.import
+    end
+
+    it "reads facet group definitions from file" do
+      expect(YAML).to have_received(:load_file).with(Rails.root.join("lib", "data", "test-facets.yml"))
+    end
+
+    it "creates the facet_group content item" do
+      expect(publishing_api).to have_received(:put_content)
+        .with(facet_group[:content_id], a_hash_including(
+          document_type: "facet_group",
+          publishing_app: "content-tagger",
+          rendering_app: "finder-frontend",
+          schema_name: "facet_group",
+          title: "A facet group",
+          details: {
+            description: "Test data facet group",
+            name: "A facet group",
+          }
+        ))
+    end
+
+    it "creates the facets content items" do
+      expect(publishing_api).to have_received(:put_content)
+        .with(facet[:content_id], a_hash_including(
+          document_type: "facet",
+          publishing_app: "content-tagger",
+          rendering_app: "finder-frontend",
+          schema_name: "facet",
+          title: "A facet",
+          details: {
+            filterable: true,
+            key: "a_facet",
+            name: "A facet",
+            type: "text",
+          }
+        ))
+    end
+
+    it "creates the facet_values content items" do
+      facet[:facet_values].each do |facet_value|
+        expect(publishing_api).to have_received(:put_content)
+          .with(facet_value[:content_id], a_hash_including(
+            document_type: "facet_value",
+            publishing_app: "content-tagger",
+            rendering_app: "finder-frontend",
+            schema_name: "facet_value",
+            title: facet_value[:title],
+            details: {
+              label: facet_value[:title],
+              value: facet_value[:value],
+            }
+        ))
+      end
+    end
+
+    it "links the facet_groups to the facets" do
+      expect(publishing_api).to have_received(:patch_links)
+        .with(facet_group[:content_id], a_hash_including(
+          links: { facets: [facet[:content_id]] }
+        ))
+    end
+
+    it "links the facet_values to the facets" do
+      facet[:facet_values].each do |facet_value|
+        expect(publishing_api).to have_received(:patch_links)
+          .with(facet_value[:content_id], a_hash_including(
+            links: { parent: [facet[:content_id]] }
+          ))
+      end
+    end
+
+    it "links the facets to the facet group and facet values" do
+      expect(publishing_api).to have_received(:patch_links)
+        .with(facet[:content_id], a_hash_including(
+          links: {
+            facet_values: facet[:facet_values].map { |v| v[:content_id] },
+            parent: [facet_group[:content_id]],
+          }
+        ))
+    end
+  end
+
+  describe "discard_draft_group" do
+    before do
+      allow(publishing_api).to receive(:discard_draft)
+      instance.discard_draft_group
+    end
+
+    it "discards the draft facet group" do
+      expect(publishing_api).to have_received(:discard_draft).with(facet_group[:content_id])
+    end
+
+    it "discards the draft facets" do
+      expect(publishing_api).to have_received(:discard_draft).with(facet[:content_id])
+    end
+
+    it "discards the draft facet values" do
+      facet[:facet_values].each do |facet_value|
+        expect(publishing_api).to have_received(:discard_draft).with(facet_value[:content_id])
+      end
+    end
+  end
+end

--- a/spec/lib/facet_group_importer_spec.rb
+++ b/spec/lib/facet_group_importer_spec.rb
@@ -48,83 +48,102 @@ RSpec.describe FacetGroupImporter do
 
     it "creates the facet_group content item" do
       expect(publishing_api).to have_received(:put_content)
-        .with(facet_group[:content_id], a_hash_including(
-          document_type: "facet_group",
-          publishing_app: "content-tagger",
-          rendering_app: "finder-frontend",
-          schema_name: "facet_group",
-          title: "A facet group",
-          details: {
-            description: "Test data facet group",
-            name: "A facet group",
-          }
-        ))
+        .with(
+          facet_group[:content_id],
+          a_hash_including(
+            document_type: "facet_group",
+            publishing_app: "content-tagger",
+            rendering_app: "finder-frontend",
+            schema_name: "facet_group",
+            title: "A facet group",
+            details: {
+              description: "Test data facet group",
+              name: "A facet group",
+            }
+          )
+        )
     end
 
     it "creates the facets content items" do
       expect(publishing_api).to have_received(:put_content)
-        .with(facet[:content_id], a_hash_including(
-          document_type: "facet",
-          publishing_app: "content-tagger",
-          rendering_app: "finder-frontend",
-          schema_name: "facet",
-          title: "A facet",
-          details: {
-            filterable: true,
-            key: "a_facet",
-            name: "A facet",
-            type: "text",
-          }
-        ))
+        .with(
+          facet[:content_id],
+          a_hash_including(
+            document_type: "facet",
+            publishing_app: "content-tagger",
+            rendering_app: "finder-frontend",
+            schema_name: "facet",
+            title: "A facet",
+            details: {
+              filterable: true,
+              key: "a_facet",
+              name: "A facet",
+              type: "text",
+            }
+          )
+        )
     end
 
     it "creates the facet_values content items" do
       facet[:facet_values].each do |facet_value|
         expect(publishing_api).to have_received(:put_content)
-          .with(facet_value[:content_id], a_hash_including(
-            document_type: "facet_value",
-            publishing_app: "content-tagger",
-            rendering_app: "finder-frontend",
-            schema_name: "facet_value",
-            title: facet_value[:title],
-            details: {
-              label: facet_value[:title],
-              value: facet_value[:value],
-            }
-        ))
+          .with(
+            facet_value[:content_id],
+            a_hash_including(
+              document_type: "facet_value",
+              publishing_app: "content-tagger",
+              rendering_app: "finder-frontend",
+              schema_name: "facet_value",
+              title: facet_value[:title],
+              details: {
+                label: facet_value[:title],
+                value: facet_value[:value],
+              }
+            )
+          )
       end
     end
 
     it "links the facet_groups to the facets" do
       expect(publishing_api).to have_received(:patch_links)
-        .with(facet_group[:content_id], a_hash_including(
-          links: { facets: [facet[:content_id]] }
-        ))
+        .with(
+          facet_group[:content_id],
+          a_hash_including(
+            links: { facets: [facet[:content_id]] }
+          )
+        )
     end
 
     it "links the facet_values to the facets" do
       facet[:facet_values].each do |facet_value|
         expect(publishing_api).to have_received(:patch_links)
-          .with(facet_value[:content_id], a_hash_including(
-            links: { parent: [facet[:content_id]] }
-          ))
+          .with(
+            facet_value[:content_id],
+            a_hash_including(
+              links: { parent: [facet[:content_id]] }
+            )
+          )
       end
     end
 
     it "links the facets to the facet group and facet values" do
       expect(publishing_api).to have_received(:patch_links)
-        .with(facet[:content_id], a_hash_including(
-          links: {
-            facet_values: facet[:facet_values].map { |v| v[:content_id] },
-            parent: [facet_group[:content_id]],
-          }
-        ))
+        .with(
+          facet[:content_id],
+          a_hash_including(
+            links: {
+              facet_values: facet[:facet_values].map { |v| v[:content_id] },
+              parent: [facet_group[:content_id]],
+            }
+          )
+        )
     end
   end
 
   describe "discard_draft_group" do
     before do
       allow(publishing_api).to receive(:discard_draft)
+      allow(publishing_api).to receive(:patch_links)
       instance.discard_draft_group
     end
 
@@ -140,6 +159,21 @@ RSpec.describe FacetGroupImporter do
       facet[:facet_values].each do |facet_value|
         expect(publishing_api).to have_received(:discard_draft).with(facet_value[:content_id])
       end
+    end
+
+    it "patches empty facet group links" do
+      expect(publishing_api).to have_received(:patch_links)
+        .with(facet_group[:content_id], links: { facets: [] })
+    end
+
+    it "patches empty facet links" do
+      expect(publishing_api).to have_received(:patch_links)
+        .with(facet[:content_id], links: { facet_group: [], facet_values: [] })
+    end
+
+    it "patches empty facet value links" do
+      expect(publishing_api).to have_received(:patch_links)
+        .with(facet_group[:content_id], links: { facets: [] })
     end
   end
 end

--- a/spec/lib/facet_group_importer_spec.rb
+++ b/spec/lib/facet_group_importer_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe FacetGroupImporter do
   end
   let(:facet) { facet_group[:facets].first }
 
-  subject(:instance) { described_class.new("test-facets.yml") }
+  subject(:instance) { described_class.new("/path/to/test-facets.yml") }
 
   before { allow(YAML).to receive(:load_file).and_return(facet_group) }
 
@@ -43,7 +43,7 @@ RSpec.describe FacetGroupImporter do
     end
 
     it "reads facet group definitions from file" do
-      expect(YAML).to have_received(:load_file).with(Rails.root.join("lib", "data", "test-facets.yml"))
+      expect(YAML).to have_received(:load_file).with("/path/to/test-facets.yml")
     end
 
     it "creates the facet_group content item" do


### PR DESCRIPTION
https://trello.com/c/qI4D3Y7w/246-make-facet-tree-available-to-publishing-api
https://trello.com/c/b9pAtzOV/265-populate-content-with-links-to-our-new-facet-tags

This PR adds a couple of importer classes:
- `FacetGroupImporter` which can import a predefined facet group structure comprised of facets and their associated values. This can be run with the rake task `facets:import_facet_group[facet_group_file_path]`
- `FacetDataTagger` which uses the same data CSV as existing metadata tagging to link content in the publishing API to the facet values imported by the above class. This can be run with `facets:tag_content_to_facet_values[tagging_data_file_path,facet_group_file_path]`