### PR TITLE
Present taggable facets in separate fields

### DIFF
--- a/app/assets/stylesheets/facets-tagging.scss
+++ b/app/assets/stylesheets/facets-tagging.scss
@@ -18,4 +18,7 @@
       display: inline;
     }
   }
+  .tag-section label {
+    display: block;
+  }
 }

--- a/app/views/facet_taggings/_form_for_facet_values.html.erb
+++ b/app/views/facet_taggings/_form_for_facet_values.html.erb
@@ -5,7 +5,11 @@
       collection: facet.last,
       label: facet.first,
       placeholder: "Choose one...",
-      input_html: { multiple: true, class: :select2 } %>
+      input_html: {
+        class: :select2,
+        id: "facets_tagging_update_form_#{facet.first.parameterize.underscore}",
+        multiple: true,
+      } %>
 <% end %>
 
 <p class="explain">

--- a/app/views/facet_taggings/_form_for_facet_values.html.erb
+++ b/app/views/facet_taggings/_form_for_facet_values.html.erb
@@ -1,11 +1,12 @@
 <h3>Facets</h3>
 
-<%= f.input :facet_values,
-    as: :grouped_select,
-    collection: linkables.facet_values(params[:facet_group_content_id]),
-    group_method: :last,
-    placeholder: "Choose one...",
-    input_html: { multiple: true, class: :select2 } %>
+<% linkables.facet_values(params[:facet_group_content_id]).each do |facet| %>
+  <%= f.input :facet_values,
+      collection: facet.last,
+      label: facet.first,
+      placeholder: "Choose one...",
+      input_html: { multiple: true, class: :select2 } %>
+<% end %>
 
 <p class="explain">
   This facet metadata is currently being developed.

--- a/spec/features/tag_facets_to_a_page_spec.rb
+++ b/spec/features/tag_facets_to_a_page_spec.rb
@@ -270,7 +270,7 @@ RSpec.describe "Tagging content with facets", type: :feature do
   end
 
   def and_i_see_the_facet_values_form_prefilled_with(option)
-    facet_values_options = all('#facets_tagging_update_form_facet_values option').map(&:text)
+    facet_values_options = all('#facets_tagging_update_form_example_facet option').map(&:text)
     expect(facet_values_options).to include(option)
   end
 
@@ -279,11 +279,11 @@ RSpec.describe "Tagging content with facets", type: :feature do
   end
 
   def when_i_select_an_additional_facet_value(selection)
-    select selection, from: "facets_tagging_update_form_facet_values"
+    select selection, from: "facets_tagging_update_form_example_facet"
   end
 
   def when_i_remove_the_facet_value(selection)
-    unselect selection, from: "facets_tagging_update_form_facet_values"
+    unselect selection, from: "facets_tagging_update_form_example_facet"
   end
 
   def when_i_pin_the_item_in_finder_results

--- a/spec/features/tag_facets_to_a_page_spec.rb
+++ b/spec/features/tag_facets_to_a_page_spec.rb
@@ -279,11 +279,11 @@ RSpec.describe "Tagging content with facets", type: :feature do
   end
 
   def when_i_select_an_additional_facet_value(selection)
-    select selection, from: "Facet values"
+    select selection, from: "facets_tagging_update_form_facet_values"
   end
 
   def when_i_remove_the_facet_value(selection)
-    unselect selection, from: "Facet values"
+    unselect selection, from: "facets_tagging_update_form_facet_values"
   end
 
   def when_i_pin_the_item_in_finder_results


### PR DESCRIPTION
https://trello.com/c/SgSAqgLR/79-split-facet-tagging-form-fields-into-separate-facets

Improves facet tagging workflow by splitting facet values out into separate facet select2 fields.

![Screenshot from 2019-05-07 10-56-55](https://user-images.githubusercontent.com/93511/57291190-e03d8e00-70b6-11e9-99ba-4dab13a7c8a9.png)
