### PR TITLE
Export a facet tagging data snapshot

### DIFF
--- a/lib/facet_data_exporter.rb
+++ b/lib/facet_data_exporter.rb
@@ -1,0 +1,69 @@
+require "csv"
+
+class FacetDataExporter
+  attr_reader :logger
+
+  def initialize(facet_group_content_id, data_file_path, facet_config_file_path, logger = Logger.new(STDOUT))
+    @facet_group_content_id = facet_group_content_id
+    @data_file_path = data_file_path
+    @facet_config_file_path = facet_config_file_path
+    @logger = logger
+  end
+
+  def export
+    logger.info("Writing facet tagging data to #{@data_file_path}")
+    CSV.open(@data_file_path, "wb") do |csv|
+      facet_values_for_content_items.each do |base_path, facet_value_data|
+        next unless facet_value_data
+
+        row = facet_value_data.unshift(base_path)
+        logger.info row.join(" | ")
+        csv << row
+      end
+    end
+  end
+
+private
+
+  attr_reader :facet_group_content_id
+
+  def facet_values_for_content_items
+    {}.tap do |hash|
+      content_items_linked_to_facet_group.each do |content_item|
+        response = publishing_api.get_links(content_item["content_id"])
+        facet_values_links = response.to_hash.fetch("links", {})["facet_values"]
+        next unless facet_values_links
+
+        tags = facet_values_tags(facet_values_links)
+        hash[content_item["base_path"]] = tags
+      end
+    end
+  end
+
+  def facet_values_tags(content_ids)
+    [].tap do |ary|
+      facet_group_config[:facets].each do |facet|
+        facet_values = facet[:facet_values]
+        ary << facet_values
+          .select { |fv| content_ids.include?(fv[:content_id]) }
+          .map { |fv| fv[:value] }
+          .sort
+          .join(",")
+      end
+    end
+  end
+
+  def content_items_linked_to_facet_group
+    publishing_api.get_linked_items(
+      facet_group_content_id, link_type: "facet_groups", fields: %w[content_id base_path document_type]
+    ).to_hash
+  end
+
+  def facet_group_config
+    @facet_group_config ||= YAML.load_file(@facet_config_file_path)
+  end
+
+  def publishing_api
+    Services.publishing_api
+  end
+end

--- a/lib/tasks/facets/facet_group.rake
+++ b/lib/tasks/facets/facet_group.rake
@@ -1,5 +1,6 @@
 require "facet_group_importer"
 require "facet_data_tagger"
+require "facet_data_exporter"
 
 namespace :facets do
   desc <<-DESC
@@ -43,5 +44,14 @@ namespace :facets do
     content_ids.each do |_, content_id|
       Services.publishing_api.patch_links(content_id, links: { finder: [Facets::FinderService::LINKED_FINDER_CONTENT_ID] })
     end
+  end
+
+  desc <<-DESC
+    Exports the facet values tagged to content in the publishing-api in csv format.
+    The csv file can be used by the `tag_content_to_facet_values` task to retag the
+    content.
+  DESC
+  task :export_content_tagged_to_facet_group, %i[facet_group_content_id export_file_path facet_group_file_path] => :environment do |_, args|
+    FacetDataExporter.new(args[:facet_group_content_id], args[:export_file_path], args[:facet_group_file_path]).export
   end
 end

--- a/spec/lib/facet_data_exporter_spec.rb
+++ b/spec/lib/facet_data_exporter_spec.rb
@@ -1,0 +1,130 @@
+require "rails_helper"
+require "facet_data_exporter"
+
+RSpec.describe FacetDataExporter do
+  let(:publishing_api) { Services.publishing_api }
+  let(:facet_group) do
+    {
+      content_id: "abc-123-def-456",
+      title: "A facet group",
+      description: "Test data facet group",
+      facets: [
+        {
+          content_id: "bcd-234-efg-567",
+          title: "A facet",
+          key: "a_facet",
+          facet_values: [
+            {
+              content_id: "cde-345-fgh-678",
+              title: "A facet value",
+              value: "a-facet-value",
+            },
+            {
+              content_id: "def-456-ghi-789",
+              title: "Another facet value",
+              value: "another-facet-value",
+            },
+            {
+              content_id: "efg-567-hij-890",
+              title: "Yet another facet value",
+              value: "yet-another-facet-value",
+            },
+          ]
+        },
+        {
+          content_id: "gbh-123-gef-000",
+          title: "Another facet",
+          key: "another_facet",
+          facet_values: [
+            {
+              content_id: "dce-435-ghf-888",
+              title: "Some facet value",
+              value: "some-facet-value",
+            },
+            {
+              content_id: "ddd-444-ggg-777",
+              title: "This facet value",
+              value: "this-facet-value",
+            },
+          ]
+        }
+
+      ]
+    }
+  end
+
+  let(:facet) { facet_group[:facets].first }
+  let(:content_items) do
+    [
+      { "content_id" => "zyx-987-cba-654", "base_path" => "/foo", "document_type" => "guide" },
+      { "content_id" => "cba-654-zyx-987", "base_path" => "/bar", "document_type" => "doc" },
+      { "content_id" => "abc-987-def-654", "base_path" => "/meh", "document_type" => "thing" },
+    ]
+  end
+
+  let(:links_for_content_ids) do
+    {
+      "zyx-987-cba-654" => %w[cde-345-fgh-678 def-456-ghi-789 ddd-444-ggg-777 dce-435-ghf-888],
+      "cba-654-zyx-987" => %w[cde-345-fgh-678 efg-567-hij-890 dce-435-ghf-888],
+      "abc-987-def-654" => %w[def-456-ghi-789],
+    }
+  end
+  let(:linked_items_response) { double(:linked_items, to_hash: content_items) }
+
+  let(:logger) { double(:logger, info: nil) }
+  let(:csv) { [] }
+
+  subject(:instance) { described_class.new("abc-123-def-456", "data.csv", "test-facets.yml", logger) }
+
+  before do
+    allow(YAML).to receive(:load_file).and_return(facet_group)
+    allow(publishing_api).to receive(:get_linked_items)
+      .with("abc-123-def-456", fields: %w[content_id base_path document_type], link_type: "facet_groups")
+      .and_return(linked_items_response)
+    links_for_content_ids.each do |k, v|
+      links_response = double(:links_response, to_hash: { "links" => { "facet_values" => v } })
+      allow(publishing_api).to receive(:get_links).with(k).and_return(links_response)
+    end
+    allow(CSV).to receive(:open).with("data.csv", "wb").and_yield(csv)
+    allow(csv).to receive(:<<)
+  end
+
+  describe "export" do
+    before { instance.export }
+
+    it "finds content items linked to a facet group" do
+      expect(publishing_api).to have_received(:get_linked_items)
+        .with("abc-123-def-456", fields: %w[content_id base_path document_type], link_type: "facet_groups")
+    end
+
+    it "finds links for each content item linked to a facet group" do
+      links_for_content_ids.each do |content_id, _|
+        expect(publishing_api).to have_received(:get_links).with(content_id)
+      end
+    end
+
+    it "writes tagged content data to csv" do
+      expect(csv).to have_received(:<<).with(
+        [
+          "/foo",
+          "a-facet-value,another-facet-value",
+          "some-facet-value,this-facet-value",
+        ]
+      )
+      expect(csv).to have_received(:<<).with(
+        [
+          "/bar",
+          "a-facet-value,yet-another-facet-value",
+          "some-facet-value",
+        ]
+      )
+      expect(csv).to have_received(:<<).with(
+        [
+          "/meh",
+          "another-facet-value",
+          "",
+        ]
+      )
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/ssBmniIV/112-create-a-snapshot-of-how-content-is-tagged-currently

Exports details about content tagged to a given facet group to a csv file.
The csv file is formatted to work with `FacetDataTagger` so that this data can be restored.