### PR TITLE
Add Whitehall document types that support related links

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -77,20 +77,78 @@ private
 
   def related_links_are_renderable?
     %w[
+      aaib_report
       answer
+      asylum_support_decision
+      authored_article
+      business_finance_support_scheme
       calculator
       calendar
+      case_study
+      closed_consultation
+      cma_case
+      consultation
+      consultation_outcome
       contact
+      corporate_report
+      correspondence
+      countryside_stewardship_grant
+      decision
+      detailed_guidance
+      detailed_guide
+      dfid_research_output
+      document_collection
+      drug_safety_update
+      employment_appeal_tribunal_decision
+      employment_tribunal_decision
+      esi_fund
+      export_health_certificate
+      foi_release
+      form
+      government_response
+      guidance
       guide
       help_page
+      impact_assessment
+      independent_report
+      international_development_fund
+      international_treaty
       licence
       local_transaction
+      maib_report
+      map
+      medical_safety_alert
+      national_statistics
+      news_article
+      news_story
+      notice
+      official_statistics
+      open_consultation
+      oral_statement
       place
+      policy_paper
+      press_release
       programme
+      promotional
+      raib_report
+      regulation
+      research
+      residential_property_tribunal_decision
+      service_standard_report
       simple_smart_answer
       smart_answer
+      specialist_document
+      speech
+      statistical_data_set
+      statutory_guidance
+      statutory_instrument
+      tax_tribunal_decision
       transaction
+      transparency
       travel_advice
+      uk_market_conformity_assessment_body
+      utaac_decision
+      written_statement
     ].include?(document_type)
   end
 


### PR DESCRIPTION
This commit adds existing Whitehall document types to Content Tagger that support related links. Originally, this was a list of apps that weren't able to render the sidebar (back in 2016) which was then converted to the associated document types (in 2017).

We now display the sidebar for many more Whitehall document types; by allowing the related links component to be renderable when editing a content item within Content Tagger, publishers will be able to update related links. Related links overrides can be added to certain Whitehall documents at the moment, but only where the document is not tagged to a taxon, which affects the minority of documents and doesn't reliably change the related links shown within the component even if set.