### PR TITLE
Rename rummager to search-api

### DIFF
--- a/app/lib/services.rb
+++ b/app/lib/services.rb
@@ -1,5 +1,5 @@
 require 'gds_api/publishing_api_v2'
-require 'gds_api/rummager'
+require 'gds_api/search'
 require 'gds_api/content_store'
 require 'gds_api/email_alert_api'
 
@@ -36,8 +36,8 @@ module Services
     end
   end
 
-  def self.rummager
-    @rummager ||= GdsApi::Rummager.new(
+  def self.search_api
+    @search_api ||= GdsApi::Search.new(
       Plek.new.find('search'),
     )
   end

--- a/app/queries/tagging_progress_by_organisations_query.rb
+++ b/app/queries/tagging_progress_by_organisations_query.rb
@@ -42,7 +42,7 @@ private
   end
 
   def total_content_count
-    Services.rummager.search(
+    Services.search_api.search(
       count: 0,
       start: 0,
       aggregate_primary_publishing_organisation: '0,scope:all_filters',
@@ -51,7 +51,7 @@ private
   end
 
   def tagged_content_count
-    Services.rummager.search(
+    Services.search_api.search(
       count: 0,
       start: 0,
       aggregate_primary_publishing_organisation: '0,scope:all_filters',

--- a/app/services/data_export/content_export.rb
+++ b/app/services/data_export/content_export.rb
@@ -69,8 +69,8 @@ module DataExport
     ].freeze
 
     def content_links_enum(page_size = 1000)
-      Services.rummager.search_enum({ reject_content_store_document_type: BLACKLIST_DOCUMENT_TYPES, fields: %w[link] },
-                                    page_size: page_size).lazy.map { |h| h['link'] }
+      Services.search_api.search_enum({ reject_content_store_document_type: BLACKLIST_DOCUMENT_TYPES, fields: %w[link] },
+                                      page_size: page_size).lazy.map { |h| h['link'] }
     end
 
     def get_content(base_path, base_fields: CONTENT_BASE_FIELDS, taxon_fields: CONTENT_TAXON_FIELDS, ppo_fields: CONTENT_PPO_FIELDS)
@@ -112,7 +112,7 @@ module DataExport
   private
 
     def document_aggregates
-      Services.rummager.search(aggregate_content_store_document_type: 10_000, count: 0)
+      Services.search_api.search(aggregate_content_store_document_type: 10_000, count: 0)
         .dig('aggregates', 'content_store_document_type', 'options')
     end
 

--- a/app/services/metrics/content_coverage_metrics.rb
+++ b/app/services/metrics/content_coverage_metrics.rb
@@ -31,14 +31,14 @@ module Metrics
   private
 
     def all_govuk_items_count
-      @all_govuk_items_count ||= Services.rummager.search(
+      @all_govuk_items_count ||= Services.search_api.search(
         count: 0,
         debug: 'include_withdrawn'
       ).to_h.fetch("total")
     end
 
     def items_in_scope_count
-      @items_in_scope_count ||= Services.rummager.search(
+      @items_in_scope_count ||= Services.search_api.search(
         count: 0,
         reject_content_store_document_type: Tagging.blacklisted_document_types,
         debug: 'include_withdrawn'
@@ -46,7 +46,7 @@ module Metrics
     end
 
     def tagged_items_in_scope_count
-      @tagged_items_in_scope_count ||= Services.rummager.search(
+      @tagged_items_in_scope_count ||= Services.search_api.search(
         count: 0,
         filter_part_of_taxonomy_tree: root_taxon_content_ids,
         reject_content_store_document_type: Tagging.blacklisted_document_types,

--- a/app/services/tagging/common_ancestor_finder.rb
+++ b/app/services/tagging/common_ancestor_finder.rb
@@ -5,8 +5,8 @@ module Tagging
     end
 
     def find_all
-      content_enum = Services.rummager.search_enum({ reject_content_store_document_type: Tagging.blacklisted_document_types,
-                                                     fields: %w[content_id title] }, page_size: 100)
+      content_enum = Services.search_api.search_enum({ reject_content_store_document_type: Tagging.blacklisted_document_types,
+                                                       fields: %w[content_id title] }, page_size: 100)
       filtered_content_enum = content_enum.lazy.select { |c| c.has_key?('content_id') }
       all_results = filtered_content_enum.map do |content_hash|
         content_id = content_hash['content_id']

--- a/app/services/taxonomy/content_counter.rb
+++ b/app/services/taxonomy/content_counter.rb
@@ -1,7 +1,7 @@
 module Taxonomy
   class ContentCounter
     def self.count(taxon_content_id)
-      Services.rummager.search(
+      Services.search_api.search(
         filter_taxons: taxon_content_id,
         count: 0,
         reject_content_store_document_type: Tagging.blacklisted_document_types

--- a/app/services/taxonomy/organisation_count.rb
+++ b/app/services/taxonomy/organisation_count.rb
@@ -36,8 +36,8 @@ module Taxonomy
     end
 
     def tagging_count_per_organisation_for_taxon(taxon)
-      rummager_result = Services.rummager.search(aggregate_primary_publishing_organisation: 100_000, count: 0, filter_taxons: [taxon['content_id']])
-      rummager_result
+      search_api_result = Services.search_api.search(aggregate_primary_publishing_organisation: 100_000, count: 0, filter_taxons: [taxon['content_id']])
+      search_api_result
         .dig('aggregates', 'primary_publishing_organisation', 'options')
         .each_with_object({}) do |result, total|
         total[result.dig('value', 'slug')] = result['documents']

--- a/app/services/taxonomy/taxonomy_query.rb
+++ b/app/services/taxonomy/taxonomy_query.rb
@@ -24,7 +24,7 @@ module Taxonomy
 
     def content_tagged_to_taxons(content_ids, slice_size: 50)
       content_id_hashes = content_ids.each_slice(slice_size).flat_map do |chunk|
-        Services.rummager.search_enum(filter_taxons: chunk, fields: %w[content_id]).to_a
+        Services.search_api.search_enum(filter_taxons: chunk, fields: %w[content_id]).to_a
       end
       content_id_hashes.map { |h| h['content_id'] }.uniq
     end

--- a/app/services/taxonomy/taxons_with_content_count.rb
+++ b/app/services/taxonomy/taxons_with_content_count.rb
@@ -47,14 +47,14 @@ module Taxonomy
     # taxon, scope to the current root taxon.
     def tagged_pages_count_by_content_id
       @tagged_pages_count_by_content_id ||= begin
-        search_result = Services.rummager.search(
+        search_result = Services.search_api.search(
           filter_part_of_taxonomy_tree: @root_taxon.content_id,
           facet_taxons: 1_000, # We have to specify a number,
           count: 0,
           debug: 'include_withdrawn',
         )
 
-        # Rummager will return a pretty odd datastructure for this query:
+        # Search API will return a pretty odd datastructure for this query:
         # https://www.gov.uk/api/search.json?count=0&facet_taxons=1000
         search_result["facets"]["taxons"]["options"].each_with_object({}) do |o, h|
           content_id = o["value"]["slug"]

--- a/lib/tasks/export_content_by_organisations.rake
+++ b/lib/tasks/export_content_by_organisations.rake
@@ -17,7 +17,7 @@ namespace :govuk do
     args.extras.each do |organisation_slug|
       puts organisation_slug
 
-      content_items_enum = Services.rummager.search_enum(
+      content_items_enum = Services.search_api.search_enum(
         fields: fields.join(','),
         filter_primary_publishing_organisation: organisation_slug
       )

--- a/lib/tasks/export_mainstream_taxons.rake
+++ b/lib/tasks/export_mainstream_taxons.rake
@@ -19,7 +19,7 @@ namespace :govuk do
       title
     ]
 
-    content_items_enum = Services.rummager.search_enum(
+    content_items_enum = Services.search_api.search_enum(
       fields: fields,
       filter_content_store_document_type: content_types
     )

--- a/lib/tasks/facets/facet_group.rake
+++ b/lib/tasks/facets/facet_group.rake
@@ -35,7 +35,7 @@ namespace :facets do
   task :patch_links_to_facet_group, [:facet_group_content_id] => :environment do |_, args|
     facet_group_content_id = args[:facet_group_content_id]
 
-    content_items_enum = Services.rummager.search_enum(
+    content_items_enum = Services.search_api.search_enum(
       filter_facet_groups: facet_group_content_id
     )
 

--- a/spec/lib/tasks/facets/facet_group_spec.rb
+++ b/spec/lib/tasks/facets/facet_group_spec.rb
@@ -1,11 +1,11 @@
 require 'rake'
 require 'rails_helper'
 require 'gds_api/test_helpers/publishing_api_v2'
-require 'gds_api/test_helpers/rummager'
+require 'gds_api/test_helpers/search'
 
 RSpec.describe 'facets:patch_links_to_facet_group' do
   include GdsApi::TestHelpers::PublishingApiV2
-  include GdsApi::TestHelpers::Rummager
+  include GdsApi::TestHelpers::Search
   include ContentItemHelper
   include PublishingApiHelper
 
@@ -25,7 +25,7 @@ RSpec.describe 'facets:patch_links_to_facet_group' do
 
   before :each do
     Rails.application.load_tasks
-    stub_any_rummager_search.to_return(body: { 'results' => results }.to_json)
+    stub_any_search.to_return(body: { 'results' => results }.to_json)
     stub_publishing_api_has_lookups(
       "/link/one" => "11111-11111-11111",
       "/link/two" => "22222-22222-22222",

--- a/spec/queries/tagging_progress_by_organisations_query_spec.rb
+++ b/spec/queries/tagging_progress_by_organisations_query_spec.rb
@@ -13,22 +13,22 @@ RSpec.describe TaggingProgressByOrganisationsQuery do
 
   describe '#percentage_tagged' do
     it 'returns an empty table when nothing is returned' do
-      stub_rummager_totals(rummager_empty)
-      stub_rummager_tagged(rummager_empty)
+      stub_search_api_totals(search_api_empty)
+      stub_search_api_tagged(search_api_empty)
       expect(TaggingProgressByOrganisationsQuery.new(organisations).percentage_tagged).to be_empty
     end
 
     it 'returns zeros when there are no documents' do
-      stub_rummager_totals(rummager_zeros)
-      stub_rummager_tagged(rummager_zeros)
+      stub_search_api_totals(search_api_zeros)
+      stub_search_api_tagged(search_api_zeros)
       expect(TaggingProgressByOrganisationsQuery.new(organisations).percentage_tagged)
         .to eq('department-for-transport' => { percentage: 0.0, total: 0, tagged: 0 },
                'high-speed-two-limited' => { percentage: 0.0, total: 0, tagged: 0 })
     end
 
     it 'returns correct values' do
-      stub_rummager_totals(rummager_totals)
-      stub_rummager_tagged(rummager_tagged)
+      stub_search_api_totals(search_api_totals)
+      stub_search_api_tagged(search_api_tagged)
       expect(TaggingProgressByOrganisationsQuery.new(organisations).percentage_tagged)
         .to eq('department-for-transport' => { percentage: 25.0, total: 20, tagged: 5 },
                'high-speed-two-limited' => { percentage: 56.25, total: 80, tagged: 45 })
@@ -37,34 +37,34 @@ RSpec.describe TaggingProgressByOrganisationsQuery do
 
   describe '#total_counts' do
     it 'returns an empty hash when nothing is returned' do
-      stub_rummager_totals(rummager_empty)
-      stub_rummager_tagged(rummager_empty)
+      stub_search_api_totals(search_api_empty)
+      stub_search_api_tagged(search_api_empty)
       expect(TaggingProgressByOrganisationsQuery.new(organisations).total_counts).to be_empty
     end
 
     it 'returns zeros when there are no documents' do
-      stub_rummager_totals(rummager_zeros)
-      stub_rummager_tagged(rummager_zeros)
+      stub_search_api_totals(search_api_zeros)
+      stub_search_api_tagged(search_api_zeros)
       expect(TaggingProgressByOrganisationsQuery.new(organisations).total_counts).to eq(percentage: 0.0, total: 0, tagged: 0)
     end
 
     it 'returns correct totals' do
-      stub_rummager_totals(rummager_totals)
-      stub_rummager_tagged(rummager_tagged)
+      stub_search_api_totals(search_api_totals)
+      stub_search_api_tagged(search_api_tagged)
       expect(TaggingProgressByOrganisationsQuery.new(organisations).total_counts)
         .to eq(percentage: 50.0, total: 100, tagged: 50)
     end
   end
 
   # HELPERS #
-  def stub_rummager_tagged(return_hash)
-    allow(Services.rummager).to receive(:search).with(
+  def stub_search_api_tagged(return_hash)
+    allow(Services.search_api).to receive(:search).with(
       hash_including(filter_part_of_taxonomy_tree: anything)
     ).and_return return_hash
   end
 
-  def stub_rummager_totals(return_hash)
-    allow(Services.rummager).to receive(:search).with(
+  def stub_search_api_totals(return_hash)
+    allow(Services.search_api).to receive(:search).with(
       hash_excluding(filter_part_of_taxonomy_tree: anything)
     ).and_return return_hash
   end
@@ -73,7 +73,7 @@ RSpec.describe TaggingProgressByOrganisationsQuery do
     ['department-for-transport', 'high-speed-two-limited']
   end
 
-  def rummager_empty
+  def search_api_empty
     { "results" => [],
       "total" => 100,
       "start" => 0,
@@ -89,7 +89,7 @@ RSpec.describe TaggingProgressByOrganisationsQuery do
       "suggested_queries" => [] }
   end
 
-  def rummager_totals
+  def search_api_totals
     { "results" => [],
       "total" => 100,
       "start" => 0,
@@ -108,7 +108,7 @@ RSpec.describe TaggingProgressByOrganisationsQuery do
       "suggested_queries" => [] }
   end
 
-  def rummager_tagged
+  def search_api_tagged
     { "results" => [],
       "total" => 50,
       "start" => 0,
@@ -127,7 +127,7 @@ RSpec.describe TaggingProgressByOrganisationsQuery do
       "suggested_queries" => [] }
   end
 
-  def rummager_zeros
+  def search_api_zeros
     { "results" => [],
       "total" => 50,
       "start" => 0,

--- a/spec/services/metrics/content_distribution_metrics_spec.rb
+++ b/spec/services/metrics/content_distribution_metrics_spec.rb
@@ -12,11 +12,11 @@ module Metrics
         content_store_has_item('/', root_taxon.to_json, draft: true)
         content_store_has_item('/taxons/root_taxon', child_taxons.to_json, draft: true)
 
-        allow(Services.rummager).to receive(:search_enum).with(include(filter_taxons: %w[root_id]))
+        allow(Services.search_api).to receive(:search_enum).with(include(filter_taxons: %w[root_id]))
                                       .and_return content_items_enum(5)
-        allow(Services.rummager).to receive(:search_enum).with(include(filter_taxons: %w[first_level_id]))
+        allow(Services.search_api).to receive(:search_enum).with(include(filter_taxons: %w[first_level_id]))
                                       .and_return content_items_enum(12)
-        allow(Services.rummager).to receive(:search_enum).with(include(filter_taxons: %w[second_level_id_1 second_level_id_2]))
+        allow(Services.search_api).to receive(:search_enum).with(include(filter_taxons: %w[second_level_id_1 second_level_id_2]))
                                       .and_return content_items_enum(3)
       end
       it 'calls gauges with number of content tagged to each level' do

--- a/spec/services/tagging/common_ancestor_finder_spec.rb
+++ b/spec/services/tagging/common_ancestor_finder_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
-require 'gds_api/test_helpers/rummager'
-include ::GdsApi::TestHelpers::Rummager
+require 'gds_api/test_helpers/search'
+include ::GdsApi::TestHelpers::Search
 
 RSpec.describe Tagging::CommonAncestorFinder do
   context 'there is one taxon' do
@@ -9,7 +9,7 @@ RSpec.describe Tagging::CommonAncestorFinder do
     end
 
     before :each do
-      stub_any_rummager_search.to_return(body: { 'results' => [{ 'content_id' => 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' }] }.to_json)
+      stub_any_search.to_return(body: { 'results' => [{ 'content_id' => 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' }] }.to_json)
     end
 
     it 'returns nothing' do
@@ -55,14 +55,14 @@ RSpec.describe Tagging::CommonAncestorFinder do
   end
 
   it 'rejects empty content_ids' do
-    stub_any_rummager_search.to_return(body: { 'results' => [{ 'content_id' => 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' }, {}] }.to_json)
+    stub_any_search.to_return(body: { 'results' => [{ 'content_id' => 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' }, {}] }.to_json)
     publishing_api_has_expanded_links(Support::TaxonHelper.expanded_link_hash('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', [[1], [1, 2]]))
     expect(Tagging::CommonAncestorFinder.new.find_all.force.length).to eq(1)
   end
 
   it 'includes title and content_id' do
-    stub_any_rummager_search.to_return(body: { 'results' => [{ 'content_id' => 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
-                                                               'title' => 'my title' }] }.to_json)
+    stub_any_search.to_return(body: { 'results' => [{ 'content_id' => 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+                                                      'title' => 'my title' }] }.to_json)
     publishing_api_has_expanded_links(Support::TaxonHelper.expanded_link_hash('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', [[1], [1, 2]]))
     result_hash = Tagging::CommonAncestorFinder.new.find_all.force.first
     expect(result_hash[:title]).to eq('my title')
@@ -70,13 +70,13 @@ RSpec.describe Tagging::CommonAncestorFinder do
   end
 
   it 'rejects empty results' do
-    stub_any_rummager_search.to_return(body: { 'results' => [{ 'content_id' => 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' }] }.to_json)
+    stub_any_search.to_return(body: { 'results' => [{ 'content_id' => 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' }] }.to_json)
     publishing_api_has_expanded_links(Support::TaxonHelper.expanded_link_hash('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', [[]]))
     expect(Tagging::CommonAncestorFinder.new.find_all.force).to be_empty
   end
 
   it 'tries again if timed out' do
-    stub_any_rummager_search.to_return(body: { 'results' => [{ 'content_id' => 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' }] }.to_json)
+    stub_any_search.to_return(body: { 'results' => [{ 'content_id' => 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' }] }.to_json)
     stub_any_publishing_api_call.to_return({ status: 504 },
                                            { status: 504 },
                                            status: 200,
@@ -86,7 +86,7 @@ RSpec.describe Tagging::CommonAncestorFinder do
   end
 
   it 'only tries 3 times' do
-    stub_any_rummager_search.to_return(body: { 'results' => [{ 'content_id' => 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' }] }.to_json)
+    stub_any_search.to_return(body: { 'results' => [{ 'content_id' => 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' }] }.to_json)
     stub_any_publishing_api_call.to_return({ status: 504 },
                                            { status: 504 },
                                            status: 504)

--- a/spec/services/taxonomy/organisation_count_spec.rb
+++ b/spec/services/taxonomy/organisation_count_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
-require 'gds_api/test_helpers/rummager'
+require 'gds_api/test_helpers/search'
 require 'gds_api/test_helpers/content_store'
 
-include ::GdsApi::TestHelpers::Rummager
+include ::GdsApi::TestHelpers::Search
 include ::GdsApi::TestHelpers::ContentStore
 
 RSpec.describe Taxonomy::OrganisationCount do
@@ -12,13 +12,13 @@ RSpec.describe Taxonomy::OrganisationCount do
     before :each do
       content_store_has_item('/', level_one_taxons.to_json, draft: true)
       content_store_has_item('/taxons/level_one', single_level_child_taxons.to_json, draft: true)
-      stub_rummager({ 'aggregate_primary_publishing_organisation' => %r{\d+},  'filter_taxons' => [taxon_ids.first] },
-                    rummager_body([{ slug: 'organisation1', count: 1 },
-                                   { slug: 'organisation2', count: 2 },
-                                   { slug: 'organisation3', count: 3 }]))
-      stub_rummager({ 'aggregate_primary_publishing_organisation' => %r{\d+},  'filter_taxons' => [taxon_ids.second] },
-                    rummager_body([{ slug: 'organisation2', count: 4 },
-                                   { slug: 'organisation1', count: 5 }]))
+      stub_search_api({ 'aggregate_primary_publishing_organisation' => %r{\d+},  'filter_taxons' => [taxon_ids.first] },
+                      search_api_body([{ slug: 'organisation1', count: 1 },
+                                       { slug: 'organisation2', count: 2 },
+                                       { slug: 'organisation3', count: 3 }]))
+      stub_search_api({ 'aggregate_primary_publishing_organisation' => %r{\d+},  'filter_taxons' => [taxon_ids.second] },
+                      search_api_body([{ slug: 'organisation2', count: 4 },
+                                       { slug: 'organisation1', count: 5 }]))
     end
 
     it 'counts all tags to taxons per organisation' do
@@ -31,7 +31,7 @@ RSpec.describe Taxonomy::OrganisationCount do
       expect(results.first[:title]).to eq('taxon_title')
     end
 
-    def rummager_body(slug_counts)
+    def search_api_body(slug_counts)
       {
         'aggregates' => {
           'primary_publishing_organisation' => {
@@ -48,7 +48,7 @@ RSpec.describe Taxonomy::OrganisationCount do
       }
     end
 
-    def stub_rummager(query_hash, json_body)
+    def stub_search_api(query_hash, json_body)
       stub_request(:get, Regexp.new(Plek.new.find('search')))
         .with(query: hash_including(query_hash))
         .to_return(body: json_body.to_json)

--- a/spec/services/taxonomy/taxonomy_query_spec.rb
+++ b/spec/services/taxonomy/taxonomy_query_spec.rb
@@ -61,20 +61,20 @@ RSpec.describe Taxonomy::TaxonomyQuery do
       expect(TaxonomyQuery.new.content_tagged_to_taxons([], slice_size: 50)).to eq([])
     end
     it 'returns content tagged to taxons' do
-      stub_rummager({ filter_taxons: %w[taxon_id_1 taxon_id_2] },
-                    [{ 'content_id' => 'content_id_1' }, { 'content_id' => 'content_id_2' }])
-      stub_rummager({ filter_taxons: %w[taxon_id_3] },
-                    [{ 'content_id' => 'content_id_3' }])
+      stub_search_api({ filter_taxons: %w[taxon_id_1 taxon_id_2] },
+                      [{ 'content_id' => 'content_id_1' }, { 'content_id' => 'content_id_2' }])
+      stub_search_api({ filter_taxons: %w[taxon_id_3] },
+                      [{ 'content_id' => 'content_id_3' }])
 
       expect(query.content_tagged_to_taxons(%w[taxon_id_1 taxon_id_2 taxon_id_3], slice_size: 2))
         .to eq(%w[content_id_1 content_id_2 content_id_3])
     end
     it 'removes duplicates' do
-      stub_rummager({}, [{ 'content_id' => 'content_id_1' }, { 'content_id' => 'content_id_1' }])
+      stub_search_api({}, [{ 'content_id' => 'content_id_1' }, { 'content_id' => 'content_id_1' }])
       expect(query.content_tagged_to_taxons(%w[id])).to eq(%w[content_id_1])
     end
 
-    def stub_rummager(query_hash, return_values)
+    def stub_search_api(query_hash, return_values)
       stub_request(:get, Regexp.new(Plek.new.find('search')))
         .with(query: hash_including(query_hash))
         .to_return(body: { 'results' => return_values }.to_json)

--- a/spec/support/taxonomy_helper.rb
+++ b/spec/support/taxonomy_helper.rb
@@ -43,16 +43,16 @@ module TaxonomyHelper
   end
 
   def stub_organisation_tagging_progress
-    stub_request(:get, rummager_url_for_all_document_counts_url)
+    stub_request(:get, search_api_url_for_all_document_counts_url)
       .to_return(body: all_document_counts_response.to_json)
 
-    stub_request(:get, rummager_url_for_tagged_document_counts_url)
+    stub_request(:get, search_api_url_for_tagged_document_counts_url)
       .to_return(body: tagged_documents_counts_response.to_json)
   end
 
 private
 
-  def rummager_url_for_all_document_counts_url
+  def search_api_url_for_all_document_counts_url
     "https://search.test.gov.uk/search.json?aggregate_primary_publishing_organisation=0,scope:all_filters&count=0&filter_primary_publishing_organisation%5B%5D=department-for-transport&filter_primary_publishing_organisation%5B%5D=high-speed-two-limited&filter_primary_publishing_organisation%5B%5D=home-office&filter_primary_publishing_organisation%5B%5D=maritime-and-coastguard-agency&start=0"
   end
 
@@ -79,7 +79,7 @@ private
     }
   end
 
-  def rummager_url_for_tagged_document_counts_url
+  def search_api_url_for_tagged_document_counts_url
     "https://search.test.gov.uk/search.json?aggregate_primary_publishing_organisation=0,scope:all_filters&count=0&filter_part_of_taxonomy_tree%5B%5D=aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa&filter_primary_publishing_organisation%5B%5D=department-for-transport&filter_primary_publishing_organisation%5B%5D=high-speed-two-limited&filter_primary_publishing_organisation%5B%5D=home-office&filter_primary_publishing_organisation%5B%5D=maritime-and-coastguard-agency&start=0"
   end
 

--- a/spec/workers/taxonomy_health/content_count_metric_spec.rb
+++ b/spec/workers/taxonomy_health/content_count_metric_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
-require 'gds_api/test_helpers/rummager'
+require 'gds_api/test_helpers/search'
 
 RSpec.describe TaxonomyHealth::ContentCountMetric do
-  include GdsApi::TestHelpers::Rummager
+  include GdsApi::TestHelpers::Search
   let(:home_page) { FactoryBot.build(:taxon_hash, :home_page, expanded_links: { level_one_taxons: [food] }) }
   let(:food) do
     FactoryBot.build(:taxon_hash,


### PR DESCRIPTION
Because I was getting annoyed seeing `GdsApi::Rummager is deprecated.  Use GdsApi::Search instead.` warnings printed to my terminal constantly when running the content-tagger tests.

Rummager has been renamed to Search API, so this PR fully removes the Rummager wording.