### PR TITLE
[Do not merge] [WIP] Add, edit and delete facet values for a page

### DIFF
--- a/app/controllers/facet_groups_controller.rb
+++ b/app/controllers/facet_groups_controller.rb
@@ -1,0 +1,14 @@
+class FacetGroupsController < ApplicationController
+  def index
+    results = Facets::RemoteFacetGroupsService.new.find_all
+
+    @facet_groups = results.map do |result|
+      Facets::FacetGroupPresenter.new(result)
+    end
+  end
+
+  def show
+    result = Facets::RemoteFacetGroupsService.new.find(params[:facet_group_content_id])
+    @facet_group = Facets::FacetGroupPresenter.new(result)
+  end
+end

--- a/app/controllers/facet_taggings_controller.rb
+++ b/app/controllers/facet_taggings_controller.rb
@@ -1,0 +1,45 @@
+class FacetTaggingsController < ::TaggingsController
+  # TODO: Check permissions to administer facet values
+  def find_by_slug
+    content_lookup = ContentLookupForm.new(lookup_params)
+
+    if content_lookup.valid?
+      redirect_to facet_group_facet_tagging_path(content_id: content_lookup.content_id)
+    else
+      render :lookup, locals: { lookup: content_lookup }
+    end
+  end
+
+  def show
+    content_item = ContentItem.find!(params[:content_id])
+
+    render :show, locals: {
+      tagging_update: Facets::TaggingUpdateForm.from_content_item(content_item)
+    }
+  rescue ContentItem::ItemNotFoundError
+    render "item_not_found", status: 404
+  end
+
+  def update
+    content_item = ContentItem.find!(params[:content_id])
+    publisher = Facets::TaggingUpdatePublisher.new(content_item, params[:facets_tagging_update_form])
+
+    if publisher.save_to_publishing_api
+      redirect_back(
+        fallback_location: facet_group_facet_tagging_path(content_item.content_id),
+        success: "Facet values have been updated!"
+      )
+    else
+      tagging_update = Facets::TaggingUpdateForm.from_content_item(content_item)
+      tagging_update.update_attributes_from_form(params[:facets_tagging_update_form])
+
+      flash.now[:danger] = "This form contains errors. Please correct them and try again."
+      render :show, locals: { tagging_update: tagging_update }
+    end
+  rescue GdsApi::HTTPConflict
+    redirect_back(
+      fallback_location: facets_tagging_path(content_item.content_id),
+      danger: "Somebody changed the tags before you could. Your changes have not been saved."
+    )
+  end
+end

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -39,6 +39,10 @@ class ContentItem
     @link_set ||= Tagging::ContentItemExpandedLinks.find(content_id)
   end
 
+  def facets_link_set
+    @facets_link_set ||= Facets::ContentItemExpandedLinks.find(content_id)
+  end
+
   def taxons?
     link_set.taxons.present?
   end

--- a/app/models/facets/content_item_expanded_links.rb
+++ b/app/models/facets/content_item_expanded_links.rb
@@ -1,18 +1,9 @@
-module Tagging
+module Facets
   class ContentItemExpandedLinks
     include ActiveModel::Model
     attr_accessor :content_id, :previous_version
 
-    TAG_TYPES = %i[
-      taxons
-      ordered_related_items
-      ordered_related_items_overrides
-      mainstream_browse_pages
-      parent
-      topics
-      organisations
-      meets_user_needs
-    ].freeze
+    TAG_TYPES = %i[facet_groups facet_values].freeze
 
     attr_accessor(*TAG_TYPES)
 

--- a/app/models/facets/remote_facet_groups_service.rb
+++ b/app/models/facets/remote_facet_groups_service.rb
@@ -1,5 +1,13 @@
 module Facets
   class RemoteFacetGroupsService
+    # TODO: There's currently only one facet group defined, and we don't yet
+    # have a sophisticated enough UI to 'choose' different facet groups so
+    # defining the group here means we can default to the only published group
+    # for now. This will save on an additional call to the publishing API.
+    # Once we have multiple groups and a UI to handle choosing a group to use
+    # when tagging content, this constant can be removed.
+    PUBLISHED_FACET_GROUPS = %w[52435175-82ed-4a04-adef-74c0199d0f46].freeze
+
     def find_all
       facet_group_content_items.to_hash["results"]
     end
@@ -11,7 +19,7 @@ module Facets
   private
 
     # Returns a facet group from the publishing API.
-    def facet_group_content_items(query = '', states = %w(published))
+    def facet_group_content_items(query = '', states = %w[published])
       Services
         .publishing_api_with_long_timeout
         .get_content_items(

--- a/app/models/facets/remote_facet_groups_service.rb
+++ b/app/models/facets/remote_facet_groups_service.rb
@@ -1,0 +1,32 @@
+module Facets
+  class RemoteFacetGroupsService
+    def find_all
+      facet_group_content_items.to_hash["results"]
+    end
+
+    def find(content_id)
+      expanded_facet_group(content_id).to_hash
+    end
+
+  private
+
+    # Returns a facet group from the publishing API.
+    def facet_group_content_items(query = '', states = %w(published))
+      Services
+        .publishing_api_with_long_timeout
+        .get_content_items(
+          document_type: 'facet_group',
+          order: '-public_updated_at',
+          q: query || '',
+          search_in: %i[title],
+          page: 1,
+          per_page: 50,
+          states: states,
+        )
+    end
+
+    def expanded_facet_group(content_id)
+      Services.publishing_api_with_long_timeout.get_expanded_links(content_id)
+    end
+  end
+end

--- a/app/models/linkables.rb
+++ b/app/models/linkables.rb
@@ -28,6 +28,10 @@ class Linkables
     @mainstream_browse_pages ||= for_nested_document_type('mainstream_browse_page')
   end
 
+  def facet_values
+    @facet_values ||= for_facet_group
+  end
+
 private
 
   def for_document_type(document_type, include_draft: true)
@@ -50,6 +54,12 @@ private
       .select { |item| item.fetch('internal_name').include?(' / ') }
 
     organise_items(present_items(items))
+  end
+
+  def for_facet_group(content_id = Facets::RemoteFacetGroupsService::PUBLISHED_FACET_GROUPS.first)
+    Facets::FacetGroupPresenter.new(
+      Facets::RemoteFacetGroupsService.new.find(content_id)
+    ).grouped_facet_values
   end
 
   def present_items(items)

--- a/app/models/tagging/content_item_expanded_links.rb
+++ b/app/models/tagging/content_item_expanded_links.rb
@@ -12,6 +12,7 @@ module Tagging
       topics
       organisations
       meets_user_needs
+      facet_values
     ].freeze
 
     attr_accessor(*TAG_TYPES)

--- a/app/presenters/facets/base_presenter.rb
+++ b/app/presenters/facets/base_presenter.rb
@@ -1,0 +1,25 @@
+module Facets
+  class BasePresenter
+    attr_reader :raw_data
+
+    def initialize(raw_data)
+      @raw_data = raw_data
+    end
+
+    def content_id
+      raw_data["content_id"]
+    end
+
+    def title
+      raw_data["title"]
+    end
+
+    def details
+      raw_data.fetch("details", {})
+    end
+
+    def links
+      raw_data.fetch("links", {})
+    end
+  end
+end

--- a/app/presenters/facets/facet_group_presenter.rb
+++ b/app/presenters/facets/facet_group_presenter.rb
@@ -1,0 +1,31 @@
+module Facets
+  class FacetGroupPresenter < BasePresenter
+    def name
+      details["name"]
+    end
+
+    def description
+      details["description"]
+    end
+
+    def state
+      raw_data["publication_state"]
+    end
+
+    def facets
+      expanded_links.fetch("facets", []).map do |facet_data|
+        Facets::FacetPresenter.new(facet_data)
+      end
+    end
+
+    def grouped_facet_values
+      facets.map { |f| { id: f.key, text: f.title, children: f.facet_values.map(&:option_data) } }
+    end
+
+  private
+
+    def expanded_links
+      raw_data.fetch("expanded_links", {})
+    end
+  end
+end

--- a/app/presenters/facets/facet_group_presenter.rb
+++ b/app/presenters/facets/facet_group_presenter.rb
@@ -19,7 +19,9 @@ module Facets
     end
 
     def grouped_facet_values
-      facets.map { |f| { id: f.key, text: f.title, children: f.facet_values.map(&:option_data) } }
+      facets.map do |f|
+        [f.title, f.facet_values.map { |fv| [fv.label, fv.content_id] }]
+      end
     end
 
   private

--- a/app/presenters/facets/facet_presenter.rb
+++ b/app/presenters/facets/facet_presenter.rb
@@ -1,0 +1,13 @@
+module Facets
+  class FacetPresenter < BasePresenter
+    def key
+      details["key"]
+    end
+
+    def facet_values
+      links.fetch("facet_values", []).map do |facet_value_data|
+        Facets::FacetValuePresenter.new(facet_value_data)
+      end
+    end
+  end
+end

--- a/app/presenters/facets/facet_value_presenter.rb
+++ b/app/presenters/facets/facet_value_presenter.rb
@@ -1,0 +1,10 @@
+module Facets
+  class FacetValuePresenter < BasePresenter
+    def option_data
+      {
+        id: details["value"],
+        text: details["label"],
+      }
+    end
+  end
+end

--- a/app/presenters/facets/facet_value_presenter.rb
+++ b/app/presenters/facets/facet_value_presenter.rb
@@ -1,10 +1,11 @@
 module Facets
   class FacetValuePresenter < BasePresenter
-    def option_data
-      {
-        id: details["value"],
-        text: details["label"],
-      }
+    def label
+      details["label"]
+    end
+
+    def value
+      details["value"]
     end
   end
 end

--- a/app/services/facets/tagging_update_form.rb
+++ b/app/services/facets/tagging_update_form.rb
@@ -1,0 +1,67 @@
+module Facets
+  # ActiveModel-compliant object that is passed into the tagging form.
+  class TaggingUpdateForm
+    include ActiveModel::Model
+    attr_accessor :content_item, :previous_version, :links
+
+    delegate :content_id, to: :content_item
+
+    TAG_TYPES = %i[facet_groups facet_values].freeze
+    attr_accessor(*TAG_TYPES)
+
+    def self.from_content_item(content_item)
+      links = content_item.facets_link_set
+
+      tag_values = TAG_TYPES.each_with_object({}) do |tag_type, current_tags|
+        current_tags[tag_type] = links.send(tag_type).map { |links_hash| links_hash["content_id"] }
+
+        base_paths = links.send(tag_type).map { |links_hash| links_hash["base_path"] }
+
+        # The number of extra empty form fields to add to a link section when the link
+        # section shows an individual form input for each value. This allows users to
+        # append new links to the end of the existing list.
+        empty_entries = [""] * 5
+        current_tags[tag_type] = base_paths + empty_entries
+      end
+
+      new(
+        links: links,
+        content_item: content_item,
+        previous_version: links.previous_version,
+        **tag_values
+      )
+    end
+
+    def allowed_tag_types
+      TAG_TYPES
+    end
+
+    def linkables
+      @linkables ||= Linkables.new
+    end
+
+    def update_attributes_from_form(params)
+      @previous_version = params[:previous_version]
+
+      TAG_TYPES.each do |tag_type|
+        send("#{tag_type}=", params[tag_type])
+      end
+    end
+
+    def facet_group_name
+      links.facet_groups.first["title"]
+    end
+
+    def facet_groups
+      links.facet_groups.map { |fv| fv["content_id"] }
+    end
+
+    def facet_values
+      links.facet_values.map { |fv| fv["content_id"] }
+    end
+
+    def promoted
+      false
+    end
+  end
+end

--- a/app/services/facets/tagging_update_publisher.rb
+++ b/app/services/facets/tagging_update_publisher.rb
@@ -1,0 +1,46 @@
+# Receives the form input from the user and sends the links to the
+# publishing-api.
+module Facets
+  class TaggingUpdatePublisher
+    attr_reader :content_item, :params
+
+    def initialize(content_item, params)
+      @content_item = content_item
+      @params = params
+    end
+
+    def save_to_publishing_api
+      return false unless valid?
+
+      Services.statsd.time "patch_links" do
+        Services.publishing_api.patch_links(
+          content_item.content_id,
+          links: generate_links_payload,
+          previous_version: params[:previous_version].to_i,
+        )
+      end
+    end
+
+    def generate_links_payload
+      TaggingUpdateForm::TAG_TYPES.reduce({}) do |payload, tag_type|
+        content_ids = fetch_content_ids(tag_type)
+
+        payload.merge(tag_type => content_ids)
+      end
+    end
+
+  private
+
+    def fetch_content_ids(tag_type)
+      clean_input_array(params[tag_type])
+    end
+
+    def valid?
+      true
+    end
+
+    def clean_input_array(select_form_input)
+      Array(select_form_input).select(&:present?)
+    end
+  end
+end

--- a/app/services/tagging/tagging_update_form.rb
+++ b/app/services/tagging/tagging_update_form.rb
@@ -73,5 +73,9 @@ module Tagging
         send("#{tag_type}=", params[tag_type])
       end
     end
+
+    def facet_values
+      links.facet_values.map { |fv| fv["content_id"] }
+    end
   end
 end

--- a/app/views/facet_groups/index.html.erb
+++ b/app/views/facet_groups/index.html.erb
@@ -1,0 +1,30 @@
+<%= display_header title: "All facet groups", breadcrumbs: [] %>
+
+<table class="state-table add-bottom-margin">
+  <thead class="text-muted">
+    <tr>
+      <th>
+        state
+      </th>
+      <th>
+        name
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @facet_groups.each do |group| %>
+    <tr>
+      <td>
+        <span class="label add-right-margin state-label--<%= group.state %>">
+          <%= group.state %>
+        </span>
+      </td>
+      <td>
+        <span class="add-right-margin">
+        <%= link_to group.title, lookup_facet_group_facet_taggings_path(facet_group_content_id: group.content_id) %>
+        </span>
+      </td>
+    </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/facet_groups/show.html.erb
+++ b/app/views/facet_groups/show.html.erb
@@ -1,0 +1,12 @@
+<ul>
+<% @facet_group.facets.each do |facet| %>
+  <li>
+    <h3><%= facet.title %></h3>
+    <ul>
+    <% facet.facet_values.each do |facet_value| %>
+      <li><%= facet_value.title %></li>
+    <% end %>
+    </ul>
+  </li>
+<% end %>
+</ul>

--- a/app/views/facet_taggings/_form_for_facet_groups.html.erb
+++ b/app/views/facet_taggings/_form_for_facet_groups.html.erb
@@ -1,0 +1,5 @@
+<%= f.input :facet_groups, as: :hidden, value: params[:facet_group_id] %>
+
+<p>
+  You are tagging this content to facet values in the '<%= f.object.facet_group_name %>' facet group.
+</p>

--- a/app/views/facet_taggings/_form_for_facet_values.html.erb
+++ b/app/views/facet_taggings/_form_for_facet_values.html.erb
@@ -10,3 +10,8 @@
 <p class="explain">
   This facet metadata is currently being developed.
 </p>
+
+<p>
+  <%= check_box_tag "promoted", f.object.promoted %>
+  &nbsp;Promote this item in finder results
+</p>

--- a/app/views/facet_taggings/_tagging_form.html.erb
+++ b/app/views/facet_taggings/_tagging_form.html.erb
@@ -1,0 +1,18 @@
+<%= simple_form_for tagging_update, url: facet_group_facet_tagging_path, method: 'put' do |f| %>
+  <%= f.hidden_field :content_id %>
+  <%= f.hidden_field :previous_version %>
+
+  <% tagging_update.allowed_tag_types.each do |tag_type| %>
+    <div class='tag-section'>
+      <%= render "form_for_#{tag_type}", {
+        f: f,
+        linkables: tagging_update.linkables,
+        tagging_update: tagging_update
+      } %>
+    </div>
+  <% end %>
+
+  <hr/>
+
+  <%= f.submit I18n.t('taggings.update_facets'), class: "btn btn-lg btn-success" %>
+<% end %>

--- a/app/views/facet_taggings/lookup.html.erb
+++ b/app/views/facet_taggings/lookup.html.erb
@@ -1,0 +1,22 @@
+<%= display_header title: t('navigation.tagging_title'),
+  breadcrumbs: [t('navigation.tagging_content')] %>
+
+<div class="lead">
+  Enter the URL or path of a GOV.UK page to edit its tagging or related links.
+</div>
+
+<%= simple_form_for lookup,
+    url: lookup_facet_group_facet_taggings_path(params[:facet_group_content_id]) do |f| %>
+  <div class="form-group">
+    <%= f.input :base_path,
+      label: false,
+      required: false,
+      input_html: { class: 'form-control' }
+    %>
+
+    For example: <%= link_to "https://www.gov.uk/pay-vat", "/taggings/lookup/pay-vat" %>
+    or <%= link_to "/bank-holidays", "/taggings/lookup/bank-holidays" %>
+  </div>
+
+  <%= submit_tag I18n.t('taggings.search'), class: 'btn btn-success btn-md' %>
+<% end %>

--- a/app/views/taggings/_form_for_facet_values.html.erb
+++ b/app/views/taggings/_form_for_facet_values.html.erb
@@ -1,0 +1,12 @@
+<h3>Facets</h3>
+
+<%= f.input :facet_values,
+    as: :grouped_select,
+    collection: linkables.facet_values,
+    group_method: :last,
+    placeholder: "Choose one...",
+    input_html: { multiple: true, class: :select2 } %>
+
+<p class="explain">
+  This facet metadata is currently being developed.
+</p>

--- a/config/blacklisted_tag_types.yml
+++ b/config/blacklisted_tag_types.yml
@@ -62,6 +62,7 @@ test:
     - organisations
     - parent
     - taxons
+    - facet_values
 
 production:
   <<: *default

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,6 +73,13 @@ Rails.application.routes.draw do
 
   resources :tagging_history, only: %i[index show]
 
+  resources :facet_groups, only: %i[index show], param: :content_id do
+    resources :facet_taggings, only: %i[show update], param: :content_id do
+      get '/lookup', action: 'lookup', on: :collection
+      post '/lookup', action: 'find_by_slug', on: :collection
+    end
+  end
+
   if Rails.env.development?
     mount GovukAdminTemplate::Engine, at: '/style-guide'
 

--- a/spec/controllers/facets/facet_groups_controller_spec.rb
+++ b/spec/controllers/facets/facet_groups_controller_spec.rb
@@ -1,0 +1,59 @@
+require "rails_helper"
+
+RSpec.describe Facets::FacetGroupsController do
+  let(:facet_groups_service) do
+    double(:service, find_all: [{ "content_id" => "xyz-987" }])
+  end
+
+  before do
+    allow(Facets::RemoteFacetGroupsService).to receive(:new)
+      .and_return(facet_groups_service)
+  end
+
+  describe "GET #index" do
+    it "returns a success response" do
+      get :index
+      expect(response).to be_successful
+    end
+
+    it "fetches facet groups from a service" do
+      get :index
+
+      expect(facet_groups_service).to have_received(:find_all).once
+    end
+
+    it "presents results" do
+      expect(Facets::FacetGroupPresenter).to receive(:new)
+        .with("content_id" => "xyz-987")
+
+      get :index
+    end
+  end
+
+  describe "GET #show" do
+    before do
+      allow(facet_groups_service).to receive(:find)
+        .with("xyz-987")
+        .and_return("title" => "A facet group")
+    end
+
+    it "returns a success response" do
+      get :show, params: { id: "xyz-987" }
+      expect(response).to be_successful
+    end
+
+    it "fetches the facet group from a service" do
+      get :show, params: { id: "xyz-987" }
+
+      expect(facet_groups_service).to have_received(:find)
+        .with("xyz-987")
+    end
+
+    it "presents a facet group" do
+      expect(Facets::FacetGroupPresenter).to receive(:new)
+        .with("title" => "A facet group")
+
+      get :show, params: { id: "xyz-987" }
+    end
+  end
+end

--- a/spec/features/related_item_tagging_spec.rb
+++ b/spec/features/related_item_tagging_spec.rb
@@ -33,6 +33,8 @@ RSpec.describe "Tagging content", type: :feature do
   end
 
   def and_i_navigate_to_tagging_page_for_item
+    stub_facet_group_lookup
+
     visit "/taggings/MY-CONTENT-ID"
   end
 
@@ -105,6 +107,7 @@ RSpec.describe "Tagging content", type: :feature do
       topics: [],
       organisations: [],
       meets_user_needs: [],
+      facet_values: [],
     )
   end
 end

--- a/spec/features/tag_a_page_spec.rb
+++ b/spec/features/tag_a_page_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe "Tagging content", type: :feature do
     and_i_see_the_taxon_form
 
     when_i_select_an_additional_topic("Business tax / Pension scheme administration")
+    when_i_select_an_additional_facet_value("Agriculture")
     and_i_submit_the_form
 
     then_the_publishing_api_is_sent(
@@ -29,7 +30,7 @@ RSpec.describe "Tagging content", type: :feature do
       topics: ["e1d6b771-a692-4812-a4e7-7562214286ef", example_topic['content_id']],
       organisations: [],
       meets_user_needs: [],
-      facet_values: [],
+      facet_values: ["FACET-VALUE-UUID"],
     )
   end
 
@@ -225,6 +226,9 @@ RSpec.describe "Tagging content", type: :feature do
     values.each do |i, value|
       expect(fields[i].value).to eq(value)
     end
+  end
+
+  def and_the_facet_values_should_be_prefilled_with(values)
   end
 
   def then_i_am_on_the_page_for_an_item

--- a/spec/features/tag_facets_to_a_page_spec.rb
+++ b/spec/features/tag_facets_to_a_page_spec.rb
@@ -1,0 +1,97 @@
+require "rails_helper"
+
+RSpec.describe "Tagging content with facets", type: :feature do
+  include PublishingApiHelper
+
+  before do
+    stub_facet_groups_lookup
+    given_we_can_populate_facets_with_content_from_publishing_api
+  end
+
+  scenario "User tags a content item with facet values" do
+    given_there_is_a_content_item_with_expanded_links(
+      facet_groups: [example_facet_group],
+      facet_values: [example_facet_value],
+    )
+    when_i_visit_facet_groups_page
+    and_i_select_the_facet_group("Example facet group")
+    and_i_edit_facets_for_the_page("/my-content-item")
+    and_i_see_the_facet_values_form_prefilled_with("Agriculture")
+
+    when_i_select_an_additional_facet_value("Aerospace")
+
+    and_i_submit_the_facets_tagging_form
+
+    then_the_publishing_api_is_sent(
+      facet_groups: ["abc-123"],
+      facet_values: ["ANOTHER-FACET-VALUE-UUID", "EXISTING-FACET-VALUE-UUID"],
+    )
+  end
+
+  def given_we_can_populate_facets_with_content_from_publishing_api
+    publishing_api_has_facet_values_linkables(%w[Agriculture"])
+  end
+
+  def given_there_is_a_content_item_with_expanded_links(**expanded_links)
+    publishing_api_has_lookups(
+      '/my-content-item' => 'MY-CONTENT-ID'
+    )
+
+    stub_request(:get, "#{PUBLISHING_API}/v2/content/MY-CONTENT-ID")
+      .to_return(body: {
+        publishing_app: "a-migrated-app",
+        rendering_app: "frontend",
+        content_id: "MY-CONTENT-ID",
+        base_path: '/my-content-item',
+        document_type: 'guide',
+        title: 'This Is A Content Item',
+      }.to_json)
+
+    stub_request(:get, "#{PUBLISHING_API}/v2/expanded-links/MY-CONTENT-ID?generate=true")
+      .to_return(body: {
+        content_id: "MY-CONTENT-ID",
+        expanded_links: expanded_links,
+        version: 54_321,
+      }.to_json)
+
+    stub_facet_group_lookup
+  end
+
+  def when_i_visit_facet_groups_page
+    visit facet_groups_path
+  end
+
+  def and_i_select_the_facet_group(name)
+    click_link name
+  end
+
+  def and_i_edit_facets_for_the_page(path)
+    fill_in 'content_lookup_form_base_path', with: path
+    click_on 'Edit page'
+  end
+
+  def and_i_see_the_facet_values_form_prefilled_with(option)
+    facet_values_options = all('#facets_tagging_update_form_facet_values option').map(&:text)
+    expect(facet_values_options).to include(option)
+  end
+
+  def and_i_submit_the_facets_tagging_form
+    click_on I18n.t('taggings.update_facets')
+  end
+
+  def when_i_select_an_additional_facet_value(selection)
+    @facets_tagging_request = stub_request(:patch, "#{PUBLISHING_API}/v2/links/MY-CONTENT-ID")
+      .to_return(status: 200)
+
+    select selection, from: "Facet values"
+  end
+
+  def then_the_publishing_api_is_sent(**links)
+    body = {
+      links: links,
+      previous_version: 54_321,
+    }
+
+    expect(@facets_tagging_request.with(body: body.to_json)).to have_been_made
+  end
+end

--- a/spec/features/viewing_facet_group_spec.rb
+++ b/spec/features/viewing_facet_group_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.feature 'View a facet group', type: :feature do
+  include PublishingApiHelper
+
+  scenario 'Viewing a published facet group' do
+    given_there_is_a_published_facet_group
+    when_i_view_the_facet_group
+    i_can_see_facets_and_facet_values_for_the_facet_group
+  end
+
+  def given_there_is_a_published_facet_group
+    stub_facet_groups_lookup
+    stub_facet_group_lookup
+
+    visit facets_facet_groups_path
+  end
+
+  def when_i_view_the_facet_group
+    click_link 'Example facet group'
+  end
+
+  def i_can_see_facets_and_facet_values_for_the_facet_group
+    expect(page).to have_content("Example facet")
+    expect(page).to have_content("Agriculture")
+    expect(page).to have_content("Aerospace")
+  end
+end

--- a/spec/models/facets/remote_facet_groups_service_spec.rb
+++ b/spec/models/facets/remote_facet_groups_service_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Facets::RemoteFacetGroupsService do
           search_in: %i[title],
           page: 1,
           per_page: 50,
-          states: %w(published),
+          states: %w[published],
         )
     end
   end

--- a/spec/models/facets/remote_facet_groups_service_spec.rb
+++ b/spec/models/facets/remote_facet_groups_service_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe Facets::RemoteFacetGroupsService do
+  let(:publishing_api) { Services.publishing_api_with_long_timeout }
+
+  describe "find_all" do
+    let(:api_response) { double(:response, to_hash: { "results" => "Woo!" }) }
+
+    before do
+      allow(publishing_api).to receive(:get_content_items).and_return(api_response)
+    end
+
+    it "fetches all facet groups from the publishing api" do
+      result = subject.find_all
+      expect(result).to eq("Woo!")
+      expect(publishing_api).to have_received(:get_content_items)
+        .with(
+          document_type: "facet_group",
+          order: "-public_updated_at",
+          q: "",
+          search_in: %i[title],
+          page: 1,
+          per_page: 50,
+          states: %w(published),
+        )
+    end
+  end
+
+  describe "find" do
+    let(:api_response) { double(:response, to_hash: "Yeah!") }
+    before do
+      allow(publishing_api).to receive(:get_expanded_links).and_return(api_response)
+    end
+
+    it "fetches the expanded facet group from the publishing api" do
+      result = subject.find("abc-123")
+      expect(result).to eq("Yeah!")
+      expect(publishing_api).to have_received(:get_expanded_links).with("abc-123")
+    end
+  end
+end

--- a/spec/presenters/facets/facet_group_presenter_spec.rb
+++ b/spec/presenters/facets/facet_group_presenter_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe Facets::FacetGroupPresenter do
+  let(:raw_data) do
+    {
+      "content_id" => "abc-123",
+      "title" => "Facet group 1",
+      "details" => { "name" => "Facet group 1", "description" => "This is facet group 1" },
+      "publication_state" => "published",
+      "expanded_links" => {
+        "facets" => [
+          {
+            "title" => "Facet 1",
+            "details" => { "key" => "facet_1" },
+            "links" => {
+              "facet_values" => [
+                {
+                  "details" => { "label" => "Facet value 1", "value" => "facet_value_1" }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  end
+
+  subject(:instance) { described_class.new(raw_data) }
+
+  describe "facet group attributes" do
+    it "exposes content_id, title, name, description and state" do
+      expect(instance.content_id).to eq(raw_data["content_id"])
+      expect(instance.title).to eq(raw_data["title"])
+      expect(instance.name).to eq(raw_data["details"]["name"])
+      expect(instance.description).to eq(raw_data["details"]["description"])
+      expect(instance.state).to eq(raw_data["publication_state"])
+    end
+  end
+
+  describe "facets" do
+    it "presents facets" do
+      expect(instance.facets.first).to be_a(Facets::FacetPresenter)
+    end
+  end
+
+  describe "grouped_facet_values" do
+    it "creates a nested facet hash" do
+      expect(instance.grouped_facet_values).to eq(
+        [
+          {
+            id: "facet_1", text: "Facet 1",
+            children: [{ id: "facet_value_1", text: "Facet value 1" }],
+          }
+        ]
+      )
+    end
+  end
+end

--- a/spec/presenters/facets/facet_group_presenter_spec.rb
+++ b/spec/presenters/facets/facet_group_presenter_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe Facets::FacetGroupPresenter do
             "links" => {
               "facet_values" => [
                 {
-                  "details" => { "label" => "Facet value 1", "value" => "facet_value_1" }
+                  "content_id" => "FACET-VALUE-UUID",
+                  "details" => { "label" => "Facet value 1" }
                 }
               ]
             }
@@ -46,12 +47,7 @@ RSpec.describe Facets::FacetGroupPresenter do
   describe "grouped_facet_values" do
     it "creates a nested facet hash" do
       expect(instance.grouped_facet_values).to eq(
-        [
-          {
-            id: "facet_1", text: "Facet 1",
-            children: [{ id: "facet_value_1", text: "Facet value 1" }],
-          }
-        ]
+        [["Facet 1", [["Facet value 1", "FACET-VALUE-UUID"]]]]
       )
     end
   end

--- a/spec/presenters/facets/facet_presenter_spec.rb
+++ b/spec/presenters/facets/facet_presenter_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe Facets::FacetPresenter do
+  let(:raw_data) do
+    {
+      "content_id" => "abc-123",
+      "title" => "Facet 1",
+      "details" => { "key" => "facet_1" },
+      "links" => {
+        "facet_values" => [
+          { "title" => "Facet value 1" }
+        ]
+      }
+    }
+  end
+
+  subject(:instance) { described_class.new(raw_data) }
+
+  describe "facet attributes" do
+    it "exposes content_id, title and key" do
+      expect(instance.content_id).to eq(raw_data["content_id"])
+      expect(instance.title).to eq(raw_data["title"])
+      expect(instance.key).to eq(raw_data["details"]["key"])
+    end
+  end
+
+  describe "facet_values" do
+    it "presents facet values" do
+      expect(instance.facet_values.first).to be_a(Facets::FacetValuePresenter)
+    end
+  end
+end

--- a/spec/support/publishing_api_helper.rb
+++ b/spec/support/publishing_api_helper.rb
@@ -118,8 +118,25 @@ module PublishingApiHelper
     )
   end
 
+  def publishing_api_has_facet_values_linkables(labels)
+    publishing_api_has_linkables(
+      stubbed_facet_values.select { |fv| labels.include?(fv["title"]) },
+      document_type: 'facet_value'
+    )
+  end
+
   def select_by_base_path(tags, base_paths)
     tags.select { |tag| base_paths.include?(tag["base_path"]) }
+  end
+
+  def stub_facet_group_lookup
+    content_id = Facets::RemoteFacetGroupsService::PUBLISHED_FACET_GROUPS.first
+    stub_request(:get, "#{PUBLISHING_API}/v2/expanded-links/#{content_id}")
+    .to_return(body: {
+      content_id: content_id,
+      expanded_links: example_facet_group,
+      version: 54_321,
+    }.to_json)
   end
 
   def stubbed_taxons
@@ -200,5 +217,51 @@ module PublishingApiHelper
         "internal_name" => "Driving and transport / Vehicle tax and SORN"
       },
     ]
+  end
+
+  def stubbed_facet_values
+    [
+      {
+        "public_updated_at" => "2018-06-20 10:19:10",
+        "title" => "Agriculture",
+        "content_id" => "FACET-VALUE-UUID",
+        "publication_state" => "published",
+      }
+    ]
+  end
+
+  def example_facet_value
+    {
+      "content_id" => "EXISTING-FACET-VALUE-UUID",
+      "title" => "Agriculture",
+      "details" => {
+        "label" => "Agriculture",
+        "value" => "agriculture",
+      }
+    }
+  end
+
+  def example_facet_group
+    {
+      "title" => "Example facet group",
+      "facets" => [
+        {
+          "title" => "Example facet",
+          "links" => {
+            "facet_values" => [
+              {
+                "content_id" => "ANOTHER-FACET-VALUE-UUID",
+                "title" => "Aerospace",
+                "details" => {
+                  "label" => "Aerospace",
+                  "value" => "aerospace",
+                }
+              },
+              example_facet_value
+            ]
+          }
+        }
+      ]
+    }
   end
 end

--- a/spec/support/publishing_api_helper.rb
+++ b/spec/support/publishing_api_helper.rb
@@ -1,4 +1,5 @@
 require_relative('email_alert_api_helper')
+require 'facets/remote_facet_groups_service'
 
 module PublishingApiHelper
   include EmailAlertApiHelper
@@ -129,8 +130,15 @@ module PublishingApiHelper
     tags.select { |tag| base_paths.include?(tag["base_path"]) }
   end
 
-  def stub_facet_group_lookup
-    content_id = Facets::RemoteFacetGroupsService::PUBLISHED_FACET_GROUPS.first
+  def stub_facet_groups_lookup
+    stub_request(:get, "#{PUBLISHING_API}/v2/content?document_type=facet_group&order=-public_updated_at&page=1&per_page=50&q=&search_in[]=title&states[]=published")
+    .to_return(body: {
+      results: [example_facet_group],
+    }.to_json)
+  end
+
+  def stub_facet_group_lookup(content_id = "abc-123")
+    stub_const "Facets::RemoteFacetGroupsService::PUBLISHED_FACET_GROUPS", [content_id]
     stub_request(:get, "#{PUBLISHING_API}/v2/expanded-links/#{content_id}")
     .to_return(body: {
       content_id: content_id,
@@ -243,9 +251,11 @@ module PublishingApiHelper
 
   def example_facet_group
     {
+      "content_id" => "abc-123",
       "title" => "Example facet group",
       "facets" => [
         {
+          "content_id" => "def-456",
           "title" => "Example facet",
           "links" => {
             "facet_values" => [


### PR DESCRIPTION
https://trello.com/c/LflCRvo3/285-view-facet-group-in-content-tagger

![Screenshot from 2019-03-18 12-39-00](https://user-images.githubusercontent.com/93511/54530519-e5197780-497a-11e9-8aad-f7965bdfc89c.png)

Initial work to display published facet groups in content tagger. This will be the basis of CRUD operations on these content items.

Do not merge as we're looking at how to best present this information.