### PR TITLE
Update to Brexit guidance email notification

### DIFF
--- a/app/views/facet_taggings/_tagging_form.html.erb
+++ b/app/views/facet_taggings/_tagging_form.html.erb
@@ -31,7 +31,7 @@
                     "This field does not accept markdown or HTML.",
               input_html: {
                 placeholder: " eg. You’re getting this email because you subscribed to " +
-                             "‘EU Exit guidance for your business or organisation’ updates on GOV.UK.",
+                             "‘Brexit guidance for your business or organisation’ updates on GOV.UK.",
                 size: 140,
               } %>
 


### PR DESCRIPTION
...placeholder

We are changing all instances of EU Exit to Brexit across
GOV.UK.

As part of the updates in place for email templates, it makes sense
to update the placeholder message here for consistency when emails
are sent out.

It updates:
![Screen Shot 2019-08-06 at 16 52 27](https://user-images.githubusercontent.com/19667619/62557213-6e6c1080-b86e-11e9-81f3-f6e604deba6f.png)

This will compliment https://github.com/alphagov/email-alert-api/pull/921

Trello card: https://trello.com/c/GnNdTWi9/1160-change-email-template-eu-exit-to-brexit