### PR TITLE
Reorder 'Digital, technology and computer services' alphabetically

### DIFF
--- a/lib/data/find-eu-exit-guidance-business.yml
+++ b/lib/data/find-eu-exit-guidance-business.yml
@@ -46,9 +46,6 @@
       - :content_id: a7263c3b-7ade-4a91-9f51-40ebc57b3f98
         :title: Clothing and consumer goods manufacture
         :value: clothing-consumer-goods-manufacturing
-      - :content_id: 70e6087f-714e-4922-8e06-72cfff997785
-        :title: Digital, technology and computer services
-        :value: computer-services
       - :content_id: 9eb88205-118b-4f0b-abd9-ac6b469054c5
         :title: Construction
         :value: construction-contracting
@@ -58,6 +55,9 @@
       - :content_id: 77764805-73e6-4d47-9f20-aedd6de7dab9
         :title: Defence
         :value: defence
+      - :content_id: 70e6087f-714e-4922-8e06-72cfff997785
+        :title: Digital, technology and computer services
+        :value: computer-services
       - :content_id: 7c980b5d-a7ea-4d6e-aad1-e80e882566c4
         :title: Education
         :value: education


### PR DESCRIPTION
Depended on by https://github.com/alphagov/search-api/pull/1590.

Previous value was 'Computer services', so current position in the YAML files
would have been in alphabetical order. But following a review, this was renamed in
https://github.com/alphagov/content-tagger/commit/6c27028fca08b7e3b8ed1326266065d7476c23c8 and no longer appears in alphabetical order.

| Before | After |
|-------|-------|
|![in wrong order](https://user-images.githubusercontent.com/5111927/59666416-b646b380-91ac-11e9-87e3-0b3b3bf8a977.png)|![in right order](https://user-images.githubusercontent.com/5111927/59670273-96ff5480-91b3-11e9-838f-2a326c274aef.png)|

Trello card: https://trello.com/c/PADPKr9M

