### PR TITLE
Tag content with facet values

### DIFF
--- a/app/models/facets/remote_facet_groups_service.rb
+++ b/app/models/facets/remote_facet_groups_service.rb
@@ -1,5 +1,13 @@
 module Facets
   class RemoteFacetGroupsService
+    # TODO: There's currently only one facet group defined, and we don't yet
+    # have a sophisticated enough UI to 'choose' different facet groups so
+    # defining the group here means we can default to the only published group
+    # for now. This will save on an additional call to the publishing API.
+    # Once we have multiple groups and a UI to handle choosing a group to use
+    # when tagging content, this constant can be removed.
+    PUBLISHED_FACET_GROUPS = %w[52435175-82ed-4a04-adef-74c0199d0f46].freeze
+
     def find_all
       facet_group_content_items.to_hash["results"]
     end
@@ -11,7 +19,7 @@ module Facets
   private
 
     # Returns a facet group from the publishing API.
-    def facet_group_content_items(query = '', states = %w(published))
+    def facet_group_content_items(query = '', states = %w[published])
       Services
         .publishing_api_with_long_timeout
         .get_content_items(

--- a/app/models/facets/remote_facet_groups_service.rb
+++ b/app/models/facets/remote_facet_groups_service.rb
@@ -1,0 +1,32 @@
+module Facets
+  class RemoteFacetGroupsService
+    def find_all
+      facet_group_content_items.to_hash["results"]
+    end
+
+    def find(content_id)
+      expanded_facet_group(content_id).to_hash
+    end
+
+  private
+
+    # Returns a facet group from the publishing API.
+    def facet_group_content_items(query = '', states = %w(published))
+      Services
+        .publishing_api_with_long_timeout
+        .get_content_items(
+          document_type: 'facet_group',
+          order: '-public_updated_at',
+          q: query || '',
+          search_in: %i[title],
+          page: 1,
+          per_page: 50,
+          states: states,
+        )
+    end
+
+    def expanded_facet_group(content_id)
+      Services.publishing_api_with_long_timeout.get_expanded_links(content_id)
+    end
+  end
+end

--- a/app/models/linkables.rb
+++ b/app/models/linkables.rb
@@ -28,6 +28,10 @@ class Linkables
     @mainstream_browse_pages ||= for_nested_document_type('mainstream_browse_page')
   end
 
+  def facet_values
+    @facet_values ||= for_facet_group
+  end
+
 private
 
   def for_document_type(document_type, include_draft: true)
@@ -50,6 +54,12 @@ private
       .select { |item| item.fetch('internal_name').include?(' / ') }
 
     organise_items(present_items(items))
+  end
+
+  def for_facet_group(content_id = Facets::RemoteFacetGroupsService::PUBLISHED_FACET_GROUPS.first)
+    Facets::FacetGroupPresenter.new(
+      Facets::RemoteFacetGroupsService.new.find(content_id)
+    ).grouped_facet_values
   end
 
   def present_items(items)

--- a/app/models/tagging/content_item_expanded_links.rb
+++ b/app/models/tagging/content_item_expanded_links.rb
@@ -12,6 +12,7 @@ module Tagging
       topics
       organisations
       meets_user_needs
+      facet_values
     ].freeze
 
     attr_accessor(*TAG_TYPES)

--- a/app/presenters/facets/base_presenter.rb
+++ b/app/presenters/facets/base_presenter.rb
@@ -1,0 +1,25 @@
+module Facets
+  class BasePresenter
+    attr_reader :raw_data
+
+    def initialize(raw_data)
+      @raw_data = raw_data
+    end
+
+    def content_id
+      raw_data["content_id"]
+    end
+
+    def title
+      raw_data["title"]
+    end
+
+    def details
+      raw_data.fetch("details", {})
+    end
+
+    def links
+      raw_data.fetch("links", {})
+    end
+  end
+end

--- a/app/presenters/facets/facet_group_presenter.rb
+++ b/app/presenters/facets/facet_group_presenter.rb
@@ -1,0 +1,31 @@
+module Facets
+  class FacetGroupPresenter < BasePresenter
+    def name
+      details["name"]
+    end
+
+    def description
+      details["description"]
+    end
+
+    def state
+      raw_data["publication_state"]
+    end
+
+    def facets
+      expanded_links.fetch("facets", []).map do |facet_data|
+        Facets::FacetPresenter.new(facet_data)
+      end
+    end
+
+    def grouped_facet_values
+      facets.map { |f| { id: f.key, text: f.title, children: f.facet_values.map(&:option_data) } }
+    end
+
+  private
+
+    def expanded_links
+      raw_data.fetch("expanded_links", {})
+    end
+  end
+end

--- a/app/presenters/facets/facet_group_presenter.rb
+++ b/app/presenters/facets/facet_group_presenter.rb
@@ -19,7 +19,9 @@ module Facets
     end
 
     def grouped_facet_values
-      facets.map { |f| { id: f.key, text: f.title, children: f.facet_values.map(&:option_data) } }
+      facets.map do |f|
+        [f.title, f.facet_values.map { |fv| [fv.label, fv.content_id] }]
+      end
     end
 
   private

--- a/app/presenters/facets/facet_presenter.rb
+++ b/app/presenters/facets/facet_presenter.rb
@@ -1,0 +1,13 @@
+module Facets
+  class FacetPresenter < BasePresenter
+    def key
+      details["key"]
+    end
+
+    def facet_values
+      links.fetch("facet_values", []).map do |facet_value_data|
+        Facets::FacetValuePresenter.new(facet_value_data)
+      end
+    end
+  end
+end

--- a/app/presenters/facets/facet_value_presenter.rb
+++ b/app/presenters/facets/facet_value_presenter.rb
@@ -1,0 +1,10 @@
+module Facets
+  class FacetValuePresenter < BasePresenter
+    def option_data
+      {
+        id: details["value"],
+        text: details["label"],
+      }
+    end
+  end
+end

--- a/app/presenters/facets/facet_value_presenter.rb
+++ b/app/presenters/facets/facet_value_presenter.rb
@@ -1,10 +1,11 @@
 module Facets
   class FacetValuePresenter < BasePresenter
-    def option_data
-      {
-        id: details["value"],
-        text: details["label"],
-      }
+    def label
+      details["label"]
+    end
+
+    def value
+      details["value"]
     end
   end
 end

--- a/app/services/tagging/tagging_update_form.rb
+++ b/app/services/tagging/tagging_update_form.rb
@@ -73,5 +73,9 @@ module Tagging
         send("#{tag_type}=", params[tag_type])
       end
     end
+
+    def facet_values
+      links.facet_values.map { |fv| fv["content_id"] }
+    end
   end
 end

--- a/app/views/taggings/_form_for_facet_values.html.erb
+++ b/app/views/taggings/_form_for_facet_values.html.erb
@@ -1,0 +1,12 @@
+<h3>Facets</h3>
+
+<%= f.input :facet_values,
+    as: :grouped_select,
+    collection: linkables.facet_values,
+    group_method: :last,
+    placeholder: "Choose one...",
+    input_html: { multiple: true, class: :select2 } %>
+
+<p class="explain">
+  This facet metadata is currently being developed.
+</p>

--- a/config/blacklisted_tag_types.yml
+++ b/config/blacklisted_tag_types.yml
@@ -62,6 +62,7 @@ test:
     - organisations
     - parent
     - taxons
+    - facet_values
 
 production:
   <<: *default

--- a/spec/features/related_item_tagging_spec.rb
+++ b/spec/features/related_item_tagging_spec.rb
@@ -33,6 +33,8 @@ RSpec.describe "Tagging content", type: :feature do
   end
 
   def and_i_navigate_to_tagging_page_for_item
+    stub_facet_group_lookup
+
     visit "/taggings/MY-CONTENT-ID"
   end
 
@@ -105,6 +107,7 @@ RSpec.describe "Tagging content", type: :feature do
       topics: [],
       organisations: [],
       meets_user_needs: [],
+      facet_values: [],
     )
   end
 end

--- a/spec/models/facets/remote_facet_groups_service_spec.rb
+++ b/spec/models/facets/remote_facet_groups_service_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Facets::RemoteFacetGroupsService do
           search_in: %i[title],
           page: 1,
           per_page: 50,
-          states: %w(published),
+          states: %w[published],
         )
     end
   end

--- a/spec/models/facets/remote_facet_groups_service_spec.rb
+++ b/spec/models/facets/remote_facet_groups_service_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe Facets::RemoteFacetGroupsService do
+  let(:publishing_api) { Services.publishing_api_with_long_timeout }
+
+  describe "find_all" do
+    let(:api_response) { double(:response, to_hash: { "results" => "Woo!" }) }
+
+    before do
+      allow(publishing_api).to receive(:get_content_items).and_return(api_response)
+    end
+
+    it "fetches all facet groups from the publishing api" do
+      result = subject.find_all
+      expect(result).to eq("Woo!")
+      expect(publishing_api).to have_received(:get_content_items)
+        .with(
+          document_type: "facet_group",
+          order: "-public_updated_at",
+          q: "",
+          search_in: %i[title],
+          page: 1,
+          per_page: 50,
+          states: %w(published),
+        )
+    end
+  end
+
+  describe "find" do
+    let(:api_response) { double(:response, to_hash: "Yeah!") }
+    before do
+      allow(publishing_api).to receive(:get_expanded_links).and_return(api_response)
+    end
+
+    it "fetches the expanded facet group from the publishing api" do
+      result = subject.find("abc-123")
+      expect(result).to eq("Yeah!")
+      expect(publishing_api).to have_received(:get_expanded_links).with("abc-123")
+    end
+  end
+end

--- a/spec/presenters/facets/facet_group_presenter_spec.rb
+++ b/spec/presenters/facets/facet_group_presenter_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe Facets::FacetGroupPresenter do
+  let(:raw_data) do
+    {
+      "content_id" => "abc-123",
+      "title" => "Facet group 1",
+      "details" => { "name" => "Facet group 1", "description" => "This is facet group 1" },
+      "publication_state" => "published",
+      "expanded_links" => {
+        "facets" => [
+          {
+            "title" => "Facet 1",
+            "details" => { "key" => "facet_1" },
+            "links" => {
+              "facet_values" => [
+                {
+                  "details" => { "label" => "Facet value 1", "value" => "facet_value_1" }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  end
+
+  subject(:instance) { described_class.new(raw_data) }
+
+  describe "facet group attributes" do
+    it "exposes content_id, title, name, description and state" do
+      expect(instance.content_id).to eq(raw_data["content_id"])
+      expect(instance.title).to eq(raw_data["title"])
+      expect(instance.name).to eq(raw_data["details"]["name"])
+      expect(instance.description).to eq(raw_data["details"]["description"])
+      expect(instance.state).to eq(raw_data["publication_state"])
+    end
+  end
+
+  describe "facets" do
+    it "presents facets" do
+      expect(instance.facets.first).to be_a(Facets::FacetPresenter)
+    end
+  end
+
+  describe "grouped_facet_values" do
+    it "creates a nested facet hash" do
+      expect(instance.grouped_facet_values).to eq(
+        [
+          {
+            id: "facet_1", text: "Facet 1",
+            children: [{ id: "facet_value_1", text: "Facet value 1" }],
+          }
+        ]
+      )
+    end
+  end
+end

--- a/spec/presenters/facets/facet_group_presenter_spec.rb
+++ b/spec/presenters/facets/facet_group_presenter_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe Facets::FacetGroupPresenter do
             "links" => {
               "facet_values" => [
                 {
-                  "details" => { "label" => "Facet value 1", "value" => "facet_value_1" }
+                  "content_id" => "FACET-VALUE-UUID",
+                  "details" => { "label" => "Facet value 1" }
                 }
               ]
             }
@@ -46,12 +47,7 @@ RSpec.describe Facets::FacetGroupPresenter do
   describe "grouped_facet_values" do
     it "creates a nested facet hash" do
       expect(instance.grouped_facet_values).to eq(
-        [
-          {
-            id: "facet_1", text: "Facet 1",
-            children: [{ id: "facet_value_1", text: "Facet value 1" }],
-          }
-        ]
+        [["Facet 1", [["Facet value 1", "FACET-VALUE-UUID"]]]]
       )
     end
   end

--- a/spec/presenters/facets/facet_presenter_spec.rb
+++ b/spec/presenters/facets/facet_presenter_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe Facets::FacetPresenter do
+  let(:raw_data) do
+    {
+      "content_id" => "abc-123",
+      "title" => "Facet 1",
+      "details" => { "key" => "facet_1" },
+      "links" => {
+        "facet_values" => [
+          { "title" => "Facet value 1" }
+        ]
+      }
+    }
+  end
+
+  subject(:instance) { described_class.new(raw_data) }
+
+  describe "facet attributes" do
+    it "exposes content_id, title and key" do
+      expect(instance.content_id).to eq(raw_data["content_id"])
+      expect(instance.title).to eq(raw_data["title"])
+      expect(instance.key).to eq(raw_data["details"]["key"])
+    end
+  end
+
+  describe "facet_values" do
+    it "presents facet values" do
+      expect(instance.facet_values.first).to be_a(Facets::FacetValuePresenter)
+    end
+  end
+end

--- a/spec/support/publishing_api_helper.rb
+++ b/spec/support/publishing_api_helper.rb
@@ -118,8 +118,25 @@ module PublishingApiHelper
     )
   end
 
+  def publishing_api_has_facet_values_linkables(labels)
+    publishing_api_has_linkables(
+      stubbed_facet_values.select { |fv| labels.include?(fv["title"]) },
+      document_type: 'facet_value'
+    )
+  end
+
   def select_by_base_path(tags, base_paths)
     tags.select { |tag| base_paths.include?(tag["base_path"]) }
+  end
+
+  def stub_facet_group_lookup
+    content_id = Facets::RemoteFacetGroupsService::PUBLISHED_FACET_GROUPS.first
+    stub_request(:get, "#{PUBLISHING_API}/v2/expanded-links/#{content_id}")
+    .to_return(body: {
+      content_id: content_id,
+      expanded_links: example_facet_group,
+      version: 54_321,
+    }.to_json)
   end
 
   def stubbed_taxons
@@ -200,5 +217,51 @@ module PublishingApiHelper
         "internal_name" => "Driving and transport / Vehicle tax and SORN"
       },
     ]
+  end
+
+  def stubbed_facet_values
+    [
+      {
+        "public_updated_at" => "2018-06-20 10:19:10",
+        "title" => "Agriculture",
+        "content_id" => "FACET-VALUE-UUID",
+        "publication_state" => "published",
+      }
+    ]
+  end
+
+  def example_facet_value
+    {
+      "content_id" => "EXISTING-FACET-VALUE-UUID",
+      "title" => "Agriculture",
+      "details" => {
+        "label" => "Agriculture",
+        "value" => "agriculture",
+      }
+    }
+  end
+
+  def example_facet_group
+    {
+      "title" => "Example facet group",
+      "facets" => [
+        {
+          "title" => "Example facet",
+          "links" => {
+            "facet_values" => [
+              {
+                "content_id" => "ANOTHER-FACET-VALUE-UUID",
+                "title" => "Aerospace",
+                "details" => {
+                  "label" => "Aerospace",
+                  "value" => "aerospace",
+                }
+              },
+              example_facet_value
+            ]
+          }
+        }
+      ]
+    }
   end
 end


### PR DESCRIPTION
https://trello.com/c/ws1zcCKX/286-update-facet-values-for-a-content-item

![Screenshot_from_2019-03-14_16-38-40](https://user-images.githubusercontent.com/93511/54433341-83ab9b80-4723-11e9-9cdc-aeb721a4c451.png)

This PR appends an additional _Facets_ tagging select2 input which allows facet values to be updated for a content item.

At present there's only one facet group defined in the Publishing API hence the hard-wiring to this specific group until we've iterated the UI to tag within the context of multiple facet groups.
This feature means we can opt to update specific content item `facet_values` links in content tagger similar to topics and related links. The aim being to ultimately replace the current metadata tagging process in Rummager.