### PR TITLE
Use different field for AND filter

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,7 +67,7 @@ Rails.application.routes.draw do
     get 'results' => 'bulk_tags#results', as: "search_results_for"
   end
 
-  get '/healthcheck', to: proc { [200, {}, %w(OK)] }
+  get '/healthcheck', to: proc { [200, {}, %w[OK]] }
 
   resources :taxonomies, only: %i[show], param: :content_id
 

--- a/lib/data/find-eu-exit-guidance-business.yml
+++ b/lib/data/find-eu-exit-guidance-business.yml
@@ -207,7 +207,7 @@
     :key: business_activity
     :display_as_result_metadata: true
     :filterable: true
-    :filter_key: facet_values
+    :filter_key: and_facet_values
     :combine_mode: and
     :preposition: "you"
     :type: content_id


### PR DESCRIPTION
Use new filter key for business_activity.

We need to send a different filter key to rummager
for the `AND` part of the business finder to work correctly.

The `and_facet_values` filter is identical to the `facet_values`
filter, but being a different field allows the default
behaviour (AND between fields OR within them) to work correctly.