### PR TITLE
Remove ability to pin to facets

### DIFF
--- a/app/services/facets/finder_service.rb
+++ b/app/services/facets/finder_service.rb
@@ -8,10 +8,6 @@ module Facets
       end
     end
 
-    def pinned_item_links(content_id = LINKED_FINDER_CONTENT_ID)
-      finder_links(content_id).to_hash.fetch("links", {})["ordered_related_items"] || []
-    end
-
   private
 
     def finders_for_facet_group(facet_group_content_id)

--- a/app/services/facets/tagging_update_form.rb
+++ b/app/services/facets/tagging_update_form.rb
@@ -2,7 +2,7 @@ module Facets
   # ActiveModel-compliant object that is passed into the tagging form.
   class TaggingUpdateForm
     include ActiveModel::Model
-    attr_accessor :content_item, :previous_version, :promoted,
+    attr_accessor :content_item, :previous_version,
                   :notify, :notification_message, :links
 
     delegate :content_id, to: :content_item
@@ -12,8 +12,6 @@ module Facets
 
     def self.from_content_item(content_item)
       links = content_item.facets_link_set
-      finder_links = Facets::FinderService.new.pinned_item_links
-      promoted = finder_links.include?(content_item.content_id)
 
       tag_values = TAG_TYPES.each_with_object({}) do |tag_type, current_tags|
         current_tags[tag_type] = links.send(tag_type).map { |links_hash| links_hash["content_id"] }
@@ -23,7 +21,6 @@ module Facets
         links: links,
         content_item: content_item,
         previous_version: links.previous_version,
-        promoted: promoted,
         **tag_values
       )
     end
@@ -38,7 +35,6 @@ module Facets
 
     def update_attributes_from_form(params)
       @previous_version = params[:previous_version]
-      @promoted = params[:promoted]
       @notify = params[:notify]
       @notification_message = params[:notification_message]
       validate_notification

--- a/app/views/facet_taggings/_tagging_form.html.erb
+++ b/app/views/facet_taggings/_tagging_form.html.erb
@@ -12,14 +12,6 @@
     </div>
   <% end %>
 
-  <%= f.input :promoted,
-              as: :boolean,
-              checked_value: true,
-              unchecked_value: false,
-              label: "Pin this page to top of finder results" %>
-
-  <hr/>
-
   <%= f.input :notify,
               as: :boolean,
               checked_value: true,

--- a/spec/features/tag_facets_to_a_page_spec.rb
+++ b/spec/features/tag_facets_to_a_page_spec.rb
@@ -170,75 +170,6 @@ RSpec.describe "Tagging content with facets", type: :feature do
     then_i_see_that_there_is_a_conflict
   end
 
-  # Pinning means the content item will be ordered above others in
-  # filtered finder results. This means the item is added to the
-  # ordered_related_items links for the finder.
-  scenario "User pins a content item" do
-    stub_finder_get_links_request
-    stub_patch_links_request("finder_pinning_request", "FINDER-UUID")
-
-    given_there_is_a_content_item_with_expanded_links(
-      facet_groups: [example_facet_group],
-      facet_values: [example_facet_value],
-    )
-    when_i_visit_facet_groups_page
-    and_i_select_the_facet_group("Example facet group")
-    and_i_edit_facets_for_the_page("/my-content-item")
-
-    when_i_pin_the_item_in_finder_results
-
-    and_i_submit_the_facets_tagging_form
-
-    then_the_publishing_api_is_sent(
-      "facets_tagging_request",
-      links: {
-        facet_groups: ["FACET-GROUP-UUID"],
-        facet_values: ["EXISTING-FACET-VALUE-UUID"],
-        finder: [stub_linked_finder_content_id],
-        ordered_related_items: [stub_linked_finder_content_id],
-      },
-      previous_version: 54_321,
-    )
-
-    then_the_publishing_api_is_sent(
-      "finder_pinning_request",
-      links: { ordered_related_items: ["EXISTING-PINNED-ITEM-UUID", "MY-CONTENT-ID"] }
-    )
-  end
-
-  scenario "User unpins a content item" do
-    stub_finder_get_links_request(items: ["EXISTING-PINNED-ITEM-UUID", "MY-CONTENT-ID"])
-    stub_patch_links_request("finder_pinning_request", "FINDER-UUID")
-
-    given_there_is_a_content_item_with_expanded_links(
-      facet_groups: [example_facet_group],
-      facet_values: [example_facet_value],
-    )
-    when_i_visit_facet_groups_page
-    and_i_select_the_facet_group("Example facet group")
-    and_i_edit_facets_for_the_page("/my-content-item")
-
-    when_i_unpin_the_item_in_finder_results
-
-    and_i_submit_the_facets_tagging_form
-
-    then_the_publishing_api_is_sent(
-      "facets_tagging_request",
-      links: {
-        facet_groups: ["FACET-GROUP-UUID"],
-        facet_values: ["EXISTING-FACET-VALUE-UUID"],
-        finder: [stub_linked_finder_content_id],
-        ordered_related_items: [stub_linked_finder_content_id],
-      },
-      previous_version: 54_321,
-    )
-
-    then_the_publishing_api_is_sent(
-      "finder_pinning_request",
-      links: { ordered_related_items: ["EXISTING-PINNED-ITEM-UUID"] }
-    )
-  end
-
   def given_we_can_populate_facets_with_content_from_publishing_api
     publishing_api_has_facet_values_linkables(%w[Agriculture"])
   end
@@ -297,14 +228,6 @@ RSpec.describe "Tagging content with facets", type: :feature do
 
   def when_i_remove_the_facet_value(selection)
     unselect selection, from: "facets_tagging_update_form_example_facet"
-  end
-
-  def when_i_pin_the_item_in_finder_results
-    check 'facets_tagging_update_form_promoted'
-  end
-
-  def when_i_unpin_the_item_in_finder_results
-    uncheck 'facets_tagging_update_form_promoted'
   end
 
   def and_i_see_the_notification_is_invalid

--- a/spec/lib/tasks/facets/facet_group_spec.rb
+++ b/spec/lib/tasks/facets/facet_group_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'facets:patch_links_to_facet_group' do
   let(:facet_group_content_id) { "FACET-GROUP-CONTENT-ID" }
   let(:finder_content_id) { "FINDER-CONTENT-ID" }
   let(:finder_service_class) { Facets::FinderService }
-  let(:finder_service) { double(:finder_service, pinned_item_links: []) }
+  let(:finder_service) { double(:finder_service) }
   let(:publishing_api) { Services.publishing_api }
 
   before :each do

--- a/spec/services/facets/tagging_update_publisher_spec.rb
+++ b/spec/services/facets/tagging_update_publisher_spec.rb
@@ -6,9 +6,8 @@ RSpec.describe Facets::TaggingUpdatePublisher do
   describe "save_to_publishing_api" do
     let(:facet_group_content_id) { "FACET-GROUP-CONTENT-ID" }
     let(:finder_content_id) { "FINDER-CONTENT-ID" }
-    let(:pinned_item_links) { ["PINNED-ITEM-UUID"] }
     let(:finder_service_class) { Facets::FinderService }
-    let(:finder_service) { double(:finder_service, pinned_item_links: pinned_item_links) }
+    let(:finder_service) { double(:finder_service) }
     let(:links) { { "ordered_related_items": ["RELATED-LINK"] } }
     let(:content_item) { double(:content_item, content_id: "MY-CONTENT-ID", links: links) }
     let(:links_item) { { content_id: "MY-CONTENT-ID", links: links } }
@@ -52,7 +51,6 @@ RSpec.describe Facets::TaggingUpdatePublisher do
           facet_groups: [],
           facet_values: [],
           ordered_related_items: ["RELATED-LINK"],
-          promoted: true,
         }
       end
 
@@ -75,38 +73,6 @@ RSpec.describe Facets::TaggingUpdatePublisher do
 
     it "returns a truthy result" do
       expect(instance.save_to_publishing_api).to be_truthy
-    end
-
-    context "without pinning the content" do
-      it "does not patch finder links" do
-        instance.save_to_publishing_api
-
-        expect(publishing_api).not_to have_received(:patch_links)
-          .with(finder_content_id, anything)
-      end
-    end
-
-    context "pinning the content" do
-      let(:params) do
-        {
-          facet_groups: [facet_group_content_id],
-          facet_values: ["A-FACET-VALUE-UUID"],
-          ordered_related_items: [finder_content_id, "RELATED-LINK"],
-          promoted: true,
-        }
-      end
-
-      it "patches finder links" do
-        instance.save_to_publishing_api
-
-        expect(publishing_api).to have_received(:patch_links)
-          .with(
-            finder_content_id,
-            links: {
-              ordered_related_items: ["MY-CONTENT-ID", "PINNED-ITEM-UUID"],
-            },
-          )
-      end
     end
   end
 end


### PR DESCRIPTION
The EU Exit Business Readiness Finder was the only finder using pinning (this is where a content item was promoted to the top of a facet by adding it as a related item on the content item of the finder itself).

After retagging content, it has been decided that pinning is no longer required, therefore this commit removes the ability to pin content items when tagging to facets.

Trello card: https://trello.com/c/47TGkbHM/157-remove-pinning-code-from-content-tagger