### PR TITLE
README: Remove old, dev VM 'how to run the app' instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,15 +30,6 @@ application.
 User.first.update permissions: ["signin", "GDS Editor"]
 ```
 
-Then from `govuk/govuk-puppet/development-vm`, run:
-
-```
-$ bowl content-tagger
-```
-
-If you're using the VM, the app should appear on
-[http://content-tagger.dev.gov.uk/](http://content-tagger.dev.gov.uk/).
-
 ### Running the test suite
 
 ```


### PR DESCRIPTION
- These instructions referenced the deprecated GOV.UK Development VM, `bowler`.
- The new standard is [GOV.UK Docker](https://github.com/alphagov/govuk-docker).