### PR TITLE
Notify email alert api of facet tagging

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -9,4 +9,10 @@
 
 $(document).ready(function() {
   $(".select2:not(.tagging_project):not(.bulk_tagger)").select2({ allowClear: true });
+
+  // Facet tagging form, hide or show notification message.
+  var $notificationMessage = $(".facets_tagging_update_form_notification_message");
+  $("#facets_tagging_update_form_notify").change(function () {
+    $notificationMessage.toggle(this.checked);
+  });
 });

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,6 +13,7 @@ $red: #b10e1e;
 @import 'views/bubbles';
 @import 'tagathon_project';
 @import 'views/table-filter';
+@import 'facets-tagging';
 
 .error-message {
   color: $red;

--- a/app/assets/stylesheets/facets-tagging.scss
+++ b/app/assets/stylesheets/facets-tagging.scss
@@ -1,6 +1,12 @@
 .new_facets_tagging_update_form {
   .facets_tagging_update_form_notification_message {
     display: none;
+    .help-inline {
+      display: block;
+    }
+  }
+  .facets_tagging_update_form_notification_message.has-error {
+    display: block;
   }
   .form-group.boolean {
     div {

--- a/app/assets/stylesheets/facets-tagging.scss
+++ b/app/assets/stylesheets/facets-tagging.scss
@@ -1,0 +1,15 @@
+.new_facets_tagging_update_form {
+  .facets_tagging_update_form_notification_message {
+    display: none;
+  }
+  .form-group.boolean {
+    div {
+      display: inline;
+      float: left;
+      margin-right: 10px;
+    }
+    label {
+      display: inline;
+    }
+  }
+}

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -3,6 +3,7 @@ class ContentItem
     :content_id,
     :title,
     :base_path,
+    :description,
     :publishing_app,
     :rendering_app,
     :document_type,
@@ -16,6 +17,7 @@ class ContentItem
     @content_id = data.fetch('content_id')
     @title = data.fetch('title')
     @base_path = data.fetch('base_path')
+    @description = data.fetch('description', nil)
     @publishing_app = data.fetch('publishing_app', nil)
     @rendering_app = data.fetch('rendering_app', nil)
     @document_type = data.fetch('document_type')

--- a/app/presenters/facets/facets_tagging_notification_presenter.rb
+++ b/app/presenters/facets/facets_tagging_notification_presenter.rb
@@ -1,0 +1,31 @@
+module Facets
+  class FacetsTaggingNotificationPresenter
+    attr_reader :document, :change_note, :links
+
+    def initialize(document, change_note, links)
+      @document = document
+      @change_note = change_note
+      @links = links
+    end
+
+    def present
+      {
+        base_path: document.base_path,
+        change_note: change_note,
+        content_id: document.content_id,
+        description: document.description,
+        document_type: document.document_type,
+        email_document_supertype: "other",
+        government_document_supertype: "other",
+        links: links,
+        priority: "high",
+        public_updated_at: Time.now.iso8601,
+        publishing_app: "content-tagger",
+        subject: document.title,
+        tags: links,
+        title: document.title,
+        urgent: true,
+      }
+    end
+  end
+end

--- a/app/presenters/facets/facets_tagging_notification_presenter.rb
+++ b/app/presenters/facets/facets_tagging_notification_presenter.rb
@@ -1,11 +1,12 @@
 module Facets
   class FacetsTaggingNotificationPresenter
-    attr_reader :document, :change_note, :links
+    attr_reader :document, :change_note, :links, :tags
 
-    def initialize(document, change_note, links)
+    def initialize(document, change_note, links = {}, tags = {})
       @document = document
       @change_note = change_note
       @links = links
+      @tags = tags
     end
 
     def present
@@ -22,7 +23,7 @@ module Facets
         public_updated_at: Time.now.iso8601,
         publishing_app: "content-tagger",
         subject: document.title,
-        tags: links,
+        tags: tags,
         title: document.title,
         urgent: true,
       }

--- a/app/services/facets/tagging_update_form.rb
+++ b/app/services/facets/tagging_update_form.rb
@@ -41,10 +41,20 @@ module Facets
       @promoted = params[:promoted]
       @notify = params[:notify]
       @notification_message = params[:notification_message]
+      validate_notification
 
       TAG_TYPES.each do |tag_type|
         send("#{tag_type}=", params[tag_type])
       end
+    end
+
+    def validate_notification
+      return unless notify && notification_message.blank?
+
+      errors.add(
+        :notification_message,
+        "must be present when notifying subscribers"
+      )
     end
 
     def facet_group(facet_group_content_id)

--- a/app/services/facets/tagging_update_form.rb
+++ b/app/services/facets/tagging_update_form.rb
@@ -2,7 +2,8 @@ module Facets
   # ActiveModel-compliant object that is passed into the tagging form.
   class TaggingUpdateForm
     include ActiveModel::Model
-    attr_accessor :content_item, :previous_version, :promoted, :links
+    attr_accessor :content_item, :previous_version, :promoted,
+                  :notify, :notification_message, :links
 
     delegate :content_id, to: :content_item
 
@@ -38,6 +39,8 @@ module Facets
     def update_attributes_from_form(params)
       @previous_version = params[:previous_version]
       @promoted = params[:promoted]
+      @notify = params[:notify]
+      @notification_message = params[:notification_message]
 
       TAG_TYPES.each do |tag_type|
         send("#{tag_type}=", params[tag_type])

--- a/app/services/facets/tagging_update_publisher.rb
+++ b/app/services/facets/tagging_update_publisher.rb
@@ -45,6 +45,7 @@ module Facets
             content_item,
             params[:notification_message],
             links_payload,
+            email_alert_tags_payload,
           ).present
         )
       end
@@ -78,6 +79,13 @@ module Facets
         facet_groups: facet_groups_content_ids.uniq,
         facet_values: facet_values_content_ids,
       }
+    end
+
+    # FIXME: This is a temporary tag set which can be removed once
+    # we've updated finder email signup to handle links based signup config
+    # as we will no longer need to send tags as well as facet group links.
+    def email_alert_tags_payload
+      { "appear_in_find_eu_exit_guidance_business_finder" => "yes" }
     end
 
     def fetch_content_ids(tag_type)

--- a/app/views/facet_taggings/_tagging_form.html.erb
+++ b/app/views/facet_taggings/_tagging_form.html.erb
@@ -20,5 +20,27 @@
 
   <hr/>
 
+  <%= f.input :notify,
+              as: :boolean,
+              checked_value: true,
+              unchecked_value: false,
+              label: "Notify email subscribers that this content has been tagged" %>
+
+  <p class="explain">
+    Check this field if you'd like to notify subscribers that this content has been re-tagged.
+    eg. This content is being added to a high priority finder and we wish to notify email
+    subscribers for the finder that new guidance is being made available.
+  </p>
+
+  <%= f.input :notification_message,
+              as: :text,
+              label: "Change note to for email notification",
+              hint: "This message appears in the email body sent to subscribers explaining " +
+                    "why they are receiving the email and what the change is about.",
+              input_html: { cols: 120, rows: 3 } %>
+
+
+  <hr/>
+
   <%= f.submit I18n.t('taggings.update_facets'), class: "btn btn-lg btn-success" %>
 <% end %>

--- a/app/views/facet_taggings/_tagging_form.html.erb
+++ b/app/views/facet_taggings/_tagging_form.html.erb
@@ -33,11 +33,15 @@
   </p>
 
   <%= f.input :notification_message,
-              as: :text,
               label: "Change note to for email notification",
               hint: "This message appears in the email body sent to subscribers explaining " +
-                    "why they are receiving the email and what the change is about.",
-              input_html: { cols: 120, rows: 3 } %>
+                    "why they are receiving the email and what the change is about. " +
+                    "This field does not accept markdown or HTML.",
+              input_html: {
+                placeholder: " eg. You’re getting this email because you subscribed to " +
+                             "‘EU Exit guidance for your business or organisation’ updates on GOV.UK.",
+                size: 140,
+              } %>
 
 
   <hr/>

--- a/spec/features/tag_facets_to_a_page_spec.rb
+++ b/spec/features/tag_facets_to_a_page_spec.rb
@@ -34,6 +34,57 @@ RSpec.describe "Tagging content with facets", type: :feature do
     )
   end
 
+  scenario "User tags a content item with facet values and notifies users" do
+    Timecop.freeze("2019-04-12T15:05:59+00:00") do
+
+      stub_finder_get_links_request
+      stub_notification_request
+      expected_links = {
+        facet_groups: ["FACET-GROUP-UUID"],
+        facet_values: ["ANOTHER-FACET-VALUE-UUID", "EXISTING-FACET-VALUE-UUID"],
+      }
+
+      given_there_is_a_content_item_with_expanded_links(
+        facet_groups: [example_facet_group],
+        facet_values: [example_facet_value],
+      )
+      when_i_visit_facet_groups_page
+      and_i_select_the_facet_group("Example facet group")
+      and_i_edit_facets_for_the_page("/my-content-item")
+      and_i_see_the_facet_values_form_prefilled_with("Agriculture")
+
+      when_i_select_an_additional_facet_value("Aerospace")
+      and_i_opt_to_notify_users
+      and_i_fill_in_the_notification_message_with("Retagged!")
+
+      and_i_submit_the_facets_tagging_form
+
+      then_the_publishing_api_is_sent(
+        "facets_tagging_request",
+        links: expected_links,
+        previous_version: 54_321,
+      )
+
+      and_the_email_alert_api_is_sent(
+        base_path: "/my-content-item",
+        change_note: "Retagged!",
+        content_id: "MY-CONTENT-ID",
+        description: "Describes my content item",
+        document_type: "guide",
+        email_document_supertype: "other",
+        government_document_supertype: "other",
+        links: expected_links,
+        priority: "high",
+        public_updated_at: "2019-04-12T15:05:59+00:00",
+        publishing_app: "content-tagger",
+        subject: 'This Is A Content Item',
+        tags: expected_links,
+        title: 'This Is A Content Item',
+        urgent: true,
+      )
+    end
+  end
+
   scenario "User removes all facet values" do
     stub_finder_get_links_request
     given_there_is_a_content_item_with_expanded_links(
@@ -159,6 +210,7 @@ RSpec.describe "Tagging content with facets", type: :feature do
         content_id: "MY-CONTENT-ID",
         base_path: '/my-content-item',
         document_type: 'guide',
+        description: 'Describes my content item',
         title: 'This Is A Content Item',
       }.to_json)
 
@@ -240,6 +292,10 @@ RSpec.describe "Tagging content with facets", type: :feature do
     expect(stubbed_request.with(body: body.to_json)).to have_been_made
   end
 
+  def and_the_email_alert_api_is_sent(body)
+    expect(@notification_request.with(body: body.to_json)).to have_been_made
+  end
+
   def and_somebody_else_makes_a_change
     @facets_tagging_request = stub_request(:patch, "#{PUBLISHING_API}/v2/links/MY-CONTENT-ID")
       .to_return(status: 409)
@@ -247,6 +303,14 @@ RSpec.describe "Tagging content with facets", type: :feature do
 
   def then_i_see_that_there_is_a_conflict
     expect(page).to have_content 'Somebody changed the tags before you could'
+  end
+
+  def and_i_opt_to_notify_users
+    check "facets_tagging_update_form_notify"
+  end
+
+  def and_i_fill_in_the_notification_message_with(message)
+    fill_in "facets_tagging_update_form_notification_message", with: message
   end
 
   def publishing_api_has_facet_values_linkables(labels)

--- a/spec/features/tag_facets_to_a_page_spec.rb
+++ b/spec/features/tag_facets_to_a_page_spec.rb
@@ -43,6 +43,10 @@ RSpec.describe "Tagging content with facets", type: :feature do
         facet_values: ["ANOTHER-FACET-VALUE-UUID", "EXISTING-FACET-VALUE-UUID"],
       }
 
+      expected_tags = {
+        "appear_in_find_eu_exit_guidance_business_finder" => "yes"
+      }
+
       given_there_is_a_content_item_with_expanded_links(
         facet_groups: [example_facet_group],
         facet_values: [example_facet_value],
@@ -77,7 +81,7 @@ RSpec.describe "Tagging content with facets", type: :feature do
         public_updated_at: "2019-04-12T15:05:59+00:00",
         publishing_app: "content-tagger",
         subject: 'This Is A Content Item',
-        tags: expected_links,
+        tags: expected_tags,
         title: 'This Is A Content Item',
         urgent: true,
       )

--- a/spec/features/tag_facets_to_a_page_spec.rb
+++ b/spec/features/tag_facets_to_a_page_spec.rb
@@ -36,7 +36,6 @@ RSpec.describe "Tagging content with facets", type: :feature do
 
   scenario "User tags a content item with facet values and notifies users" do
     Timecop.freeze("2019-04-12T15:05:59+00:00") do
-
       stub_finder_get_links_request
       stub_notification_request
       expected_links = {
@@ -83,6 +82,35 @@ RSpec.describe "Tagging content with facets", type: :feature do
         urgent: true,
       )
     end
+  end
+
+  scenario "User tags a content item and notifies users without a message" do
+    stub_finder_get_links_request
+    stub_notification_request
+
+    given_there_is_a_content_item_with_expanded_links(
+      facet_groups: [example_facet_group],
+      facet_values: [example_facet_value],
+    )
+    when_i_visit_facet_groups_page
+    and_i_select_the_facet_group("Example facet group")
+    and_i_edit_facets_for_the_page("/my-content-item")
+    and_i_see_the_facet_values_form_prefilled_with("Agriculture")
+
+    when_i_select_an_additional_facet_value("Aerospace")
+    and_i_opt_to_notify_users
+
+    and_i_submit_the_facets_tagging_form
+
+    then_the_publishing_api_is_sent(
+      "facets_tagging_request",
+      links: {
+        facet_groups: ["FACET-GROUP-UUID"],
+        facet_values: ["ANOTHER-FACET-VALUE-UUID", "EXISTING-FACET-VALUE-UUID"],
+      },
+      previous_version: 54_321,
+    )
+    and_i_see_the_notification_is_invalid
   end
 
   scenario "User removes all facet values" do
@@ -262,6 +290,12 @@ RSpec.describe "Tagging content with facets", type: :feature do
     uncheck 'facets_tagging_update_form_promoted'
   end
 
+  def and_i_see_the_notification_is_invalid
+    within(".facets_tagging_update_form_notification_message") do
+      expect(page).to have_css("#facets_tagging_update_form_notification_message[aria-invalid='true']")
+    end
+  end
+
   def stub_finder_get_links_request(content_id: "FINDER-UUID", items: ["EXISTING-PINNED-ITEM-UUID"])
     # Set the class as a local var otherwise RSpec confuses the interpreter
     # by defining `Facets::FinderService` as a module here.
@@ -284,6 +318,12 @@ RSpec.describe "Tagging content with facets", type: :feature do
       stub_request(:patch, "#{PUBLISHING_API}/v2/links/#{content_id}")
         .to_return(status: 200)
     )
+  end
+
+  def stub_notification_request
+    @notification_request = stub_request(
+      :post, "#{EMAIL_ALERT_API}/notifications"
+    ).to_return(status: 200)
   end
 
   def then_the_publishing_api_is_sent(stubbed_request_name, body)

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -56,6 +56,7 @@ RSpec.describe ContentItem do
     item = ContentItem.new({
       base_path: double,
       content_id: double,
+      description: double,
       document_type: double,
       publishing_app: double,
       rendering_app: 'frontend',

--- a/spec/presenters/facets/facets_tagging_notification_presenter_spec.rb
+++ b/spec/presenters/facets/facets_tagging_notification_presenter_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+RSpec.describe Facets::FacetsTaggingNotificationPresenter do
+  let(:content_item) do
+    double(
+      :content_item,
+      base_path: "/my-content-item",
+      content_id: "MY-CONTENT-ID",
+      description: "This describes my content item",
+      document_type: "guide",
+      title: 'This Is A Content Item',
+    )
+  end
+
+  let(:message) { "Retagged!" }
+
+  let(:links) do
+    {
+      facet_groups: ["FACET-GROUP-UUID"],
+      facet_values: ["ANOTHER-FACET-VALUE-UUID", "EXISTING-FACET-VALUE-UUID"],
+    }
+  end
+
+  subject(:presenter) { described_class.new(content_item, message, links) }
+
+  describe "#present" do
+    let(:expected_payload) do
+      {
+        base_path: "/my-content-item",
+        change_note: "Retagged!",
+        content_id: "MY-CONTENT-ID",
+        description: "This describes my content item",
+        document_type: "guide",
+        email_document_supertype: "other",
+        government_document_supertype: "other",
+        links: links,
+        priority: "high",
+        public_updated_at: "2019-04-12T15:05:59+00:00",
+        publishing_app: "content-tagger",
+        subject: 'This Is A Content Item',
+        tags: links,
+        title: 'This Is A Content Item',
+        urgent: true,
+      }
+    end
+
+    it "presents a payload combining content item and links attributes" do
+      Timecop.freeze("2019-04-12T15:05:59+00:00") do
+        expect(presenter.present).to eq(expected_payload)
+      end
+    end
+  end
+end

--- a/spec/presenters/facets/facets_tagging_notification_presenter_spec.rb
+++ b/spec/presenters/facets/facets_tagging_notification_presenter_spec.rb
@@ -21,7 +21,13 @@ RSpec.describe Facets::FacetsTaggingNotificationPresenter do
     }
   end
 
-  subject(:presenter) { described_class.new(content_item, message, links) }
+  let(:tags) do
+    {
+      "appear_in_find_eu_exit_guidance_business_finder" => "yes"
+    }
+  end
+
+  subject(:presenter) { described_class.new(content_item, message, links, tags) }
 
   describe "#present" do
     let(:expected_payload) do
@@ -38,7 +44,7 @@ RSpec.describe Facets::FacetsTaggingNotificationPresenter do
         public_updated_at: "2019-04-12T15:05:59+00:00",
         publishing_app: "content-tagger",
         subject: 'This Is A Content Item',
-        tags: links,
+        tags: tags,
         title: 'This Is A Content Item',
         urgent: true,
       }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -16,6 +16,7 @@ require 'govuk_sidekiq/testing'
 Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 Dir[Rails.root.join('spec/matchers/**/*.rb')].each { |f| require f }
 
+EMAIL_ALERT_API = "https://email-alert-api.test.gov.uk".freeze
 PUBLISHING_API = "https://publishing-api.test.gov.uk".freeze
 
 require 'capybara/rails'


### PR DESCRIPTION
https://trello.com/c/0wiO10tC/16-email-trigger-mechanism-for-new-content-tagger-process

Simpler version of [notifying subscribers of tagging changes](https://github.com/alphagov/content-tagger/pull/898) this sends notifications directly to the email-alert-api.

![Screenshot from 2019-04-18 11-40-44](https://user-images.githubusercontent.com/93511/56355865-49746480-61cf-11e9-9edf-5a3e08f38ddb.png)
