### PR TITLE
Remove headless gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,6 @@ end
 group :test do
   gem 'database_cleaner'
   gem 'govuk_test'
-  gem 'headless'
   gem 'timecop'
   gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,7 +150,6 @@ GEM
       selenium-webdriver
     hashdiff (0.3.8)
     hashie (3.6.0)
-    headless (2.3.1)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     i18n (1.6.0)
@@ -422,7 +421,6 @@ DEPENDENCIES
   govuk_taxonomy_helpers (~> 1.0.0)
   govuk_test
   hashdiff (~> 0.3.8)
-  headless
   jquery-ui-rails (= 6.0.1)
   kaminari (~> 1.1)
   pg
@@ -442,4 +440,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.16.2
+   1.17.2

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,7 +20,6 @@ PUBLISHING_API = "https://publishing-api.test.gov.uk".freeze
 
 require 'capybara/rails'
 require 'gds_api/test_helpers/publishing_api_v2'
-require 'headless'
 require 'database_cleaner'
 require 'govuk_test'
 
@@ -50,12 +49,9 @@ RSpec.configure do |config|
   config.around(:each, js: true) do |example|
     DatabaseCleaner.strategy = :truncation
     GovukTest.configure
-    headless = Headless.new
-    headless.start
 
     example.run
 
-    headless.destroy
     Capybara.javascript_driver = :rack_test
     DatabaseCleaner.strategy = :transaction
   end


### PR DESCRIPTION
We are seeing errors on CI to do with the `headless` gem:

```
Failure/Error: headless = Headless.new
[build] 
[build]      Headless::Exception:
[build]        Display socket is taken but lock file is missing - check the Headless troubleshooting guide
```

The [troubleshooting guide](https://github.com/leonid-shevtsov/headless#display-socket-is-taken-but-lock-file-is-missing) notes that `This is an exceptional situation. Please stop the server process manually (pkill Xvfb) and open an issue.`

We probably don't need to use this anymore since we now include [`govuk_test`](https://github.com/alphagov/govuk_test) which sets up default options for [headless browser](https://github.com/alphagov/govuk_test/blob/8a5860531ad6f432e36d5d320186fb58cc0874cb/lib/govuk_test.rb#L20) support in testing.