### PR TITLE
Update navigation spec

### DIFF
--- a/spec/features/navigation_spec.rb
+++ b/spec/features/navigation_spec.rb
@@ -28,6 +28,24 @@ RSpec.feature "Navigation", type: :feature do
     then_i_can_see_the_full_set_of_navigation_options
   end
 
+  context "Clicking navigation option" do
+    before do
+      given_i_am_logged_in_as_a_gds_editor
+      when_i_visit_the_application
+    end
+
+    navigation_options = ["Edit a page", "Bulk tag", "Edit taxonomy", "Tagging history", "Taxonomy Health", "Projects", "Facets"].freeze
+    navigation_paths = %w[/taggings/lookup /bulk_tag/new /taxons /tagging_history /taxonomy/health_warnings /projects /facet_groups].freeze
+
+    navigation_options.zip(navigation_paths).each do |option, path|
+      scenario "#{option} redirects to the correct page" do
+        stub_get_request(option)
+        and_when_i_click_navigation_option(option)
+        then_i_am_redirected_to_the_page(path)
+      end
+    end
+  end
+
   def given_i_am_logged_in_as_a_user_with_no_special_permissions
     login_as create(:user)
   end
@@ -54,6 +72,8 @@ RSpec.feature "Navigation", type: :feature do
       expect(page).not_to have_text "Edit a page"
       expect(page).not_to have_text "Bulk tag"
       expect(page).not_to have_text "Edit taxonomy"
+      expect(page).not_to have_text "Tagging history"
+      expect(page).not_to have_text "Taxonomy Health"
       expect(page).not_to have_text "Projects"
       expect(page).not_to have_text "Facets"
     end
@@ -64,6 +84,8 @@ RSpec.feature "Navigation", type: :feature do
       expect(page).not_to have_text "Edit a page"
       expect(page).not_to have_text "Bulk tag"
       expect(page).not_to have_text "Edit taxonomy"
+      expect(page).not_to have_text "Tagging history"
+      expect(page).not_to have_text "Taxonomy Health"
       expect(page).not_to have_text "Facets"
       expect(page).to have_text "Projects"
     end
@@ -74,8 +96,35 @@ RSpec.feature "Navigation", type: :feature do
       expect(page).to have_text "Edit a page"
       expect(page).to have_text "Bulk tag"
       expect(page).to have_text "Edit taxonomy"
+      expect(page).to have_text "Tagging history"
+      expect(page).to have_text "Taxonomy Health"
       expect(page).to have_text "Projects"
       expect(page).to have_text "Facets"
     end
+  end
+
+  def and_when_i_click_navigation_option(option)
+    within "nav .navbar-nav" do
+      click_link option
+    end
+  end
+
+  def then_i_am_redirected_to_the_page(path)
+    expect(page).to have_current_path(path)
+  end
+
+  def stub_get_request(option)
+    stubbed_request_data = {
+      "Facets" => {
+        url: "https://publishing-api.test.gov.uk/v2/content?document_type=facet_group&order=-public_updated_at&page=1&per_page=50&q=&search_in%5B%5D=title&states%5B%5D=published",
+        body: { results: [] }
+      },
+      "Tagging history" => {
+        url: "https://publishing-api.test.gov.uk/v2/links/changes?link_types%5B%5D=taxons",
+        body: { link_changes: [] }
+      }
+    }
+
+    stub_request(:get, stubbed_request_data[option][:url]).to_return(status: 200, body: stubbed_request_data[option][:body].to_json) unless stubbed_request_data[option].nil?
   end
 end


### PR DESCRIPTION
This adds "Tagging history" and "Taxonomy Health" navigation options to the
permission tests and a new test to check if clicking the link redirects to the
correct page.

<img width="520" alt="Test results" src="https://user-images.githubusercontent.com/38078064/56115780-1fffd280-5f5c-11e9-9d1f-6a7149de072e.png">

[Trello card](https://trello.com/c/HE6yY5Pl/44-update-content-tagger-navigation-tests-proactive)