### PR TITLE
Link content tagged to a facet group back to a finder

### DIFF
--- a/app/services/facets/tagging_update_publisher.rb
+++ b/app/services/facets/tagging_update_publisher.rb
@@ -75,11 +75,16 @@ module Facets
         facet_groups_content_ids.delete(facet_group_content_id)
       end
 
-      {
+      links = {
         facet_groups: facet_groups_content_ids.uniq,
         facet_values: facet_values_content_ids,
-        finder: [FinderService::LINKED_FINDER_CONTENT_ID],
       }
+
+      if facet_values_content_ids.any?
+        links.merge!(finder: [FinderService::LINKED_FINDER_CONTENT_ID])
+      end
+
+      links
     end
 
     # FIXME: This is a temporary tag set which can be removed once

--- a/app/services/facets/tagging_update_publisher.rb
+++ b/app/services/facets/tagging_update_publisher.rb
@@ -78,6 +78,7 @@ module Facets
       {
         facet_groups: facet_groups_content_ids.uniq,
         facet_values: facet_values_content_ids,
+        finder: [FinderService::LINKED_FINDER_CONTENT_ID],
       }
     end
 

--- a/lib/tasks/facets/facet_group.rake
+++ b/lib/tasks/facets/facet_group.rake
@@ -27,4 +27,21 @@ namespace :facets do
   task :tag_content_to_facet_values, %i[tagging_file_path facet_group_file_path] => :environment do |_, args|
     FacetDataTagger.new(args[:tagging_file_path], args[:facet_group_file_path]).link_content_to_facet_values
   end
+
+  desc <<-DESC
+    Sends a patch links request for all content tagged to a facet_group.
+  DESC
+  task :patch_links_to_facet_group, [:facet_group_content_id] => :environment do |_, args|
+    facet_group_content_id = args[:facet_group_content_id]
+
+    content_items_enum = Services.rummager.search_enum(
+      filter_facet_groups: facet_group_content_id
+    )
+
+    content_ids = Services.publishing_api.lookup_content_ids(base_paths: content_items_enum.pluck("link"))
+
+    content_ids.each do |_, content_id|
+      Services.publishing_api.patch_links(content_id, links: { finder: [Facets::FinderService::LINKED_FINDER_CONTENT_ID] })
+    end
+  end
 end

--- a/spec/features/tag_facets_to_a_page_spec.rb
+++ b/spec/features/tag_facets_to_a_page_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe "Tagging content with facets", type: :feature do
       links: {
         facet_groups: ["FACET-GROUP-UUID"],
         facet_values: ["ANOTHER-FACET-VALUE-UUID", "EXISTING-FACET-VALUE-UUID"],
+        finder: [stub_linked_finder_content_id],
       },
       previous_version: 54_321,
     )
@@ -41,6 +42,7 @@ RSpec.describe "Tagging content with facets", type: :feature do
       expected_links = {
         facet_groups: ["FACET-GROUP-UUID"],
         facet_values: ["ANOTHER-FACET-VALUE-UUID", "EXISTING-FACET-VALUE-UUID"],
+        finder: [stub_linked_finder_content_id],
       }
 
       expected_tags = {
@@ -111,6 +113,7 @@ RSpec.describe "Tagging content with facets", type: :feature do
       links: {
         facet_groups: ["FACET-GROUP-UUID"],
         facet_values: ["ANOTHER-FACET-VALUE-UUID", "EXISTING-FACET-VALUE-UUID"],
+        finder: [stub_linked_finder_content_id],
       },
       previous_version: 54_321,
     )
@@ -185,6 +188,7 @@ RSpec.describe "Tagging content with facets", type: :feature do
       links: {
         facet_groups: ["FACET-GROUP-UUID"],
         facet_values: ["EXISTING-FACET-VALUE-UUID"],
+        finder: [stub_linked_finder_content_id],
       },
       previous_version: 54_321,
     )
@@ -216,6 +220,7 @@ RSpec.describe "Tagging content with facets", type: :feature do
       links: {
         facet_groups: ["FACET-GROUP-UUID"],
         facet_values: ["EXISTING-FACET-VALUE-UUID"],
+        finder: [stub_linked_finder_content_id],
       },
       previous_version: 54_321,
     )
@@ -300,12 +305,8 @@ RSpec.describe "Tagging content with facets", type: :feature do
     end
   end
 
-  def stub_finder_get_links_request(content_id: "FINDER-UUID", items: ["EXISTING-PINNED-ITEM-UUID"])
-    # Set the class as a local var otherwise RSpec confuses the interpreter
-    # by defining `Facets::FinderService` as a module here.
-    finder_service_class = Facets::FinderService
-    stub_const "#{finder_service_class}::LINKED_FINDER_CONTENT_ID", content_id
-    stub_request(:get, "#{PUBLISHING_API}/v2/links/#{content_id}")
+  def stub_finder_get_links_request(items: ["EXISTING-PINNED-ITEM-UUID"])
+    stub_request(:get, "#{PUBLISHING_API}/v2/links/#{stub_linked_finder_content_id}")
       .to_return(
         status: 200,
         body: {
@@ -388,5 +389,12 @@ RSpec.describe "Tagging content with facets", type: :feature do
           base_path: "/some-finder",
         }
       ].to_json)
+  end
+
+  def stub_linked_finder_content_id
+    # Set the class as a local var otherwise RSpec confuses the interpreter
+    # by defining `Facets::FinderService` as a module here.
+    finder_service_class = Facets::FinderService
+    stub_const "#{finder_service_class}::LINKED_FINDER_CONTENT_ID", "FINDER-UUID"
   end
 end

--- a/spec/lib/tasks/facets/facet_group_spec.rb
+++ b/spec/lib/tasks/facets/facet_group_spec.rb
@@ -1,0 +1,44 @@
+require 'rake'
+require 'rails_helper'
+require 'gds_api/test_helpers/publishing_api_v2'
+require 'gds_api/test_helpers/rummager'
+
+RSpec.describe 'facets:patch_links_to_facet_group' do
+  include GdsApi::TestHelpers::PublishingApiV2
+  include GdsApi::TestHelpers::Rummager
+  include ContentItemHelper
+  include PublishingApiHelper
+
+  let(:results) do
+    [
+      { 'link' =>  "/link/one" },
+      { 'link' =>  "/link/two" },
+      { 'link' =>  "/link/three" },
+    ]
+  end
+
+  let(:facet_group_content_id) { "FACET-GROUP-CONTENT-ID" }
+  let(:finder_content_id) { "FINDER-CONTENT-ID" }
+  let(:finder_service_class) { Facets::FinderService }
+  let(:finder_service) { double(:finder_service, pinned_item_links: []) }
+  let(:publishing_api) { Services.publishing_api }
+
+  before :each do
+    Rails.application.load_tasks
+    stub_any_rummager_search.to_return(body: { 'results' => results }.to_json)
+    stub_publishing_api_has_lookups(
+      "/link/one" => "11111-11111-11111",
+      "/link/two" => "22222-22222-22222",
+      "/link/three" => "33333-33333-33333",
+    )
+
+    stub_const("#{finder_service_class}::LINKED_FINDER_CONTENT_ID", finder_content_id)
+    allow(finder_service_class).to receive(:new).and_return(finder_service)
+    allow(publishing_api).to receive(:patch_links)
+  end
+
+  it "updates all content tagged to a facet group" do
+    Rake::Task['facets:patch_links_to_facet_group'].invoke(facet_group_content_id)
+    expect(publishing_api).to have_received(:patch_links).exactly(3).times
+  end
+end

--- a/spec/services/facets/tagging_update_publisher_spec.rb
+++ b/spec/services/facets/tagging_update_publisher_spec.rb
@@ -25,19 +25,45 @@ RSpec.describe Facets::TaggingUpdatePublisher do
       allow(publishing_api).to receive(:patch_links)
     end
 
-    it "patches content item links" do
-      instance.save_to_publishing_api
+    context "when content is tagged to facets" do
+      it "patches content item links" do
+        instance.save_to_publishing_api
 
-      expect(publishing_api).to have_received(:patch_links)
-        .with(
-          "MY-CONTENT-ID",
-          links: {
-            facet_groups: ["FACET-GROUP-CONTENT-ID"],
-            facet_values: ["A-FACET-VALUE-UUID"],
-            finder: [finder_content_id],
-          },
-          previous_version: 0,
-        )
+        expect(publishing_api).to have_received(:patch_links)
+          .with(
+            "MY-CONTENT-ID",
+            links: {
+              facet_groups: ["FACET-GROUP-CONTENT-ID"],
+              facet_values: ["A-FACET-VALUE-UUID"],
+              finder: [finder_content_id],
+            },
+            previous_version: 0,
+          )
+      end
+    end
+
+    context "when content isn't tagged to any facets" do
+      let(:params) do
+        {
+          facet_groups: [],
+          facet_values: [],
+          promoted: true,
+        }
+      end
+
+      it "doesn't patch any links if the document isn't tagged to a facet" do
+        instance.save_to_publishing_api
+
+        expect(publishing_api).to have_received(:patch_links)
+          .with(
+            "MY-CONTENT-ID",
+            links: {
+              facet_groups: [],
+              facet_values: [],
+            },
+            previous_version: 0,
+          )
+      end
     end
 
     it "returns a truthy result" do

--- a/spec/services/facets/tagging_update_publisher_spec.rb
+++ b/spec/services/facets/tagging_update_publisher_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe Facets::TaggingUpdatePublisher do
           links: {
             facet_groups: ["FACET-GROUP-CONTENT-ID"],
             facet_values: ["A-FACET-VALUE-UUID"],
+            finder: [finder_content_id],
           },
           previous_version: 0,
         )


### PR DESCRIPTION
Trello: https://trello.com/c/uR7v1Rri

Related to:
https://github.com/alphagov/govuk_publishing_components/pull/831
https://github.com/alphagov/govuk-content-schemas/pull/891

## What's changed
Every time content is tagged to a links-based facet group also tag it to the associated finder. At the moment there is only one links-based facet group, so the value for the finder is being hard-coded.

## Why
Based on research we know we need to provide users with a route to (or back to) the business finder from content. Breadcrumbs are the way we consistently provide routes 'upward' from content on the site.

To be able to add the breadcrumb, the content item needs to be able to pass information about the finder to the breadcrumb component.

An existing pattern for content tagged to specialist finders, is to add the `finder` to the `links` hash in the content item. For example: https://www.gov.uk/api/content/cma-cases/musical-instruments-and-equipment-suspected-anti-competitive-agreements-50565-3