### PR TITLE
Add a related link to content tagged to the EU Exit Business Readiness Finder

### DIFF
--- a/app/services/facets/tagging_update_publisher.rb
+++ b/app/services/facets/tagging_update_publisher.rb
@@ -69,19 +69,30 @@ module Facets
       facet_groups_content_ids = fetch_content_ids(:facet_groups)
       facet_values_content_ids = fetch_content_ids(:facet_values)
       finder_content_ids = [FinderService::LINKED_FINDER_CONTENT_ID]
+      ordered_related_items_ids = ordered_related_links
 
       if facet_values_content_ids.any?
         facet_groups_content_ids.push(facet_group_content_id)
+        ordered_related_items_ids.unshift(FinderService::LINKED_FINDER_CONTENT_ID)
       else
         facet_groups_content_ids.delete(facet_group_content_id)
         finder_content_ids = []
+        ordered_related_items_ids.delete(FinderService::LINKED_FINDER_CONTENT_ID)
       end
 
       {
         facet_groups: facet_groups_content_ids.uniq,
         facet_values: facet_values_content_ids,
         finder: finder_content_ids,
+        ordered_related_items: ordered_related_items_ids,
       }
+    end
+
+    def ordered_related_links
+      Services.publishing_api.get_links(content_item.content_id)
+        .to_hash
+        .fetch("links")
+        .fetch("ordered_related_items", [])
     end
 
     # FIXME: This is a temporary tag set which can be removed once

--- a/lib/tasks/eu_exit_business_finder.rake
+++ b/lib/tasks/eu_exit_business_finder.rake
@@ -1,0 +1,21 @@
+namespace :eu_exit_business_finder do
+  desc <<-DESC
+    Adds a link to the EU Exit Business Readiness Finder to all content items which are tagged to this finder
+  DESC
+  task add_related_link_to_tagged_content: [:environment] do
+    facet_group_content_id = "52435175-82ed-4a04-adef-74c0199d0f46"
+    finder_content_id = "42ce66de-04f3-4192-bf31-8394538e0734"
+
+    content_ids = Services.publishing_api.get_linked_items(
+      facet_group_content_id, link_type: "facet_groups", fields: %w[content_id]
+    ).pluck('content_id')
+
+    content_ids.each do |content_id|
+      ordered_links = Services.publishing_api.get_links(content_id)
+        .to_hash
+        .fetch("links")
+        .fetch("ordered_related_items", [])
+      Services.publishing_api.patch_links(content_id, links: { ordered_related_items: ordered_links.unshift(finder_content_id) })
+    end
+  end
+end

--- a/spec/features/tag_facets_to_a_page_spec.rb
+++ b/spec/features/tag_facets_to_a_page_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "Tagging content with facets", type: :feature do
 
   before do
     stub_facet_groups_lookup
+    stub_publishing_api_has_links(content_id: "MY-CONTENT-ID", links: { ordered_related_items: [] })
     stub_patch_links_request("facets_tagging_request", "MY-CONTENT-ID")
     given_we_can_populate_facets_with_content_from_publishing_api
   end
@@ -30,6 +31,7 @@ RSpec.describe "Tagging content with facets", type: :feature do
         facet_groups: ["FACET-GROUP-UUID"],
         facet_values: ["ANOTHER-FACET-VALUE-UUID", "EXISTING-FACET-VALUE-UUID"],
         finder: [stub_linked_finder_content_id],
+        ordered_related_items: [stub_linked_finder_content_id],
       },
       previous_version: 54_321,
     )
@@ -43,6 +45,7 @@ RSpec.describe "Tagging content with facets", type: :feature do
         facet_groups: ["FACET-GROUP-UUID"],
         facet_values: ["ANOTHER-FACET-VALUE-UUID", "EXISTING-FACET-VALUE-UUID"],
         finder: [stub_linked_finder_content_id],
+        ordered_related_items: [stub_linked_finder_content_id],
       }
 
       expected_tags = {
@@ -114,6 +117,7 @@ RSpec.describe "Tagging content with facets", type: :feature do
         facet_groups: ["FACET-GROUP-UUID"],
         facet_values: ["ANOTHER-FACET-VALUE-UUID", "EXISTING-FACET-VALUE-UUID"],
         finder: [stub_linked_finder_content_id],
+        ordered_related_items: [stub_linked_finder_content_id],
       },
       previous_version: 54_321,
     )
@@ -141,6 +145,7 @@ RSpec.describe "Tagging content with facets", type: :feature do
         facet_groups: [],
         facet_values: [],
         finder: [],
+        ordered_related_items: [],
       },
       previous_version: 54_321,
     )
@@ -190,6 +195,7 @@ RSpec.describe "Tagging content with facets", type: :feature do
         facet_groups: ["FACET-GROUP-UUID"],
         facet_values: ["EXISTING-FACET-VALUE-UUID"],
         finder: [stub_linked_finder_content_id],
+        ordered_related_items: [stub_linked_finder_content_id],
       },
       previous_version: 54_321,
     )
@@ -222,6 +228,7 @@ RSpec.describe "Tagging content with facets", type: :feature do
         facet_groups: ["FACET-GROUP-UUID"],
         facet_values: ["EXISTING-FACET-VALUE-UUID"],
         finder: [stub_linked_finder_content_id],
+        ordered_related_items: [stub_linked_finder_content_id],
       },
       previous_version: 54_321,
     )

--- a/spec/services/facets/tagging_update_publisher_spec.rb
+++ b/spec/services/facets/tagging_update_publisher_spec.rb
@@ -9,7 +9,9 @@ RSpec.describe Facets::TaggingUpdatePublisher do
     let(:pinned_item_links) { ["PINNED-ITEM-UUID"] }
     let(:finder_service_class) { Facets::FinderService }
     let(:finder_service) { double(:finder_service, pinned_item_links: pinned_item_links) }
-    let(:content_item) { double(:content_item, content_id: "MY-CONTENT-ID") }
+    let(:links) { { "ordered_related_items": ["RELATED-LINK"] } }
+    let(:content_item) { double(:content_item, content_id: "MY-CONTENT-ID", links: links) }
+    let(:links_item) { { content_id: "MY-CONTENT-ID", links: links } }
     let(:params) do
       {
         facet_groups: [facet_group_content_id],
@@ -21,6 +23,7 @@ RSpec.describe Facets::TaggingUpdatePublisher do
 
     before do
       stub_const "#{finder_service_class}::LINKED_FINDER_CONTENT_ID", finder_content_id
+      stub_publishing_api_has_links(links_item)
       allow(finder_service_class).to receive(:new).and_return(finder_service)
       allow(publishing_api).to receive(:patch_links)
     end
@@ -36,6 +39,7 @@ RSpec.describe Facets::TaggingUpdatePublisher do
               facet_groups: ["FACET-GROUP-CONTENT-ID"],
               facet_values: ["A-FACET-VALUE-UUID"],
               finder: [finder_content_id],
+              ordered_related_items: [finder_content_id, "RELATED-LINK"],
             },
             previous_version: 0,
           )
@@ -47,6 +51,7 @@ RSpec.describe Facets::TaggingUpdatePublisher do
         {
           facet_groups: [],
           facet_values: [],
+          ordered_related_items: ["RELATED-LINK"],
           promoted: true,
         }
       end
@@ -61,6 +66,7 @@ RSpec.describe Facets::TaggingUpdatePublisher do
               facet_groups: [],
               facet_values: [],
               finder: [],
+              ordered_related_items: ["RELATED-LINK"],
             },
             previous_version: 0,
           )
@@ -85,6 +91,7 @@ RSpec.describe Facets::TaggingUpdatePublisher do
         {
           facet_groups: [facet_group_content_id],
           facet_values: ["A-FACET-VALUE-UUID"],
+          ordered_related_items: [finder_content_id, "RELATED-LINK"],
           promoted: true,
         }
       end


### PR DESCRIPTION
There are two aspects:
- New rake task to add related link for business finder linked content.  This adds a related link (back to the finder itself) to all content items that are tagged to the EU Exit Business Readiness Finder.  This is intended to be run once to add the related link to all existing content, then can be removed.  Task run as `bundle exec rake eu_exit_business_finder:add_related_link_to_tagged_content`.
- Adding a related link when tagging to the business finder.  When content is tagged to the business readiness finder, a related link will be created in the content item.  This related link will always be the first related item for that content item, so will show first in the list (in the event of there being other related links for that content).  The related link is removed when the content item is no longer tagged to any of the facets within the finder.  All other related links are retained.

Example of document with related link added:
<img width="1000" alt="Screen Shot 2019-06-05 at 14 00 04" src="https://user-images.githubusercontent.com/6329861/58958194-47279300-879a-11e9-941a-2ea458de050d.png">

Trello card: https://trello.com/c/GqRWFNoB/144-add-a-related-link-to-all-content-tagged-to-the-business-finder-to-take-users-to-it