### PR TITLE
Fix short name for employ eu citizens

### DIFF
--- a/lib/data/find-eu-exit-guidance-business.yml
+++ b/lib/data/find-eu-exit-guidance-business.yml
@@ -229,6 +229,7 @@
         :value: transporting
   - :content_id: b2716a1e-dc24-4566-b8ed-f3ee23a994ec
     :name: "Who you employ"
+    :short_name: "Employing EU citizens"
     :key: employ_eu_citizens
     :display_as_result_metadata: true
     :filterable: true

--- a/lib/facet_group_importer.rb
+++ b/lib/facet_group_importer.rb
@@ -116,7 +116,8 @@ private
       title: data[:name],
       details: data.slice(
         *:combine_mode, :display_as_result_metadata,
-        :filterable, :key, :filter_key, :name, :preposition, :type
+        :filterable, :key, :filter_key, :name, :short_name,
+        :preposition, :type
       )
     }.merge(publishing_and_rendering_apps)
   end

--- a/spec/lib/facet_group_importer_spec.rb
+++ b/spec/lib/facet_group_importer_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe FacetGroupImporter do
           filterable: true,
           key: "a_facet",
           name: "A facet",
+          short_name: "Facet",
           preposition: "do something with",
           type: "content_id",
           filter_key: 'facet_filter_key',
@@ -88,6 +89,7 @@ RSpec.describe FacetGroupImporter do
               key: "a_facet",
               filter_key: 'facet_filter_key',
               name: "A facet",
+              short_name: "Facet",
               preposition: "do something with",
               type: "content_id",
             }


### PR DESCRIPTION
https://github.com/alphagov/govuk-app-deployment-secrets/blob/master/shared_config/find-eu-exit-guidance-business.yml#L194 

![Screenshot from 2019-04-18 16-19-11](https://user-images.githubusercontent.com/93511/56371815-bbf83b00-61f5-11e9-927a-8638086cc2d4.png)

The facet `short_name` is attribute used as a display value for one particular facet on the business readiness finder. This custom value provides a better grouping header for results. The facet value on the relevant content item needs to be consistent with what's currently in the finder facets definition.

This change will need deploying and the facet group importing and publishing as per the rake tasks documented here : https://docs.publishing.service.gov.uk/manual/publishing-a-facet-group.html