### PR TITLE
Adds count of documents tagged to each branch of taxonomy

### DIFF
--- a/app/presenters/taxonomy/csv_tree_presenter.rb
+++ b/app/presenters/taxonomy/csv_tree_presenter.rb
@@ -11,7 +11,27 @@ module Taxonomy
         @tree.each do |node|
           row = [node.title]
           node.depth.times { row.unshift nil }
+          row << get_count(node.content_id)
           csv << row
+        end
+      end
+    end
+
+  private
+
+    def get_count(content_id)
+      taxonomy_tree_counts[content_id]
+    end
+
+    def taxonomy_tree_counts
+      @taxonomy_tree_counts ||= begin
+        params = {
+          count: 0,
+          facet_taxons: 4000
+        }
+        results = Services.search_api.search(params).to_hash
+        results.dig('facets', 'taxons', 'options').each_with_object({}) do |option, taxon_content_count|
+          taxon_content_count[option['value']['slug']] = option['documents']
         end
       end
     end

--- a/spec/features/viewing_taxons_spec.rb
+++ b/spec/features/viewing_taxons_spec.rb
@@ -321,6 +321,21 @@ RSpec.describe "Viewing taxons" do
   end
 
   def and_i_can_download_the_taxonomy_in_csv_form
+    document_counts = {
+      'facets' => {
+        'taxons' => {
+          'options' => [
+            { 'value' => { 'slug' => 'Root' }, 'documents' => 1 },
+            { 'value' => { 'slug' => 'Child-1' }, 'documents' => 2 },
+            { 'value' => { 'slug' => 'Child-2' }, 'documents' => 3 },
+            { 'value' => { 'slug' => 'Child-3' }, 'documents' => 4 },
+          ]
+        }
+      }
+    }
+
+    stub_request(:get, "https://search.test.gov.uk/search.json").with(query: { "count" => 0, "facet_taxons" => 4000 })
+        .to_return(body: document_counts.to_json)
     click_link I18n.t('views.taxons.download_csv')
     expect(page.response_headers['Content-Type']).to match(/csv/)
     expect(page.response_headers['Content-Disposition']).to match(/attachment/)

--- a/spec/presenters/taxonomy/csv_tree_presenter_spec.rb
+++ b/spec/presenters/taxonomy/csv_tree_presenter_spec.rb
@@ -28,9 +28,25 @@ module Taxonomy
       end
 
       it "presents the tree in CSV form" do
+        document_counts = {
+          'facets' => {
+            'taxons' => {
+              'options' => [
+                { 'value' => { 'slug' => 'Root' }, 'documents' => 1 },
+                { 'value' => { 'slug' => 'Child-1' }, 'documents' => 2 },
+                { 'value' => { 'slug' => 'Child-2' }, 'documents' => 3 },
+                { 'value' => { 'slug' => 'Child-3' }, 'documents' => 4 },
+              ]
+            }
+          }
+        }
+
+        stub_request(:get, "https://search.test.gov.uk/search.json?count=0&facet_taxons=4000")
+            .to_return(body: document_counts.to_json)
+
         presented = CsvTreePresenter.new(root_node).present
 
-        expect(presented.split("\n")).to eq %w[Root ,Child-1 ,,Child-2 ,,Child-3]
+        expect(presented.split("\n")).to eq %w[Root,1 ,Child-1,2 ,,Child-2,3 ,,Child-3,4]
       end
     end
   end


### PR DESCRIPTION
Adds count of documents tagged to each branch of the taxonomy to the final row of the CSV

Trello: https://trello.com/c/b0r0qY4t/17-add-number-of-content-items-tagged-to-each-taxon-to-the-csv-generated-in-content-tagger