### PR TITLE
Add missing `filter_key` from facet group importer

### DIFF
--- a/lib/data/find-eu-exit-guidance-business.yml
+++ b/lib/data/find-eu-exit-guidance-business.yml
@@ -8,6 +8,7 @@
     :key: sector_business_area
     :display_as_result_metadata: true
     :filterable: true
+    :filter_key: facet_values
     :combine_mode: and
     :preposition: "your business is in"
     :type: content_id
@@ -146,6 +147,7 @@
     :key: business_activity
     :display_as_result_metadata: true
     :filterable: true
+    :filter_key: facet_values
     :combine_mode: and
     :preposition: "you"
     :type: content_id
@@ -170,6 +172,7 @@
     :key: employ_eu_citizens
     :display_as_result_metadata: true
     :filterable: true
+    :filter_key: facet_values
     :combine_mode: or
     :preposition: "you employ"
     :type: content_id
@@ -185,6 +188,7 @@
     :key: personal_data
     :display_as_result_metadata: true
     :filterable: true
+    :filter_key: facet_values
     :combine_mode: or
     :preposition: "you exchange personal data by"
     :type: content_id
@@ -203,6 +207,7 @@
     :key: intellectual_property
     :display_as_result_metadata: true
     :filterable: true
+    :filter_key: facet_values
     :combine_mode: or
     :preposition: "you use or rely on"
     :type: content_id
@@ -227,6 +232,7 @@
     :key: eu_uk_government_funding
     :display_as_result_metadata: true
     :filterable: true
+    :filter_key: facet_values
     :combine_mode: or
     :preposition: "you get"
     :type: content_id
@@ -242,6 +248,7 @@
     :key: public_sector_procurement
     :display_as_result_metadata: true
     :filterable: true
+    :filter_key: facet_values
     :combine_mode: or
     :preposition: "you apply for"
     :type: content_id

--- a/lib/facet_group_importer.rb
+++ b/lib/facet_group_importer.rb
@@ -116,7 +116,7 @@ private
       title: data[:name],
       details: data.slice(
         *:combine_mode, :display_as_result_metadata,
-        :filterable, :key, :name, :preposition, :type
+        :filterable, :key, :filter_key, :name, :preposition, :type
       )
     }.merge(publishing_and_rendering_apps)
   end

--- a/spec/lib/facet_group_importer_spec.rb
+++ b/spec/lib/facet_group_importer_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe FacetGroupImporter do
           name: "A facet",
           preposition: "do something with",
           type: "content_id",
+          filter_key: 'facet_filter_key',
           facet_values: [
             {
               content_id: "cde-345-fgh-678",
@@ -85,6 +86,7 @@ RSpec.describe FacetGroupImporter do
               display_as_result_metadata: true,
               filterable: true,
               key: "a_facet",
+              filter_key: 'facet_filter_key',
               name: "A facet",
               preposition: "do something with",
               type: "content_id",


### PR DESCRIPTION
The new finder-frontend facet links needs this.

Trello: https://trello.com/c/Sd7omEFH/263-mapping-rummager-request-response-in-finder-frontend