### PR TITLE
Make updates to business sectors and business activities for EU Exit Business Readiness Finder

### DIFF
--- a/lib/data/find-eu-exit-guidance-business.yml
+++ b/lib/data/find-eu-exit-guidance-business.yml
@@ -300,7 +300,7 @@
     :type: content_id
     :facet_values:
       - :content_id: f165dc7c-7cef-446a-bdfd-8a1ca685d091
-        :title: Civil government contracts
+        :title: Public sector contracts
         :value: civil-government-contracts
       - :content_id: 33fc20d7-6a45-40c9-b31f-e4678f962ff1
         :title: Defence contracts

--- a/lib/data/find-eu-exit-guidance-business.yml
+++ b/lib/data/find-eu-exit-guidance-business.yml
@@ -82,7 +82,7 @@
       - :content_id: 9f3476e1-8ff0-455d-a14e-003236b2797c
         :title: Food, drink and tobacco (processing)
         :value: food-drink-tobacco
-      - :content_id: '040649fc-4e2c-4028-b846-77fe3eebd1f7'
+      - :content_id: 040649fc-4e2c-4028-b846-77fe3eebd1f7
         :title: Furniture manufacture
         :value: furniture-manufacture
       - :content_id: 6ae9d424-6ade-456e-bcbe-6ce72b72ca13
@@ -154,7 +154,7 @@
       - :content_id: f07527f1-e6de-4fe8-b7d9-b197769e1f1f
         :title: Professional, legal and business services
         :value: professional-and-business-services
-      - :content_id: '091c0e83-bb54-4727-9b2c-a919510e1e79'
+      - :content_id: 091c0e83-bb54-4727-9b2c-a919510e1e79
         :title: Public administration
         :value: public-administration
       - :content_id: 53bcfcf0-e22a-416d-91ac-2661e1d6ed04
@@ -224,7 +224,7 @@
       - :content_id: 7ae8e57c-ea7a-42de-84fc-a084b5f64bca
         :title: Do other types of business in the EU
         :value: other-eu
-      - :content_id: '07398027-ee4d-4bda-b53e-2dc655734049'
+      - :content_id: 07398027-ee4d-4bda-b53e-2dc655734049
         :title: Transport goods abroad
         :value: transporting
   - :content_id: b2716a1e-dc24-4566-b8ed-f3ee23a994ec

--- a/lib/data/find-eu-exit-guidance-business.yml
+++ b/lib/data/find-eu-exit-guidance-business.yml
@@ -19,12 +19,18 @@
       - :content_id: 24fd50fa-6619-46ca-96cd-8ce90fa076ce
         :title: Aerospace and space
         :value: aerospace
+      - :content_id: 9d54c591-f5ca-4d0c-a484-12d5591987cb
+        :title: Agriculture and farming
+        :value: agriculture-and-farming
       - :content_id: 94b3cfe2-af89-4744-b8d7-7fc79edcbc85
         :title: Agriculture and forestry (including wholesale)
         :value: agriculture
       - :content_id: 43d328b3-59ee-4d5d-bda0-7c7d4bb301be
         :title: Air freight and air passenger services
         :value: air-freight-air-passenger-services
+      - :content_id: 769b6a0c-9d64-45a4-850a-a8f7cfd5b60e
+        :title: Animals and animal products (excluding food)
+        :value: animals-and-animal-products
       - :content_id: cf341686-c886-42c7-bf8e-cf177b6a2100
         :title: Arts, culture and heritage
         :value: arts-culture-heritage
@@ -52,6 +58,9 @@
       - :content_id: 77764805-73e6-4d47-9f20-aedd6de7dab9
         :title: Defence
         :value: defence
+      - :content_id: a68e08f2-6728-4f1d-bb90-514e733db8de
+        :title: Diamonds
+        :value: diamonds
       - :content_id: 70e6087f-714e-4922-8e06-72cfff997785
         :title: Digital, technology and computer services
         :value: computer-services
@@ -142,6 +151,9 @@
       - :content_id: 93f5c156-2449-4e52-9e92-aefc73586ffd
         :title: Pharmaceuticals and clinical trials
         :value: pharmaceuticals
+      - :content_id: afd45eef-743a-417d-9245-3eab8322116d
+        :title: Plants and forestry
+        :value: plants-and-forestry
       - :content_id: 4591ce75-7568-48c6-af5f-3558f89f7f57
         :title: Ports and airports
         :value: ports-airports

--- a/lib/data/find-eu-exit-guidance-business.yml
+++ b/lib/data/find-eu-exit-guidance-business.yml
@@ -17,7 +17,7 @@
         :title: Accommodation
         :value: accommodation
       - :content_id: 24fd50fa-6619-46ca-96cd-8ce90fa076ce
-        :title: Aerospace
+        :title: Aerospace and space
         :value: aerospace
       - :content_id: 94b3cfe2-af89-4744-b8d7-7fc79edcbc85
         :title: Agriculture and forestry (including wholesale)
@@ -44,7 +44,7 @@
         :title: Clothing and consumer goods
         :value: clothing-consumer-goods
       - :content_id: a7263c3b-7ade-4a91-9f51-40ebc57b3f98
-        :title: Clothing and consumer goods manufacture
+        :title: Manufacturing of consumer goods
         :value: clothing-consumer-goods-manufacturing
       - :content_id: 9eb88205-118b-4f0b-abd9-ac6b469054c5
         :title: Construction
@@ -77,7 +77,7 @@
         :title: Fisheries (including wholesale)
         :value: fisheries
       - :content_id: 53f9ce4c-7cbb-447f-bdf1-a9b022896d3a
-        :title: Food, drink and tobacco (retail and wholesale)
+        :title: Food, drink and tobacco
         :value: food-and-drink
       - :content_id: 9f3476e1-8ff0-455d-a14e-003236b2797c
         :title: Food, drink and tobacco (processing)
@@ -101,7 +101,7 @@
         :title: Justice including prisons
         :value: justice-prisons
       - :content_id: 18c3892e-8a0e-4884-906e-5938380eceee
-        :title: Marine
+        :title: Marine and marine transport
         :value: marine
       - :content_id: 356f46a0-17d3-4ba4-8952-8c02244f9045
         :title: Marine transport
@@ -134,7 +134,7 @@
         :title: Oil, gas and coal
         :value: oil-gas-coal
       - :content_id: 2c562ab5-7891-4a00-8510-a5ebdb4001c8
-        :title: Other energy
+        :title: Renewable energy
         :value: other-energy
       - :content_id: 7536c0c4-fb41-43f4-a2c4-08f4fa9f5427
         :title: Other manufacturing
@@ -143,7 +143,7 @@
         :title: Personal services
         :value: personal-services
       - :content_id: 93f5c156-2449-4e52-9e92-aefc73586ffd
-        :title: Pharmaceuticals
+        :title: Pharmaceuticals and clinical trials
         :value: pharmaceuticals
       - :content_id: 4591ce75-7568-48c6-af5f-3558f89f7f57
         :title: Ports and airports
@@ -152,13 +152,13 @@
         :title: Postal and courier services
         :value: postal-courier-services
       - :content_id: f07527f1-e6de-4fe8-b7d9-b197769e1f1f
-        :title: Professional and business services
+        :title: Professional, legal and business services
         :value: professional-and-business-services
       - :content_id: '091c0e83-bb54-4727-9b2c-a919510e1e79'
         :title: Public administration
         :value: public-administration
       - :content_id: 53bcfcf0-e22a-416d-91ac-2661e1d6ed04
-        :title: Rail
+        :title: Rail (manufacture)
         :value: rail
       - :content_id: 2e1cf5a9-d410-4cfc-9f54-d94302f8fbd1
         :title: Rail (passengers and freight)
@@ -176,7 +176,7 @@
         :title: Restaurants, bars and catering
         :value: restaurants-bars-catering
       - :content_id: 34a6edd0-46ea-4a76-ae80-8c96709d4f59
-        :title: Retail and wholesale (excluding motor trade, food and drink)
+        :title: Retail and wholesale (excluding food, drink and motors)
         :value: retail
       - :content_id: 6f5f8dbb-3cd3-475d-8f3a-ed6e22d370be
         :title: Road (passengers and freight)
@@ -197,7 +197,7 @@
         :title: Veterinary
         :value: veterinary
       - :content_id: c66d8196-977f-47a5-806f-885c9cf01412
-        :title: Voluntary and community organistions
+        :title: Voluntary and community organisations
         :value: voluntary-community-organisations
       - :content_id: 15ad9a45-5536-4323-97f9-ed470cdf1e3b
         :title: Warehousing, services and pipelines

--- a/lib/data/find-eu-exit-guidance-business.yml
+++ b/lib/data/find-eu-exit-guidance-business.yml
@@ -43,9 +43,6 @@
       - :content_id: 1e3e8abd-135d-4844-afa8-5c51df3d3c57
         :title: Clothing and consumer goods
         :value: clothing-consumer-goods
-      - :content_id: a7263c3b-7ade-4a91-9f51-40ebc57b3f98
-        :title: Manufacturing of consumer goods
-        :value: clothing-consumer-goods-manufacturing
       - :content_id: 9eb88205-118b-4f0b-abd9-ac6b469054c5
         :title: Construction
         :value: construction-contracting
@@ -100,6 +97,9 @@
       - :content_id: cec78369-d11b-48cb-9a90-ebd4ebb5de37
         :title: Justice including prisons
         :value: justice-prisons
+      - :content_id: a7263c3b-7ade-4a91-9f51-40ebc57b3f98
+        :title: Manufacturing of consumer goods
+        :value: clothing-consumer-goods-manufacturing
       - :content_id: 18c3892e-8a0e-4884-906e-5938380eceee
         :title: Marine and marine transport
         :value: marine
@@ -133,9 +133,6 @@
       - :content_id: 46ad5a1d-fc2d-4065-a34f-3f7b2fea8e81
         :title: Oil, gas and coal
         :value: oil-gas-coal
-      - :content_id: 2c562ab5-7891-4a00-8510-a5ebdb4001c8
-        :title: Renewable energy
-        :value: other-energy
       - :content_id: 7536c0c4-fb41-43f4-a2c4-08f4fa9f5427
         :title: Other manufacturing
         :value: other-manufacturing
@@ -166,6 +163,9 @@
       - :content_id: dba1b198-1ead-4de4-a961-b11d71fc6f20
         :title: Real estate
         :value: real-estate-excl-imputed-rent
+      - :content_id: 2c562ab5-7891-4a00-8510-a5ebdb4001c8
+        :title: Renewable energy
+        :value: other-energy
       - :content_id: c1d8057c-76bf-431c-9ac8-6281a4b7b9ca
         :title: Repair of computers and consumer goods
         :value: repair-of-computers-consumer-goods

--- a/lib/data/find-eu-exit-guidance-business.yml
+++ b/lib/data/find-eu-exit-guidance-business.yml
@@ -195,20 +195,23 @@
     :type: content_id
     :facet_values:
       - :content_id: a55f04df-3877-4c73-bbfe-ad7339cdfccf
-        :title: Sell products or goods in the UK
+        :title: Sell goods or provide services in the UK
         :value: products-or-goods
       - :content_id: d422aa2e-59ad-4986-8ef0-973959878912
-        :title: Buy products or goods from abroad
+        :title: Import from the EU
         :value: buying
       - :content_id: 7283b8e1-840f-49da-967f-c0a512a3f531
-        :title: Sell products or goods abroad
+        :title: Export to the EU
         :value: selling
       - :content_id: 7ae8e57c-ea7a-42de-84fc-a084b5f64bca
-        :title: Do other types of business in the EU
+        :title: Provide services or do business in the EU
         :value: other-eu
       - :content_id: 07398027-ee4d-4bda-b53e-2dc655734049
-        :title: Transport goods abroad
+        :title: Haulage of goods across EU borders
         :value: transporting
+      - :content_id: c35c2e8c-f88e-42e0-83ed-62e896aafd92
+        :title: None of these
+        :value: none-of-these
   - :content_id: b2716a1e-dc24-4566-b8ed-f3ee23a994ec
     :name: "Who you employ"
     :short_name: "Employing EU citizens"

--- a/lib/data/find-eu-exit-guidance-business.yml
+++ b/lib/data/find-eu-exit-guidance-business.yml
@@ -22,9 +22,6 @@
       - :content_id: 9d54c591-f5ca-4d0c-a484-12d5591987cb
         :title: Agriculture and farming
         :value: agriculture-and-farming
-      - :content_id: 94b3cfe2-af89-4744-b8d7-7fc79edcbc85
-        :title: Agriculture and forestry (including wholesale)
-        :value: agriculture
       - :content_id: 43d328b3-59ee-4d5d-bda0-7c7d4bb301be
         :title: Air freight and air passenger services
         :value: air-freight-air-passenger-services
@@ -37,18 +34,12 @@
       - :content_id: e53e578a-01d2-4844-b52b-fd375ee4c4b9
         :title: Automotive
         :value: automotive
-      - :content_id: 5faa1741-fc55-4110-b342-de92f6324118
-        :title: Auxiliary activities
-        :value: auxiliary-activities
       - :content_id: 05334231-9be3-4670-a2f5-84bef7e3badd
         :title: Charities
         :value: charities
       - :content_id: 7620da7a-0427-4b3c-9498-db9dc25209b0
         :title: Chemicals
         :value: chemicals
-      - :content_id: 1e3e8abd-135d-4844-afa8-5c51df3d3c57
-        :title: Clothing and consumer goods
-        :value: clothing-consumer-goods
       - :content_id: 9eb88205-118b-4f0b-abd9-ac6b469054c5
         :title: Construction
         :value: construction-contracting
@@ -85,12 +76,6 @@
       - :content_id: 53f9ce4c-7cbb-447f-bdf1-a9b022896d3a
         :title: Food, drink and tobacco
         :value: food-and-drink
-      - :content_id: 9f3476e1-8ff0-455d-a14e-003236b2797c
-        :title: Food, drink and tobacco (processing)
-        :value: food-drink-tobacco
-      - :content_id: 040649fc-4e2c-4028-b846-77fe3eebd1f7
-        :title: Furniture manufacture
-        :value: furniture-manufacture
       - :content_id: 6ae9d424-6ade-456e-bcbe-6ce72b72ca13
         :title: Gambling
         :value: gambling
@@ -112,9 +97,6 @@
       - :content_id: 18c3892e-8a0e-4884-906e-5938380eceee
         :title: Marine and marine transport
         :value: marine
-      - :content_id: 356f46a0-17d3-4ba4-8952-8c02244f9045
-        :title: Marine transport
-        :value: marine-transport
       - :content_id: 442e7d39-9ebf-46c5-813a-daa328e135b8
         :title: Media and broadcasting
         :value: broadcasting
@@ -136,15 +118,9 @@
       - :content_id: 45bfb0a2-b60d-40f2-b9af-b5d2b4b91445
         :title: Nuclear
         :value: nuclear
-      - :content_id: 14cf2a68-3297-44d3-ba01-a4426845b1b8
-        :title: Other advanced manufacturing
-        :value: other-advanced-manufacturing
       - :content_id: 46ad5a1d-fc2d-4065-a34f-3f7b2fea8e81
         :title: Oil, gas and coal
         :value: oil-gas-coal
-      - :content_id: 7536c0c4-fb41-43f4-a2c4-08f4fa9f5427
-        :title: Other manufacturing
-        :value: other-manufacturing
       - :content_id: d9da7c7b-b0c9-4757-aa45-9c70dd78df62
         :title: Personal services
         :value: personal-services
@@ -178,9 +154,6 @@
       - :content_id: 2c562ab5-7891-4a00-8510-a5ebdb4001c8
         :title: Renewable energy
         :value: other-energy
-      - :content_id: c1d8057c-76bf-431c-9ac8-6281a4b7b9ca
-        :title: Repair of computers and consumer goods
-        :value: repair-of-computers-consumer-goods
       - :content_id: 39771bc2-8b2c-43e9-9cfc-fa3606b67db6
         :title: Research
         :value: research
@@ -193,9 +166,6 @@
       - :content_id: 6f5f8dbb-3cd3-475d-8f3a-ed6e22d370be
         :title: Road (passengers and freight)
         :value: road-passengers-freight
-      - :content_id: b4e507df-f067-4749-9468-3de120775216
-        :title: Space
-        :value: space
       - :content_id: 4d98ae8d-fd44-4e5d-8cf0-b9b01bd76b1a
         :title: Sports and recreation
         :value: sports-recreation

--- a/lib/tasks/eu_exit_business_finder.rake
+++ b/lib/tasks/eu_exit_business_finder.rake
@@ -1,0 +1,152 @@
+namespace :eu_exit_business_finder do
+  task retag_documents_to_facet_values: [:environment] do
+    EuExitBusinessRakeMethods.replace_facet_values
+    EuExitBusinessRakeMethods.retag_content_facet_values
+    EuExitBusinessRakeMethods.delete_facet_values_from_content
+  end
+end
+
+module EuExitBusinessRakeMethods
+  def self.facet_values_to_replace
+    # For each item in the array:
+    # All documents tagged with `old_facet_value` will be re-tagged
+    # with `new_facet_value`
+    [
+      {
+        "old_facet_value": "9f3476e1-8ff0-455d-a14e-003236b2797c",
+        "new_facet_value": "53f9ce4c-7cbb-447f-bdf1-a9b022896d3a"
+      },
+
+      {
+        "old_facet_value": "b4e507df-f067-4749-9468-3de120775216",
+        "new_facet_value": "24fd50fa-6619-46ca-96cd-8ce90fa076ce"
+      },
+
+      {
+        "old_facet_value": "1e3e8abd-135d-4844-afa8-5c51df3d3c57",
+        "new_facet_value": "34a6edd0-46ea-4a76-ae80-8c96709d4f59"
+      },
+
+      {
+        "old_facet_value": "c1d8057c-76bf-431c-9ac8-6281a4b7b9ca",
+        "new_facet_value": "34a6edd0-46ea-4a76-ae80-8c96709d4f59"
+      },
+
+      {
+        "old_facet_value": "356f46a0-17d3-4ba4-8952-8c02244f9045",
+        "new_facet_value": "18c3892e-8a0e-4884-906e-5938380eceee"
+      }
+    ]
+  end
+
+  def self.content_to_update_facet_values
+    # For each base path:
+    # The document will be untagged from `old_facet_value` and
+    # will be re-tagged with `new_facet_value`
+    [
+      {
+        "base_paths": [
+          "/guidance/export-animal-bones-protein-and-other-by-products-special-rules",
+          "/guidance/export-food-and-agricultural-products-special-rules",
+          "/government/publications/farm-payments-if-theres-no-brexit-deal/farm-payments-if-theres-no-brexit-deal",
+          "/guidance/how-to-comply-with-pesticide-regulations-after-brexit",
+          "/government/publications/industrial-emissions-standards-best-available-techniques-if-theres-no-brexit-deal",
+          "/guidance/protecting-food-and-drink-names-if-theres-no-brexit-deal",
+          "/government/publications/receiving-rural-development-funding-if-theres-no-brexit-deal/receiving-rural-development-funding-if-theres-no-brexit-deal",
+          "/guidance/the-farming-sector-and-preparing-for-eu-exit",
+          "/government/publications/upholding-environmental-standards-if-theres-no-brexit-deal"
+        ],
+        "old_facet_value": "94b3cfe2-af89-4744-b8d7-7fc79edcbc85",
+        "new_facet_value": "9d54c591-f5ca-4d0c-a484-12d5591987cb"
+      },
+      {
+        "base_paths": [
+          "/government/publications/approval-and-operation-of-plant-health-inspection-facilities-at-place-of-first-arrival",
+          "/guidance/importing-and-exporting-plants-and-plant-products-if-theres-no-withdrawal-deal",
+          "/guidance/trading-timber-imports-and-exports-if-theres-no-brexit-deal"
+        ],
+        "old_facet_value": "94b3cfe2-af89-4744-b8d7-7fc79edcbc85",
+        "new_facet_value": "afd45eef-743a-417d-9245-3eab8322116d"
+      }
+    ]
+  end
+
+  def self.facet_values_to_untag
+    # For each item in the array:
+    # All content tagged to that facet value will be untagged
+    [
+      "7536c0c4-fb41-43f4-a2c4-08f4fa9f5427",
+      "5faa1741-fc55-4110-b342-de92f6324118",
+      "14cf2a68-3297-44d3-ba01-a4426845b1b8",
+      "040649fc-4e2c-4028-b846-77fe3eebd1f7",
+      "94b3cfe2-af89-4744-b8d7-7fc79edcbc85"
+    ]
+  end
+
+  def self.replace_facet_values
+    content_changes = []
+    facet_values_to_replace.each do |facet_values_merge|
+      content_ids = []
+      content_links = Services.search_api.search_enum(
+        filter_facet_values: facet_values_merge[:old_facet_value]
+      ).pluck("link")
+      content_links.each do |content_link|
+        content_ids << Services.search_api.get_content(content_link).to_hash['raw_source']['content_id']
+      end
+      content_changes << {
+        "content_ids": content_ids,
+        "old_facet_value": facet_values_merge[:old_facet_value],
+        "new_facet_value": facet_values_merge[:new_facet_value]
+      }
+    end
+
+    bulk_retag_documents(content_changes)
+  end
+
+  def self.retag_content_facet_values
+    content_changes = content_to_update_facet_values
+
+    content_changes.each do |content_change|
+      content_change[:content_ids] = Services.publishing_api.lookup_content_ids(base_paths: content_change[:base_paths]).values
+    end
+
+    bulk_retag_documents(content_changes)
+  end
+
+  def self.delete_facet_values_from_content
+    facet_values_to_untag.each do |facet_value|
+      content_ids = get_content_ids_from_facet_value(facet_value)
+      content_ids.each do |content_id|
+        links = Services.publishing_api.get_links(content_id).to_hash.fetch('links', {})
+        content_facet_values = links.fetch('facet_values', [])
+        content_facet_values.delete(facet_value)
+        links['facet_values'] = content_facet_values
+        Services.publishing_api.patch_links(content_id, links: links)
+      end
+    end
+  end
+
+  def self.get_content_ids_from_facet_value(facet_value)
+    content_ids = []
+    content_links = Services.search_api.search_enum(
+      filter_facet_values: facet_value
+    ).pluck("link")
+    content_links.each do |content_link|
+      content_ids << Services.search_api.get_content(content_link).to_hash['raw_source']['content_id']
+    end
+    content_ids
+  end
+
+  def self.bulk_retag_documents(content_changes)
+    content_changes.each do |content_change|
+      content_change[:content_ids].each do |content_id|
+        links = Services.publishing_api.get_links(content_id).to_hash.fetch('links', {})
+        facet_values = links.fetch('facet_values', [])
+        facet_values.delete(content_change[:old_facet_value])
+        facet_values << content_change[:new_facet_value]
+        links['facet_values'] = facet_values
+        Services.publishing_api.patch_links(content_id, links: links)
+      end
+    end
+  end
+end

--- a/spec/lib/tasks/eu_exit_business_finder_spec.rb
+++ b/spec/lib/tasks/eu_exit_business_finder_spec.rb
@@ -98,8 +98,6 @@ RSpec.describe 'eu_exit_business_finder:retag_documents_to_facet_values' do
   end
 
   before :each do
-    Rails.application.load_tasks
-
     allow(EuExitBusinessRakeMethods).to receive(:facet_values_to_replace).and_return(facet_values_to_replace)
     allow(EuExitBusinessRakeMethods).to receive(:content_to_update_facet_values).and_return(content_to_update_facet_values)
     allow(EuExitBusinessRakeMethods).to receive(:facet_values_to_untag).and_return(facet_values_to_untag)

--- a/spec/lib/tasks/eu_exit_business_finder_spec.rb
+++ b/spec/lib/tasks/eu_exit_business_finder_spec.rb
@@ -1,0 +1,126 @@
+require 'rake'
+require 'rails_helper'
+require 'gds_api/test_helpers/publishing_api_v2'
+require 'gds_api/test_helpers/search'
+
+RSpec.describe 'eu_exit_business_finder:retag_documents_to_facet_values' do
+  include GdsApi::TestHelpers::PublishingApiV2
+  include GdsApi::TestHelpers::Search
+  include PublishingApiHelper
+
+  let(:publishing_api) { Services.publishing_api }
+
+  let(:facet_values_to_replace) do
+    [
+      {
+        "old_facet_value": "old-facet-value",
+        "new_facet_value": "new-facet-value"
+      },
+    ]
+  end
+
+  let(:content_to_update_facet_values) do
+    [
+      {
+        "base_paths": [
+          "/guidance/some-document-about-brexit"
+        ],
+        "old_facet_value": "old-facet-value",
+        "new_facet_value": "new-facet-value"
+      }
+    ]
+  end
+
+  let(:facet_values_to_untag) do
+    [
+      "another-facet-value"
+    ]
+  end
+
+  let(:search_by_facet_value) do
+    {
+      "results": [
+        {
+          "link": "/a-document-about-brexit"
+        }
+      ]
+    }
+  end
+
+  let(:search_by_link) do
+    {
+      "raw_source":
+        {
+          "content_id": "content-id-to-update"
+        }
+    }
+  end
+
+  let(:content_item_links) do
+    {
+      "links":
+      {
+        "facet_values" =>
+          [
+            "some-facet-value",
+            "old-facet-value",
+            "another-facet-value"
+          ]
+      }
+    }
+  end
+
+  let(:updated_content_item_links) do
+    {
+      "facet_values" =>
+        [
+          "some-facet-value",
+          "another-facet-value",
+          "new-facet-value"
+        ]
+    }
+  end
+
+  let(:deleted_content_item_links) do
+    {
+      "facet_values" =>
+        [
+          "some-facet-value",
+          "old-facet-value"
+        ]
+    }
+  end
+
+  let(:content_id_from_base_path) do
+    {
+      "/guidance/some-document-about-brexit": "content-id-to-update"
+    }
+  end
+
+  before :each do
+    Rails.application.load_tasks
+
+    allow(EuExitBusinessRakeMethods).to receive(:facet_values_to_replace).and_return(facet_values_to_replace)
+    allow(EuExitBusinessRakeMethods).to receive(:content_to_update_facet_values).and_return(content_to_update_facet_values)
+    allow(EuExitBusinessRakeMethods).to receive(:facet_values_to_untag).and_return(facet_values_to_untag)
+    allow(publishing_api).to receive(:patch_links)
+
+    stub_request(:get, "#{Plek.find('search')}/search.json?count=100&filter_facet_values=old-facet-value&start=0")
+         .to_return(status: 200, body: search_by_facet_value.to_json, headers: {})
+    stub_request(:get, "#{Plek.find('search')}/content?link=/a-document-about-brexit")
+         .to_return(status: 200, body: search_by_link.to_json, headers: {})
+    stub_request(:get, "#{Plek.find('publishing-api')}/v2/links/content-id-to-update")
+         .to_return(status: 200, body: content_item_links.to_json, headers: {})
+    stub_request(:post, "#{Plek.find('publishing-api')}/lookup-by-base-path")
+         .with(body: "{\"base_paths\":[\"/guidance/some-document-about-brexit\"]}")
+         .to_return(status: 200, body: content_id_from_base_path.to_json, headers: {})
+    stub_request(:get, "#{Plek.find('search')}/search.json?count=100&filter_facet_values=another-facet-value&start=0")
+         .to_return(status: 200, body: search_by_facet_value.to_json, headers: {})
+  end
+
+  it "updates relevant content items" do
+    Rake::Task['eu_exit_business_finder:retag_documents_to_facet_values'].invoke
+    expect(publishing_api).to have_received(:patch_links).with("content-id-to-update", links: updated_content_item_links).exactly(2).times
+    expect(publishing_api).to have_received(:patch_links).with("content-id-to-update", links: deleted_content_item_links)
+  end
+end

--- a/spec/lib/tasks/facets/facet_group_spec.rb
+++ b/spec/lib/tasks/facets/facet_group_spec.rb
@@ -24,7 +24,6 @@ RSpec.describe 'facets:patch_links_to_facet_group' do
   let(:publishing_api) { Services.publishing_api }
 
   before :each do
-    Rails.application.load_tasks
     stub_any_search.to_return(body: { 'results' => results }.to_json)
     stub_publishing_api_has_lookups(
       "/link/one" => "11111-11111-11111",

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -37,6 +37,8 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = false
   config.infer_spec_type_from_file_location!
 
+  Rails.application.load_tasks
+
   config.before(:each) do
     User.create!(permissions: ["signin", "GDS Editor"])
     DatabaseCleaner.start


### PR DESCRIPTION
A number of changes to business sectors and business activities have been proposed:
https://docs.google.com/spreadsheets/d/1DDsWQvq3XoTwi3R3YS_z72ixON3mUl6aWjjsI2V4NHg/edit
https://docs.google.com/document/d/1xdEkrkN4OZFLsN6xWTBLWPgmXaDTMxp4PxSLqqX0wQ4/edit
https://docs.google.com/document/d/1NWADDxTfn3aaTGPYD8hPJ-vZfPg0fpPDcDdo2gur3FQ/edit

This PR encapsulates all of these changes; including the merging/splitting/deleting of sectors, updating of the business activity question and retagging of all affected content.

Deploy https://github.com/alphagov/finder-frontend/pull/1211 at the same time.

Once deployed, the following rake tasks must be run to update the `facet_groups` content item and also retag existing content:
```
## content-tagger
rake facets:import_facet_group["lib/data/find-eu-exit-guidance-business.yml"]
rake facets:publish_facet_group["lib/data/find-eu-exit-guidance-business.yml"]
rake eu_exit_business_finder:retag_documents_to_facet_values
## search-api
rake publishing_api:publish_facet_group_eu_exit_business_finder
```

Trello card: https://trello.com/c/VTKL8TXk