### PR TITLE
Return an empty array when they are no pinned items

### DIFF
--- a/app/services/facets/finder_service.rb
+++ b/app/services/facets/finder_service.rb
@@ -9,7 +9,7 @@ module Facets
     end
 
     def pinned_item_links(content_id = LINKED_FINDER_CONTENT_ID)
-      finder_links(content_id).to_hash.fetch("links", {})["ordered_related_items"]
+      finder_links(content_id).to_hash.fetch("links", {})["ordered_related_items"] || []
     end
 
   private


### PR DESCRIPTION
When no items are pinned to the finder, `ordered_related_items` is not present in `links`, therefore nothing is returned by `pinned_item_links`.  This then leads to an error when `.include?` is invoked on the returned object (or lack of) in TaggingUpdateForm.