### PR TITLE
Publish 'cy' Brexit taxon

### DIFF
--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -1,6 +1,7 @@
 class TaxonsController < ApplicationController
+  include BrexitTaxon
+
   VISUALISATIONS = %w[list bubbles taxonomy_tree].freeze
-  BREXIT_TAXON_CONTENT_ID = "d6c2de5d-ef90-45d1-82d4-5f2438369eea".freeze
 
   before_action(
     :ensure_user_can_administer_taxonomy!,
@@ -142,7 +143,7 @@ class TaxonsController < ApplicationController
 
   def publish
     Services.publishing_api.publish(content_id)
-    if content_id == BREXIT_TAXON_CONTENT_ID
+    if brexit_taxon?(content_id)
       Services.publishing_api.publish(content_id, nil, locale: "cy")
     end
 
@@ -174,7 +175,7 @@ class TaxonsController < ApplicationController
   def discard_draft
     Services.publishing_api.discard_draft(content_id)
 
-    if content_id == BREXIT_TAXON_CONTENT_ID
+    if brexit_taxon?(content_id)
       Services.publishing_api.discard_draft(content_id, locale: "cy")
     end
 

--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -173,6 +173,11 @@ class TaxonsController < ApplicationController
 
   def discard_draft
     Services.publishing_api.discard_draft(content_id)
+
+    if content_id == BREXIT_TAXON_CONTENT_ID
+      Services.publishing_api.discard_draft(content_id, locale: "cy")
+    end
+
     redirect_to taxons_path, success: t("controllers.taxons.discard_draft_success")
   end
 

--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -1,5 +1,6 @@
 class TaxonsController < ApplicationController
   VISUALISATIONS = %w[list bubbles taxonomy_tree].freeze
+  BREXIT_TAXON_CONTENT_ID = "d6c2de5d-ef90-45d1-82d4-5f2438369eea".freeze
 
   before_action(
     :ensure_user_can_administer_taxonomy!,
@@ -141,6 +142,10 @@ class TaxonsController < ApplicationController
 
   def publish
     Services.publishing_api.publish(content_id)
+    if content_id == BREXIT_TAXON_CONTENT_ID
+      Services.publishing_api.publish(content_id, nil, locale: "cy")
+    end
+
     redirect_to taxon_path(content_id), success: "You have successfully published the taxon"
   rescue GdsApi::HTTPUnprocessableEntity => e
     # Perform a lookup on the base path to determine whether there

--- a/app/lib/brexit_taxon.rb
+++ b/app/lib/brexit_taxon.rb
@@ -1,0 +1,7 @@
+module BrexitTaxon
+  BREXIT_TAXON_CONTENT_ID = "d6c2de5d-ef90-45d1-82d4-5f2438369eea".freeze
+
+  def brexit_taxon?(content_id)
+    content_id == BREXIT_TAXON_CONTENT_ID
+  end
+end

--- a/app/services/taxonomy/build_taxon_payload.rb
+++ b/app/services/taxonomy/build_taxon_payload.rb
@@ -4,28 +4,28 @@ module Taxonomy
       @taxon = taxon
     end
 
-    def self.call(taxon:)
-      new(taxon).build
+    def self.call(taxon:, locale: "en")
+      new(taxon).build(locale)
     end
 
-    def build
+    def build(locale)
       {
-        base_path: base_path,
+        base_path: path(locale),
         document_type: "taxon",
         schema_name: "taxon",
         title: title,
-        description: description,
+        description: locale == "en" ? description : nil,
         publishing_app: "content-tagger",
         rendering_app: "collections",
         public_updated_at: Time.now.iso8601,
-        locale: "en",
+        locale: locale,
         details: {
           internal_name: internal_name,
           notes_for_editors: notes_for_editors,
           visible_to_departmental_editors: visible_to_departmental_editors,
         },
         routes: [
-          { path: base_path, type: "exact" },
+          { path: path(locale), type: "exact" },
         ],
         update_type: "major",
         phase: phase,
@@ -33,6 +33,10 @@ module Taxonomy
     end
 
   private
+
+    def path(locale)
+      @path ||= locale == "en" ? base_path : base_path + ".#{locale}"
+    end
 
     attr_reader :taxon
     delegate(

--- a/app/services/taxonomy/build_taxon_payload.rb
+++ b/app/services/taxonomy/build_taxon_payload.rb
@@ -9,12 +9,11 @@ module Taxonomy
     end
 
     def build(locale)
-      {
+      payload = {
         base_path: path(locale),
         document_type: "taxon",
         schema_name: "taxon",
         title: title,
-        description: locale == "en" ? description : nil,
         publishing_app: "content-tagger",
         rendering_app: "collections",
         public_updated_at: Time.now.iso8601,
@@ -30,6 +29,9 @@ module Taxonomy
         update_type: "major",
         phase: phase,
       }
+      payload[:description] = description if locale == "en"
+
+      payload
     end
 
   private

--- a/app/services/taxonomy/taxon_unpublisher.rb
+++ b/app/services/taxonomy/taxon_unpublisher.rb
@@ -1,5 +1,7 @@
 module Taxonomy
   class TaxonUnpublisher
+    BREXIT_TAXON_CONTENT_ID = "d6c2de5d-ef90-45d1-82d4-5f2438369eea".freeze
+
     def self.call(taxon_content_id:, redirect_to_content_id:, user:, retag: true)
       new.unpublish(taxon_content_id: taxon_content_id,
                     redirect_to_content_id: redirect_to_content_id,
@@ -31,7 +33,16 @@ module Taxonomy
 
     def unpublish_taxon(taxon_content_id, redirect_to_content_id)
       redirect_to_taxon = Services.publishing_api.get_content(redirect_to_content_id)
-      Services.publishing_api.unpublish(taxon_content_id, type: "redirect", alternative_path: redirect_to_taxon["base_path"])
+      Services.publishing_api.unpublish(taxon_content_id,
+                                        type: "redirect",
+                                        alternative_path: redirect_to_taxon["base_path"])
+
+      if taxon_content_id == BREXIT_TAXON_CONTENT_ID
+        Services.publishing_api.unpublish(taxon_content_id,
+                                          type: "redirect",
+                                          alternative_path: redirect_to_taxon["base_path"],
+                                          locale: "cy")
+      end
     end
 
     def tagged_content_base_paths(content_id)

--- a/app/services/taxonomy/update_taxon.rb
+++ b/app/services/taxonomy/update_taxon.rb
@@ -3,6 +3,8 @@ module Taxonomy
     attr_reader :taxon
     delegate :content_id, :parent_content_id, :associated_taxons, :legacy_taxons, to: :taxon
 
+    BREXIT_TAXON_CONTENT_ID = "d6c2de5d-ef90-45d1-82d4-5f2438369eea".freeze
+
     class InvalidTaxonError < StandardError; end
 
     def initialize(taxon:, version_note:)
@@ -24,6 +26,9 @@ module Taxonomy
       Taxonomy::SaveTaxonVersion.call(taxon, @version_note)
 
       Services.publishing_api.put_content(content_id, payload)
+      if content_id == BREXIT_TAXON_CONTENT_ID
+        Services.publishing_api.put_content(content_id, payload("cy"))
+      end
 
       Taxonomy::LinksUpdate.new(
         content_id: content_id,
@@ -52,8 +57,8 @@ module Taxonomy
 
   private
 
-    def payload
-      Taxonomy::BuildTaxonPayload.call(taxon: taxon)
+    def payload(locale = "en")
+      Taxonomy::BuildTaxonPayload.call(taxon: taxon, locale: locale)
     end
 
     def legacy_taxon_ids

--- a/app/services/taxonomy/update_taxon.rb
+++ b/app/services/taxonomy/update_taxon.rb
@@ -1,9 +1,9 @@
 module Taxonomy
   class UpdateTaxon
+    include BrexitTaxon
+
     attr_reader :taxon
     delegate :content_id, :parent_content_id, :associated_taxons, :legacy_taxons, to: :taxon
-
-    BREXIT_TAXON_CONTENT_ID = "d6c2de5d-ef90-45d1-82d4-5f2438369eea".freeze
 
     class InvalidTaxonError < StandardError; end
 
@@ -68,7 +68,7 @@ module Taxonomy
 
     def publishing_api_put_content_request(content_id)
       Services.publishing_api.put_content(content_id, payload)
-      return unless content_id == BREXIT_TAXON_CONTENT_ID
+      return unless brexit_taxon?(content_id)
 
       Services.publishing_api.put_content(content_id, payload("cy"))
     end

--- a/app/services/taxonomy/update_taxon.rb
+++ b/app/services/taxonomy/update_taxon.rb
@@ -25,10 +25,7 @@ module Taxonomy
       # so that we can compare the differences between the two versions.
       Taxonomy::SaveTaxonVersion.call(taxon, @version_note)
 
-      Services.publishing_api.put_content(content_id, payload)
-      if content_id == BREXIT_TAXON_CONTENT_ID
-        Services.publishing_api.put_content(content_id, payload("cy"))
-      end
+      publishing_api_put_content_request(content_id)
 
       Taxonomy::LinksUpdate.new(
         content_id: content_id,
@@ -67,6 +64,13 @@ module Taxonomy
       Array(
         Tagging::BasePathLookup.find_by_base_paths(taxon.legacy_taxons),
       ).select(&:present?).map(&:content_id)
+    end
+
+    def publishing_api_put_content_request(content_id)
+      Services.publishing_api.put_content(content_id, payload)
+      return unless content_id == BREXIT_TAXON_CONTENT_ID
+
+      Services.publishing_api.put_content(content_id, payload("cy"))
     end
   end
 end

--- a/app/workers/publish_taxon_worker.rb
+++ b/app/workers/publish_taxon_worker.rb
@@ -1,8 +1,13 @@
 class PublishTaxonWorker
   include Sidekiq::Worker
+  BREXIT_TAXON_CONTENT_ID = "d6c2de5d-ef90-45d1-82d4-5f2438369eea".freeze
 
   def perform(taxon_content_id)
     Services.publishing_api.publish(taxon_content_id)
+
+    if taxon_content_id == BREXIT_TAXON_CONTENT_ID
+      Services.publishing_api.publish(taxon_content_id, nil, locale: "cy")
+    end
   rescue GdsApi::HTTPConflict => e # Ignore attempts to publish already published content
     puts "409 #{e.message}"
   end

--- a/app/workers/publish_taxon_worker.rb
+++ b/app/workers/publish_taxon_worker.rb
@@ -1,11 +1,11 @@
 class PublishTaxonWorker
   include Sidekiq::Worker
-  BREXIT_TAXON_CONTENT_ID = "d6c2de5d-ef90-45d1-82d4-5f2438369eea".freeze
+  include BrexitTaxon
 
   def perform(taxon_content_id)
     Services.publishing_api.publish(taxon_content_id)
 
-    if taxon_content_id == BREXIT_TAXON_CONTENT_ID
+    if brexit_taxon?(taxon_content_id)
       Services.publishing_api.publish(taxon_content_id, nil, locale: "cy")
     end
   rescue GdsApi::HTTPConflict => e # Ignore attempts to publish already published content

--- a/app/workers/update_taxon_worker.rb
+++ b/app/workers/update_taxon_worker.rb
@@ -1,6 +1,6 @@
 class UpdateTaxonWorker
   include Sidekiq::Worker
-  BREXIT_TAXON_CONTENT_ID = "d6c2de5d-ef90-45d1-82d4-5f2438369eea".freeze
+  include BrexitTaxon
 
   def perform(content_id, attributes)
     previous_taxon = Taxonomy::BuildTaxon.call(content_id: content_id)
@@ -20,7 +20,7 @@ private
 
   def publishing_api_put_content_request(content_id, taxon)
     Services.publishing_api.put_content(content_id, payload(taxon))
-    return unless content_id == BREXIT_TAXON_CONTENT_ID
+    return unless brexit_taxon?(content_id)
 
     Services.publishing_api.put_content(content_id, payload(taxon, "cy"))
   end

--- a/spec/controllers/taxons_controller_spec.rb
+++ b/spec/controllers/taxons_controller_spec.rb
@@ -120,6 +120,17 @@ RSpec.describe TaxonsController, type: :controller do
 
       expect(flash.now[:danger]).to match(/<a href="(.+)">taxon<\/a> with this slug already exists/)
     end
+
+    it "sends additional publish request to Publishing API for the Brexit taxon with 'cy' locale" do
+      brexit_taxon_content_id = "d6c2de5d-ef90-45d1-82d4-5f2438369eea"
+      build(:taxon, publication_state: "unpublished", content_id: brexit_taxon_content_id)
+      stub_any_publishing_api_publish
+
+      post :publish, params: { taxon_id: brexit_taxon_content_id }
+
+      assert_publishing_api_publish(brexit_taxon_content_id, update_type: nil)
+      assert_publishing_api_publish(brexit_taxon_content_id, update_type: nil, locale: "cy")
+    end
   end
 
   describe "#confirm_bulk_publish" do

--- a/spec/controllers/taxons_controller_spec.rb
+++ b/spec/controllers/taxons_controller_spec.rb
@@ -207,6 +207,16 @@ RSpec.describe TaxonsController, type: :controller do
       delete :discard_draft, params: { taxon_id: taxon.content_id }
       expect(WebMock).to have_requested(:post, "https://publishing-api.test.gov.uk/v2/content/#{taxon.content_id}/discard-draft")
     end
+
+    it "sends a request to Publishing API to delete a draft Brexit taxon with 'cy' locale" do
+      brexit_taxon_content_id = "d6c2de5d-ef90-45d1-82d4-5f2438369eea"
+      taxon = build(:taxon, publication_state: "draft", content_id: brexit_taxon_content_id)
+      publishing_api_has_taxons([taxon])
+      stub_any_publishing_api_discard_draft
+
+      delete :discard_draft, params: { taxon_id: brexit_taxon_content_id }
+      assert_publishing_api_discard_draft(brexit_taxon_content_id, locale: "cy")
+    end
   end
 
   def stub_taxon_show_page(content_id)

--- a/spec/controllers/taxons_controller_spec.rb
+++ b/spec/controllers/taxons_controller_spec.rb
@@ -4,6 +4,9 @@ RSpec.describe TaxonsController, type: :controller do
   include EmailAlertApiHelper
   include PublishingApiHelper
   include ContentItemHelper
+  include BrexitTaxon
+
+  let(:brexit_taxon_content_id) { BrexitTaxon::BREXIT_TAXON_CONTENT_ID }
 
   describe "#index" do
     it "renders index" do
@@ -122,7 +125,6 @@ RSpec.describe TaxonsController, type: :controller do
     end
 
     it "sends additional publish request to Publishing API for the Brexit taxon with 'cy' locale" do
-      brexit_taxon_content_id = "d6c2de5d-ef90-45d1-82d4-5f2438369eea"
       build(:taxon, publication_state: "unpublished", content_id: brexit_taxon_content_id)
       stub_any_publishing_api_publish
 
@@ -209,7 +211,6 @@ RSpec.describe TaxonsController, type: :controller do
     end
 
     it "sends a request to Publishing API to delete a draft Brexit taxon with 'cy' locale" do
-      brexit_taxon_content_id = "d6c2de5d-ef90-45d1-82d4-5f2438369eea"
       taxon = build(:taxon, publication_state: "draft", content_id: brexit_taxon_content_id)
       publishing_api_has_taxons([taxon])
       stub_any_publishing_api_discard_draft

--- a/spec/lib/tasks/taxonomy/validate_taxons_base_paths_spec.rb
+++ b/spec/lib/tasks/taxonomy/validate_taxons_base_paths_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe "taxonomy:validate_taxons_base_paths" do
       {"error":{"code":422,"message":"base path=/transport conflicts with content_id=a4038b29-b332-4f13-98b1-1c9709e216bc and locale=en","fields":{"base":["base path=/transport conflicts with content_id=a4038b29-b332-4f13-98b1-1c9709e216bc and locale=en"]}}}
 
       Request body:
-      {:base_path=>"/level-one/level-two", :document_type=>"taxon", :schema_name=>"taxon", :title=>"Level Two", :description=>"...", :publishing_app=>"content-tagger", :rendering_app=>"collections", :public_updated_at=>"2018-02-28T16:23:32+00:00", :locale=>"en", :details=>{:internal_name=>"internal name for Level Two", :notes_for_editors=>"Editor notes for Level Two", :visible_to_departmental_editors=>false}, :routes=>[{:path=>"/level-one/level-two", :type=>"exact"}], :update_type=>"major", :phase=>"live"}>
+      {:base_path=>"/level-one/level-two", :document_type=>"taxon", :schema_name=>"taxon", :title=>"Level Two", :publishing_app=>"content-tagger", :rendering_app=>"collections", :public_updated_at=>"2018-02-28T16:23:32+00:00", :locale=>"en", :details=>{:internal_name=>"internal name for Level Two", :notes_for_editors=>"Editor notes for Level Two", :visible_to_departmental_editors=>false}, :routes=>[{:path=>"/level-one/level-two", :type=>"exact"}], :update_type=>"major", :phase=>"live", :description=>"..."}>
     LOG
   end
 

--- a/spec/services/taxonomy/build_taxon_payload_spec.rb
+++ b/spec/services/taxonomy/build_taxon_payload_spec.rb
@@ -44,8 +44,8 @@ RSpec.describe Taxonomy::BuildTaxonPayload do
         expect(payload[:routes][0][:path]).to eq("#{taxon.base_path}.fr")
       end
 
-      it "sets description to nil" do
-        expect(payload[:description]).to be nil
+      it "does not include description" do
+        expect(payload).not_to include(:description)
       end
     end
   end

--- a/spec/services/taxonomy/build_taxon_payload_spec.rb
+++ b/spec/services/taxonomy/build_taxon_payload_spec.rb
@@ -24,5 +24,29 @@ RSpec.describe Taxonomy::BuildTaxonPayload do
     it "assigns the expected rendering app" do
       expect(payload[:publishing_app]).to eq("content-tagger")
     end
+
+    it "sets locale to 'en' default" do
+      expect(payload[:locale]).to eq("en")
+    end
+
+    context "non-'en' locale" do
+      let(:payload) { described_class.call(taxon: taxon, locale: "fr") }
+
+      it "sets locale to non-'en' locale" do
+        expect(payload[:locale]).to eq("fr")
+      end
+
+      it "appends non-'en' locale to the base_path" do
+        expect(payload[:base_path]).to eq("#{taxon.base_path}.fr")
+      end
+
+      it "appends non-'en' locale to routes path" do
+        expect(payload[:routes][0][:path]).to eq("#{taxon.base_path}.fr")
+      end
+
+      it "sets description to nil" do
+        expect(payload[:description]).to be nil
+      end
+    end
   end
 end

--- a/spec/services/taxonomy/taxon_unpublisher_spec.rb
+++ b/spec/services/taxonomy/taxon_unpublisher_spec.rb
@@ -88,6 +88,19 @@ RSpec.describe Taxonomy::TaxonUnpublisher do
     end
   end
 
+  context "Brexit taxon" do
+    it "unpublishes the Brexit taxon with 'cy' locale" do
+      brexit_content_id = "d6c2de5d-ef90-45d1-82d4-5f2438369eea"
+      publishing_api_has_expanded_links("content_id" => brexit_content_id, "expanded_links" => {})
+
+      unpublish(brexit_content_id, redirect_content_id)
+      assert_publishing_api_unpublish(brexit_content_id,
+                                      type: "redirect",
+                                      alternative_path: "/path/to/redirect",
+                                      locale: "cy")
+    end
+  end
+
   def unpublish(taxon_content_id, redirect_to_content_id, retag = true)
     Sidekiq::Testing.inline! do
       Taxonomy::TaxonUnpublisher.call(taxon_content_id: taxon_content_id, redirect_to_content_id: redirect_to_content_id, user: User.new, retag: retag)

--- a/spec/services/taxonomy/taxon_unpublisher_spec.rb
+++ b/spec/services/taxonomy/taxon_unpublisher_spec.rb
@@ -1,6 +1,7 @@
 require "rails_helper"
 
 include ::GdsApi::TestHelpers::PublishingApiV2
+include BrexitTaxon
 
 RSpec.describe Taxonomy::TaxonUnpublisher do
   let(:taxon_content_id) { SecureRandom.uuid }
@@ -90,7 +91,7 @@ RSpec.describe Taxonomy::TaxonUnpublisher do
 
   context "Brexit taxon" do
     it "unpublishes the Brexit taxon with 'cy' locale" do
-      brexit_content_id = "d6c2de5d-ef90-45d1-82d4-5f2438369eea"
+      brexit_content_id = BrexitTaxon::BREXIT_TAXON_CONTENT_ID
       publishing_api_has_expanded_links("content_id" => brexit_content_id, "expanded_links" => {})
 
       unpublish(brexit_content_id, redirect_content_id)

--- a/spec/services/taxonomy/update_taxon_spec.rb
+++ b/spec/services/taxonomy/update_taxon_spec.rb
@@ -122,5 +122,19 @@ RSpec.describe Taxonomy::UpdateTaxon do
         )
       end
     end
+
+    context "with the Brexit taxon" do
+      it "publishes the document in the 'en' and 'cy' locale via the Publishing API" do
+        stub_any_publishing_api_put_content
+        stub_any_publishing_api_patch_links
+
+        @taxon.content_id = "d6c2de5d-ef90-45d1-82d4-5f2438369eea"
+
+        described_class.call(taxon: @taxon)
+
+        assert_publishing_api_put_content(@taxon.content_id, request_json_includes(locale: "en"))
+        assert_publishing_api_put_content(@taxon.content_id, request_json_includes(locale: "cy"))
+      end
+    end
   end
 end

--- a/spec/services/taxonomy/update_taxon_spec.rb
+++ b/spec/services/taxonomy/update_taxon_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.describe Taxonomy::UpdateTaxon do
   include ContentItemHelper
+  include BrexitTaxon
 
   before do
     @taxon = Taxon.new(
@@ -128,7 +129,7 @@ RSpec.describe Taxonomy::UpdateTaxon do
         stub_any_publishing_api_put_content
         stub_any_publishing_api_patch_links
 
-        @taxon.content_id = "d6c2de5d-ef90-45d1-82d4-5f2438369eea"
+        @taxon.content_id = BrexitTaxon::BREXIT_TAXON_CONTENT_ID
 
         described_class.call(taxon: @taxon)
 

--- a/spec/workers/update_taxon_worker_spec.rb
+++ b/spec/workers/update_taxon_worker_spec.rb
@@ -30,4 +30,24 @@ RSpec.describe UpdateTaxonWorker, "#perform" do
       ],
     )
   end
+
+  it "makes a PUT content request to Publishing API for the Brexit taxon with 'cy' and 'en' locales" do
+    brexit_taxon_content_id = "d6c2de5d-ef90-45d1-82d4-5f2438369eea"
+    taxon = taxon_with_details(
+      "Transport",
+      other_fields: {
+        content_id: brexit_taxon_content_id,
+        base_path: "/imported-topic/topic/transport",
+        publication_state: "draft",
+      },
+    )
+    publishing_api_has_item(taxon)
+    publishing_api_has_expanded_links(taxon.slice(:content_id))
+    stub_any_publishing_api_put_content
+
+    UpdateTaxonWorker.new.perform(brexit_taxon_content_id, base_path: "/base-path")
+
+    assert_publishing_api_put_content(brexit_taxon_content_id, request_json_includes(locale: "en"))
+    assert_publishing_api_put_content(brexit_taxon_content_id, request_json_includes(locale: "cy"))
+  end
 end

--- a/spec/workers/update_taxon_worker_spec.rb
+++ b/spec/workers/update_taxon_worker_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe UpdateTaxonWorker, "#perform" do
   include PublishingApiHelper
   include ContentItemHelper
+  include BrexitTaxon
 
   it "records the changes that have been made" do
     taxon = taxon_with_details(
@@ -32,7 +33,7 @@ RSpec.describe UpdateTaxonWorker, "#perform" do
   end
 
   it "makes a PUT content request to Publishing API for the Brexit taxon with 'cy' and 'en' locales" do
-    brexit_taxon_content_id = "d6c2de5d-ef90-45d1-82d4-5f2438369eea"
+    brexit_taxon_content_id = BrexitTaxon::BREXIT_TAXON_CONTENT_ID
     taxon = taxon_with_details(
       "Transport",
       other_fields: {


### PR DESCRIPTION
For https://trello.com/c/3DUTcMYK/104-build-welsh-language-landing-page

We've received a request to build a Welsh translation of the '/brexit' page.  In order to achieve this we need to publish '/brexit' in the `cy` locale.  '/brexit' is a taxon and currently we don't publish taxons in locales other than `en`, so this is a somewhat hacky approach to publishing the Brexit taxon with a `cy` locale.  In addition to publishing we've ensured that any other Publishing API-related actions taken on the Brexit taxon are also reflected in its `cy` representation.  

We're not aware of any other needs to publish taxons in other locales and given the urgency of the work this approach is very much custom for the Brexit taxon and hasn't been developed in a particularly reusable way.  We will need to look at the longer-term implications of this from a product perspective and it will be logged as GOV.UK tech debt.