### PR TITLE
Remove link to finder when content is untagged from facet group

### DIFF
--- a/app/services/facets/tagging_update_publisher.rb
+++ b/app/services/facets/tagging_update_publisher.rb
@@ -68,23 +68,20 @@ module Facets
     def generate_links_payload
       facet_groups_content_ids = fetch_content_ids(:facet_groups)
       facet_values_content_ids = fetch_content_ids(:facet_values)
+      finder_content_ids = [FinderService::LINKED_FINDER_CONTENT_ID]
 
       if facet_values_content_ids.any?
         facet_groups_content_ids.push(facet_group_content_id)
       else
         facet_groups_content_ids.delete(facet_group_content_id)
+        finder_content_ids = []
       end
 
-      links = {
+      {
         facet_groups: facet_groups_content_ids.uniq,
         facet_values: facet_values_content_ids,
+        finder: finder_content_ids,
       }
-
-      if facet_values_content_ids.any?
-        links.merge!(finder: [FinderService::LINKED_FINDER_CONTENT_ID])
-      end
-
-      links
     end
 
     # FIXME: This is a temporary tag set which can be removed once

--- a/spec/features/tag_facets_to_a_page_spec.rb
+++ b/spec/features/tag_facets_to_a_page_spec.rb
@@ -140,6 +140,7 @@ RSpec.describe "Tagging content with facets", type: :feature do
       links: {
         facet_groups: [],
         facet_values: [],
+        finder: [],
       },
       previous_version: 54_321,
     )

--- a/spec/services/facets/tagging_update_publisher_spec.rb
+++ b/spec/services/facets/tagging_update_publisher_spec.rb
@@ -60,6 +60,7 @@ RSpec.describe Facets::TaggingUpdatePublisher do
             links: {
               facet_groups: [],
               facet_values: [],
+              finder: [],
             },
             previous_version: 0,
           )


### PR DESCRIPTION
Trello: https://trello.com/c/u5KXZwqD
Related to: #916 

If a content item is "untagged" from the business finder, it should no longer show the finder in the breadcrumb.

An empty list is still being passed publishing-api to make sure that the entry for `finder` in the links is overwritten.