### PR TITLE
Rename 'Business activity' to 'Organisation activity'

### DIFF
--- a/lib/data/find-eu-exit-guidance-business.yml
+++ b/lib/data/find-eu-exit-guidance-business.yml
@@ -203,7 +203,7 @@
         :title: Warehousing, services and pipelines
         :value: warehouses-services-pipelines
   - :content_id: e2febfa3-eac9-430b-bc6e-b0dff8876b1f
-    :name: "Business activity"
+    :name: "Organisation activity"
     :key: business_activity
     :display_as_result_metadata: true
     :filterable: true


### PR DESCRIPTION
This name was updated in `govuk_app_deployment_secrets` but not in `content-tagger`.  Making this update here.