### PR TITLE
[Do not merge] Allow notifications on facet tagging

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -9,4 +9,10 @@
 
 $(document).ready(function() {
   $(".select2:not(.tagging_project):not(.bulk_tagger)").select2({ allowClear: true });
+
+  // Facet tagging form, hide or show notification message.
+  var $notificationMessage = $(".facets_tagging_update_form_notification_message");
+  $("#facets_tagging_update_form_notify").change(function () {
+    $notificationMessage.toggle(this.checked);
+  });
 });

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,6 +13,7 @@ $red: #b10e1e;
 @import 'views/bubbles';
 @import 'tagathon_project';
 @import 'views/table-filter';
+@import 'facets-tagging';
 
 .error-message {
   color: $red;

--- a/app/assets/stylesheets/facets-tagging.scss
+++ b/app/assets/stylesheets/facets-tagging.scss
@@ -1,6 +1,12 @@
 .new_facets_tagging_update_form {
   .facets_tagging_update_form_notification_message {
     display: none;
+    .help-inline {
+      display: block;
+    }
+  }
+  .facets_tagging_update_form_notification_message.has-error {
+    display: block;
   }
   .form-group.boolean {
     div {

--- a/app/assets/stylesheets/facets-tagging.scss
+++ b/app/assets/stylesheets/facets-tagging.scss
@@ -1,0 +1,15 @@
+.new_facets_tagging_update_form {
+  .facets_tagging_update_form_notification_message {
+    display: none;
+  }
+  .form-group.boolean {
+    div {
+      display: inline;
+      float: left;
+      margin-right: 10px;
+    }
+    label {
+      display: inline;
+    }
+  }
+}

--- a/app/services/facets/tagging_update_form.rb
+++ b/app/services/facets/tagging_update_form.rb
@@ -3,7 +3,7 @@ module Facets
   class TaggingUpdateForm
     include ActiveModel::Model
     attr_accessor :content_item, :previous_version, :promoted,
-      :notify, :notification_message, :links
+                  :notify, :notification_message, :links
 
     delegate :content_id, to: :content_item
 
@@ -41,10 +41,20 @@ module Facets
       @promoted = params[:promoted]
       @notify = params[:notify]
       @notification_message = params[:notification_message]
+      validate_notification
 
       TAG_TYPES.each do |tag_type|
         send("#{tag_type}=", params[tag_type])
       end
+    end
+
+    def validate_notification
+      return unless notify && notification_message.blank?
+
+      errors.add(
+        :notification_message,
+        "must be present when notifying subscribers"
+      )
     end
 
     def facet_group(facet_group_content_id)

--- a/app/services/facets/tagging_update_form.rb
+++ b/app/services/facets/tagging_update_form.rb
@@ -2,7 +2,8 @@ module Facets
   # ActiveModel-compliant object that is passed into the tagging form.
   class TaggingUpdateForm
     include ActiveModel::Model
-    attr_accessor :content_item, :previous_version, :promoted, :links
+    attr_accessor :content_item, :previous_version, :promoted,
+      :notify, :notification_message, :links
 
     delegate :content_id, to: :content_item
 
@@ -38,6 +39,8 @@ module Facets
     def update_attributes_from_form(params)
       @previous_version = params[:previous_version]
       @promoted = params[:promoted]
+      @notify = params[:notify]
+      @notification_message = params[:notification_message]
 
       TAG_TYPES.each do |tag_type|
         send("#{tag_type}=", params[tag_type])

--- a/app/services/facets/tagging_update_publisher.rb
+++ b/app/services/facets/tagging_update_publisher.rb
@@ -36,12 +36,12 @@ module Facets
       end
 
       if params[:notify]
+        return false if params[:notification_message].blank?
+
         Services.publishing_api.notify(
           content_item.content_id,
-          {
-            publishing_app: "content-tagger",
-            workflow_message: params[:notification_message]
-          }
+          publishing_app: "content-tagger",
+          workflow_message: params[:notification_message]
         )
       end
 

--- a/app/services/facets/tagging_update_publisher.rb
+++ b/app/services/facets/tagging_update_publisher.rb
@@ -35,6 +35,16 @@ module Facets
         end
       end
 
+      if params[:notify]
+        Services.publishing_api.notify(
+          content_item.content_id,
+          {
+            publishing_app: "content-tagger",
+            workflow_message: params[:notification_message]
+          }
+        )
+      end
+
       true
     end
 

--- a/app/views/facet_taggings/_tagging_form.html.erb
+++ b/app/views/facet_taggings/_tagging_form.html.erb
@@ -20,5 +20,28 @@
 
   <hr/>
 
+
+  <%= f.input :notify,
+              as: :boolean,
+              checked_value: true,
+              unchecked_value: false,
+              label: "Notify email subscribers that this content has been tagged" %>
+
+  <p class="explain">
+    Check this field if you'd like to notify subscribers that this content has been re-tagged.
+    eg. This content is being added to a high priority finder and we wish to notify email
+    subscribers for the finder that new guidance is being made available.
+  </p>
+
+  <%= f.input :notification_message,
+              as: :text,
+              label: "Change note to for email notification",
+              hint: "This message appears in the email body sent to subscribers explaining " +
+                    "why they are receiving the email and what the change is about.",
+              input_html: { cols: 120, rows: 3 } %>
+
+
+  <hr/>
+
   <%= f.submit I18n.t('taggings.update_facets'), class: "btn btn-lg btn-success" %>
 <% end %>

--- a/app/views/facet_taggings/_tagging_form.html.erb
+++ b/app/views/facet_taggings/_tagging_form.html.erb
@@ -20,7 +20,6 @@
 
   <hr/>
 
-
   <%= f.input :notify,
               as: :boolean,
               checked_value: true,


### PR DESCRIPTION
https://trello.com/c/0wiO10tC/16-email-trigger-mechanism-for-new-content-tagger-process

Enables sending a notification of facet tagging via the [Publishing API's notify endpoint](https://github.com/alphagov/publishing-api/pull/1482).

![Screenshot from 2019-04-11 15-29-15](https://user-images.githubusercontent.com/93511/55966455-598cc100-5c70-11e9-8c2f-380a7209f309.png)


Depends on:

- https://github.com/alphagov/govuk-content-schemas/pull/884
- https://github.com/alphagov/publishing-api/pull/1482
- https://github.com/alphagov/email-alert-service/pull/249
- https://github.com/alphagov/gds-api-adapters/pull/918
