### PR TITLE
Fix return value bug when saving to Publishing API

### DIFF
--- a/app/services/facets/tagging_update_publisher.rb
+++ b/app/services/facets/tagging_update_publisher.rb
@@ -19,36 +19,36 @@ module Facets
         )
       end
 
-      promote_finder_item
-    end
-
-    # Updates a finder content item so that it contains the
-    # content_id of the current content item in the ordered_related_items
-    # collection. This is how items get promoted or pinned in a finder.
-    def promote_finder_item
-      content_id = content_item.content_id
-      updated_pinned_items = pinned_items.dup
-
-      method = params[:promoted] ? :push : :delete
-      updated_pinned_items.send(method, content_id)
-      updated_pinned_items = updated_pinned_items.sort.uniq
-
-      return if updated_pinned_items == pinned_items
-
-      # TODO: Currently only one finder is linked to a facet group
-      # so there's only one item which can be pinned. In future we
-      # will need to look up finders linked to groups.
-      Services.statsd.time "patch_links" do
-        Services.publishing_api.patch_links(
-          FinderService::LINKED_FINDER_CONTENT_ID,
-          links: { "ordered_related_items": updated_pinned_items }
-        )
+      # Updates a finder content item so that it contains the
+      # content_id of the current content item in the ordered_related_items
+      # collection. This is how items get promoted or pinned in a finder.
+      updated_items = updated_pinned_items
+      unless updated_items == pinned_items
+        # TODO: Currently only one finder is linked to a facet group
+        # so there's only one item which can be pinned. In future we
+        # will need to look up finders linked to groups.
+        Services.statsd.time "patch_links" do
+          Services.publishing_api.patch_links(
+            FinderService::LINKED_FINDER_CONTENT_ID,
+            links: { "ordered_related_items": updated_items }
+          )
+        end
       end
+
+      true
     end
 
   private
 
     attr_reader :facet_group_content_id
+
+    def updated_pinned_items
+      updated_pinned_items = pinned_items.dup
+
+      method = params[:promoted] ? :push : :delete
+      updated_pinned_items.send(method, content_item.content_id)
+      updated_pinned_items.sort.uniq
+    end
 
     def generate_links_payload
       facet_groups_content_ids = fetch_content_ids(:facet_groups)

--- a/spec/services/facets/tagging_update_publisher_spec.rb
+++ b/spec/services/facets/tagging_update_publisher_spec.rb
@@ -1,0 +1,77 @@
+require 'rails_helper'
+
+RSpec.describe Facets::TaggingUpdatePublisher do
+  let(:publishing_api) { Services.publishing_api }
+
+  describe "save_to_publishing_api" do
+    let(:facet_group_content_id) { "FACET-GROUP-CONTENT-ID" }
+    let(:finder_content_id) { "FINDER-CONTENT-ID" }
+    let(:pinned_item_links) { ["PINNED-ITEM-UUID"] }
+    let(:finder_service_class) { Facets::FinderService }
+    let(:finder_service) { double(:finder_service, pinned_item_links: pinned_item_links) }
+    let(:content_item) { double(:content_item, content_id: "MY-CONTENT-ID") }
+    let(:params) do
+      {
+        facet_groups: [facet_group_content_id],
+        facet_values: ["A-FACET-VALUE-UUID"]
+      }
+    end
+
+    subject(:instance) { described_class.new(content_item, params, facet_group_content_id) }
+
+    before do
+      stub_const "#{finder_service_class}::LINKED_FINDER_CONTENT_ID", finder_content_id
+      allow(finder_service_class).to receive(:new).and_return(finder_service)
+      allow(publishing_api).to receive(:patch_links)
+    end
+
+    it "patches content item links" do
+      instance.save_to_publishing_api
+
+      expect(publishing_api).to have_received(:patch_links)
+        .with(
+          "MY-CONTENT-ID",
+          links: {
+            facet_groups: ["FACET-GROUP-CONTENT-ID"],
+            facet_values: ["A-FACET-VALUE-UUID"],
+          },
+          previous_version: 0,
+        )
+    end
+
+    it "returns a truthy result" do
+      expect(instance.save_to_publishing_api).to be_truthy
+    end
+
+    context "without pinning the content" do
+      it "does not patch finder links" do
+        instance.save_to_publishing_api
+
+        expect(publishing_api).not_to have_received(:patch_links)
+          .with(finder_content_id, anything)
+      end
+    end
+
+    context "pinning the content" do
+      let(:params) do
+        {
+          facet_groups: [facet_group_content_id],
+          facet_values: ["A-FACET-VALUE-UUID"],
+          promoted: true,
+        }
+      end
+
+      it "patches finder links" do
+        instance.save_to_publishing_api
+
+        expect(publishing_api).to have_received(:patch_links)
+          .with(
+            finder_content_id,
+            links: {
+              ordered_related_items: ["MY-CONTENT-ID", "PINNED-ITEM-UUID"],
+            },
+          )
+      end
+    end
+  end
+end


### PR DESCRIPTION
The return value from `save_to_publishing_api` was not always truthy
even when a successful update had occurred.
This results in a tagging UI error message which was misleading, the method now returns true
assuming nothing has been raised.