### PR TITLE
Add a link to facet groups

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -27,12 +27,14 @@ private
     :similar_search_results_url,
     :user_can_administer_taxonomy?,
     :user_can_manage_taxonomy?,
-    :user_can_access_tagathon_tools?
+    :user_can_access_tagathon_tools?,
+    :user_can_administer_facet_groups?
   )
 
   delegate :user_can_administer_taxonomy?,
            :user_can_manage_taxonomy?,
            :user_can_access_tagathon_tools?,
+           :user_can_administer_facet_groups?,
            to: :permission_checker
 
   def ensure_user_can_administer_taxonomy!
@@ -45,6 +47,10 @@ private
 
   def ensure_user_can_access_tagathon_tools!
     deny_access_to(:feature) unless user_can_access_tagathon_tools?
+  end
+
+  def ensure_user_can_administer_facet_groups!
+    deny_access_to(:feature) unless user_can_administer_facet_groups?
   end
 
   def deny_access_to(subject)

--- a/app/controllers/facet_taggings_controller.rb
+++ b/app/controllers/facet_taggings_controller.rb
@@ -1,5 +1,5 @@
 class FacetTaggingsController < ::TaggingsController
-  before_action :ensure_user_can_administer_taxonomy!
+  before_action :ensure_user_can_administer_facet_groups!
 
   def find_by_slug
     content_lookup = ContentLookupForm.new(lookup_params)

--- a/app/lib/permission_checker.rb
+++ b/app/lib/permission_checker.rb
@@ -19,6 +19,10 @@ class PermissionChecker
     gds_editor? || managing_editor? || tagathon_participant?
   end
 
+  def user_can_administer_facet_groups?
+    gds_editor?
+  end
+
 private
 
   attr_reader :user

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -40,6 +40,12 @@
       <%= link_to t('navigation.projects'), projects_path %>
     </li>
   <% end %>
+
+  <% if user_can_administer_facet_groups? %>
+    <li class='<%= active_navigation_item.in?(%w[facet_groups]) ? 'active' : nil %>'>
+      <%= link_to t('navigation.facet_groups'), facet_groups_path %>
+    </li>
+  <% end %>
 <% end %>
 
 <%= render template: 'layouts/govuk_admin_template' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -11,6 +11,7 @@ en:
     tag_migration: 'Bulk tag history'
     tag_importer: 'Bulk tag by upload'
     taxons: 'Edit taxonomy'
+    facet_groups: 'Facets'
   errors:
     invalid_taxon: There was a problem with your request. We have been notified of the issue and will fix it as soon as possible.
     invalid_taxon_base_path: A <a href="%{taxon_path}">taxon</a> with this slug already exists. If the taxon has been deleted, you can restore it.

--- a/spec/features/navigation_spec.rb
+++ b/spec/features/navigation_spec.rb
@@ -55,6 +55,7 @@ RSpec.feature "Navigation", type: :feature do
       expect(page).not_to have_text "Bulk tag"
       expect(page).not_to have_text "Edit taxonomy"
       expect(page).not_to have_text "Projects"
+      expect(page).not_to have_text "Facets"
     end
   end
 
@@ -63,6 +64,7 @@ RSpec.feature "Navigation", type: :feature do
       expect(page).not_to have_text "Edit a page"
       expect(page).not_to have_text "Bulk tag"
       expect(page).not_to have_text "Edit taxonomy"
+      expect(page).not_to have_text "Facets"
       expect(page).to have_text "Projects"
     end
   end
@@ -73,6 +75,7 @@ RSpec.feature "Navigation", type: :feature do
       expect(page).to have_text "Bulk tag"
       expect(page).to have_text "Edit taxonomy"
       expect(page).to have_text "Projects"
+      expect(page).to have_text "Facets"
     end
   end
 end

--- a/spec/lib/permission_checker_spec.rb
+++ b/spec/lib/permission_checker_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe PermissionChecker do
     it { is_expected.not_to have_permission(:user_can_administer_taxonomy?) }
     it { is_expected.not_to have_permission(:user_can_manage_taxonomy?) }
     it { is_expected.not_to have_permission(:user_can_access_tagathon_tools?) }
+    it { is_expected.not_to have_permission(:user_can_administer_facet_groups?) }
   end
 
   context "when the user has the Gds Editor permission" do
@@ -21,6 +22,7 @@ RSpec.describe PermissionChecker do
     it { is_expected.to have_permission(:user_can_administer_taxonomy?) }
     it { is_expected.to have_permission(:user_can_manage_taxonomy?) }
     it { is_expected.to have_permission(:user_can_access_tagathon_tools?) }
+    it { is_expected.to have_permission(:user_can_administer_facet_groups?) }
   end
 
   context "when the user has the Managing Editor permission" do
@@ -31,6 +33,7 @@ RSpec.describe PermissionChecker do
         .and_return(true)
     end
     it { is_expected.not_to have_permission(:user_can_administer_taxonomy?) }
+    it { is_expected.not_to have_permission(:user_can_administer_facet_groups?) }
     it { is_expected.to have_permission(:user_can_manage_taxonomy?) }
     it { is_expected.to have_permission(:user_can_access_tagathon_tools?) }
   end
@@ -45,6 +48,7 @@ RSpec.describe PermissionChecker do
 
     it { is_expected.not_to have_permission(:user_can_administer_taxonomy?) }
     it { is_expected.not_to have_permission(:user_can_manage_taxonomy?) }
+    it { is_expected.not_to have_permission(:user_can_administer_facet_groups?) }
     it { is_expected.to have_permission(:user_can_access_tagathon_tools?) }
   end
 end


### PR DESCRIPTION
This adds a link to the "facet_groups" page to the content-tagger menu limited to users with 'GDS Editor' permissions.

- User with 'GDS Editor' permission:
<img width="1162" alt="with 'GDS Editor' permissions" src="https://user-images.githubusercontent.com/38078064/55950214-5089f880-5c4c-11e9-96e5-5d360d61732e.png">

- User without 'GDS Editor' permission:
<img width="1163" alt="without 'GDS Editor' permissions" src="https://user-images.githubusercontent.com/38078064/55950266-65ff2280-5c4c-11e9-9a67-947e27ed718f.png">

[Trello card](https://trello.com/c/QqN7QCOC/34-permissions-for-facets-page-in-content-tagger)