### PR TITLE
Rename brexit taxon

### DIFF
--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -1,5 +1,5 @@
 class TaxonsController < ApplicationController
-  include BrexitTaxon
+  include TransitionTaxon
 
   VISUALISATIONS = %w[list bubbles taxonomy_tree].freeze
 

--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -143,7 +143,7 @@ class TaxonsController < ApplicationController
 
   def publish
     Services.publishing_api.publish(content_id)
-    if brexit_taxon?(content_id)
+    if transition_taxon?(content_id)
       Services.publishing_api.publish(content_id, nil, locale: "cy")
     end
 
@@ -175,7 +175,7 @@ class TaxonsController < ApplicationController
   def discard_draft
     Services.publishing_api.discard_draft(content_id)
 
-    if brexit_taxon?(content_id)
+    if transition_taxon?(content_id)
       Services.publishing_api.discard_draft(content_id, locale: "cy")
     end
 

--- a/app/lib/brexit_taxon.rb
+++ b/app/lib/brexit_taxon.rb
@@ -1,7 +1,0 @@
-module BrexitTaxon
-  BREXIT_TAXON_CONTENT_ID = "d6c2de5d-ef90-45d1-82d4-5f2438369eea".freeze
-
-  def brexit_taxon?(content_id)
-    content_id == BREXIT_TAXON_CONTENT_ID
-  end
-end

--- a/app/lib/transition_taxon.rb
+++ b/app/lib/transition_taxon.rb
@@ -1,0 +1,7 @@
+module TransitionTaxon
+  TRANSITION_TAXON_CONTENT_ID = "d6c2de5d-ef90-45d1-82d4-5f2438369eea".freeze
+
+  def brexit_taxon?(content_id)
+    content_id == TRANSITION_TAXON_CONTENT_ID
+  end
+end

--- a/app/lib/transition_taxon.rb
+++ b/app/lib/transition_taxon.rb
@@ -1,7 +1,7 @@
 module TransitionTaxon
   TRANSITION_TAXON_CONTENT_ID = "d6c2de5d-ef90-45d1-82d4-5f2438369eea".freeze
 
-  def brexit_taxon?(content_id)
+  def transition_taxon?(content_id)
     content_id == TRANSITION_TAXON_CONTENT_ID
   end
 end

--- a/app/services/taxonomy/taxon_unpublisher.rb
+++ b/app/services/taxonomy/taxon_unpublisher.rb
@@ -1,6 +1,6 @@
 module Taxonomy
   class TaxonUnpublisher
-    include BrexitTaxon
+    include TransitionTaxon
 
     def self.call(taxon_content_id:, redirect_to_content_id:, user:, retag: true)
       new.unpublish(taxon_content_id: taxon_content_id,

--- a/app/services/taxonomy/taxon_unpublisher.rb
+++ b/app/services/taxonomy/taxon_unpublisher.rb
@@ -34,7 +34,7 @@ module Taxonomy
     def unpublish_taxon(taxon_content_id, redirect_to_content_id)
       redirect_to_taxon = Services.publishing_api.get_content(redirect_to_content_id)
       publishing_api_unpublish(taxon_content_id, redirect_to_taxon["base_path"])
-      return unless brexit_taxon?(taxon_content_id)
+      return unless transition_taxon?(taxon_content_id)
 
       publishing_api_unpublish(taxon_content_id, redirect_to_taxon["base_path"], "cy")
     end

--- a/app/services/taxonomy/update_taxon.rb
+++ b/app/services/taxonomy/update_taxon.rb
@@ -1,6 +1,6 @@
 module Taxonomy
   class UpdateTaxon
-    include BrexitTaxon
+    include TransitionTaxon
 
     attr_reader :taxon
     delegate :content_id, :parent_content_id, :associated_taxons, :legacy_taxons, to: :taxon

--- a/app/services/taxonomy/update_taxon.rb
+++ b/app/services/taxonomy/update_taxon.rb
@@ -68,7 +68,7 @@ module Taxonomy
 
     def publishing_api_put_content_request(content_id)
       Services.publishing_api.put_content(content_id, payload)
-      return unless brexit_taxon?(content_id)
+      return unless transition_taxon?(content_id)
 
       Services.publishing_api.put_content(content_id, payload("cy"))
     end

--- a/app/workers/publish_taxon_worker.rb
+++ b/app/workers/publish_taxon_worker.rb
@@ -1,6 +1,6 @@
 class PublishTaxonWorker
   include Sidekiq::Worker
-  include BrexitTaxon
+  include TransitionTaxon
 
   def perform(taxon_content_id)
     Services.publishing_api.publish(taxon_content_id)

--- a/app/workers/publish_taxon_worker.rb
+++ b/app/workers/publish_taxon_worker.rb
@@ -5,7 +5,7 @@ class PublishTaxonWorker
   def perform(taxon_content_id)
     Services.publishing_api.publish(taxon_content_id)
 
-    if brexit_taxon?(taxon_content_id)
+    if transition_taxon?(taxon_content_id)
       Services.publishing_api.publish(taxon_content_id, nil, locale: "cy")
     end
   rescue GdsApi::HTTPConflict => e # Ignore attempts to publish already published content

--- a/app/workers/update_taxon_worker.rb
+++ b/app/workers/update_taxon_worker.rb
@@ -20,7 +20,7 @@ private
 
   def publishing_api_put_content_request(content_id, taxon)
     Services.publishing_api.put_content(content_id, payload(taxon))
-    return unless brexit_taxon?(content_id)
+    return unless transition_taxon?(content_id)
 
     Services.publishing_api.put_content(content_id, payload(taxon, "cy"))
   end

--- a/app/workers/update_taxon_worker.rb
+++ b/app/workers/update_taxon_worker.rb
@@ -1,6 +1,6 @@
 class UpdateTaxonWorker
   include Sidekiq::Worker
-  include BrexitTaxon
+  include TransitionTaxon
 
   def perform(content_id, attributes)
     previous_taxon = Taxonomy::BuildTaxon.call(content_id: content_id)

--- a/spec/controllers/taxons_controller_spec.rb
+++ b/spec/controllers/taxons_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe TaxonsController, type: :controller do
   include EmailAlertApiHelper
   include PublishingApiHelper
   include ContentItemHelper
-  include BrexitTaxon
+  include TransitionTaxon
 
   let(:brexit_taxon_content_id) { BrexitTaxon::BREXIT_TAXON_CONTENT_ID }
 

--- a/spec/controllers/taxons_controller_spec.rb
+++ b/spec/controllers/taxons_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe TaxonsController, type: :controller do
   include ContentItemHelper
   include TransitionTaxon
 
-  let(:brexit_taxon_content_id) { BrexitTaxon::BREXIT_TAXON_CONTENT_ID }
+  let(:transition_taxon_content_id) { TransitionTaxon::TRANSITION_TAXON_CONTENT_ID }
 
   describe "#index" do
     it "renders index" do
@@ -125,13 +125,13 @@ RSpec.describe TaxonsController, type: :controller do
     end
 
     it "sends additional publish request to Publishing API for the Brexit taxon with 'cy' locale" do
-      build(:taxon, publication_state: "unpublished", content_id: brexit_taxon_content_id)
+      build(:taxon, publication_state: "unpublished", content_id: transition_taxon_content_id)
       stub_any_publishing_api_publish
 
-      post :publish, params: { taxon_id: brexit_taxon_content_id }
+      post :publish, params: { taxon_id: transition_taxon_content_id }
 
-      assert_publishing_api_publish(brexit_taxon_content_id, update_type: nil)
-      assert_publishing_api_publish(brexit_taxon_content_id, update_type: nil, locale: "cy")
+      assert_publishing_api_publish(transition_taxon_content_id, update_type: nil)
+      assert_publishing_api_publish(transition_taxon_content_id, update_type: nil, locale: "cy")
     end
   end
 
@@ -211,12 +211,12 @@ RSpec.describe TaxonsController, type: :controller do
     end
 
     it "sends a request to Publishing API to delete a draft Brexit taxon with 'cy' locale" do
-      taxon = build(:taxon, publication_state: "draft", content_id: brexit_taxon_content_id)
+      taxon = build(:taxon, publication_state: "draft", content_id: transition_taxon_content_id)
       publishing_api_has_taxons([taxon])
       stub_any_publishing_api_discard_draft
 
-      delete :discard_draft, params: { taxon_id: brexit_taxon_content_id }
-      assert_publishing_api_discard_draft(brexit_taxon_content_id, locale: "cy")
+      delete :discard_draft, params: { taxon_id: transition_taxon_content_id }
+      assert_publishing_api_discard_draft(transition_taxon_content_id, locale: "cy")
     end
   end
 

--- a/spec/services/taxonomy/taxon_unpublisher_spec.rb
+++ b/spec/services/taxonomy/taxon_unpublisher_spec.rb
@@ -89,13 +89,13 @@ RSpec.describe Taxonomy::TaxonUnpublisher do
     end
   end
 
-  context "Brexit taxon" do
-    it "unpublishes the Brexit taxon with 'cy' locale" do
-      brexit_content_id = TransitionTaxon::TRANSITION_TAXON_CONTENT_ID
-      publishing_api_has_expanded_links("content_id" => brexit_content_id, "expanded_links" => {})
+  context "Transition taxon" do
+    it "unpublishes the Transition taxon with 'cy' locale" do
+      transition_taxon_content_id = TransitionTaxon::TRANSITION_TAXON_CONTENT_ID
+      publishing_api_has_expanded_links("content_id" => transition_taxon_content_id, "expanded_links" => {})
 
-      unpublish(brexit_content_id, redirect_content_id)
-      assert_publishing_api_unpublish(brexit_content_id,
+      unpublish(transition_taxon_content_id, redirect_content_id)
+      assert_publishing_api_unpublish(transition_taxon_content_id,
                                       type: "redirect",
                                       alternative_path: "/path/to/redirect",
                                       locale: "cy")

--- a/spec/services/taxonomy/taxon_unpublisher_spec.rb
+++ b/spec/services/taxonomy/taxon_unpublisher_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 include ::GdsApi::TestHelpers::PublishingApiV2
-include BrexitTaxon
+include TransitionTaxon
 
 RSpec.describe Taxonomy::TaxonUnpublisher do
   let(:taxon_content_id) { SecureRandom.uuid }

--- a/spec/services/taxonomy/taxon_unpublisher_spec.rb
+++ b/spec/services/taxonomy/taxon_unpublisher_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe Taxonomy::TaxonUnpublisher do
 
   context "Brexit taxon" do
     it "unpublishes the Brexit taxon with 'cy' locale" do
-      brexit_content_id = BrexitTaxon::BREXIT_TAXON_CONTENT_ID
+      brexit_content_id = TransitionTaxon::TRANSITION_TAXON_CONTENT_ID
       publishing_api_has_expanded_links("content_id" => brexit_content_id, "expanded_links" => {})
 
       unpublish(brexit_content_id, redirect_content_id)

--- a/spec/services/taxonomy/update_taxon_spec.rb
+++ b/spec/services/taxonomy/update_taxon_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe Taxonomy::UpdateTaxon do
         stub_any_publishing_api_put_content
         stub_any_publishing_api_patch_links
 
-        @taxon.content_id = BrexitTaxon::BREXIT_TAXON_CONTENT_ID
+        @taxon.content_id = TransitionTaxon::TRANSITION_TAXON_CONTENT_ID
 
         described_class.call(taxon: @taxon)
 

--- a/spec/services/taxonomy/update_taxon_spec.rb
+++ b/spec/services/taxonomy/update_taxon_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Taxonomy::UpdateTaxon do
   include ContentItemHelper
-  include BrexitTaxon
+  include TransitionTaxon
 
   before do
     @taxon = Taxon.new(

--- a/spec/workers/update_taxon_worker_spec.rb
+++ b/spec/workers/update_taxon_worker_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe UpdateTaxonWorker, "#perform" do
   include PublishingApiHelper
   include ContentItemHelper
-  include BrexitTaxon
+  include TransitionTaxon
 
   it "records the changes that have been made" do
     taxon = taxon_with_details(

--- a/spec/workers/update_taxon_worker_spec.rb
+++ b/spec/workers/update_taxon_worker_spec.rb
@@ -33,11 +33,11 @@ RSpec.describe UpdateTaxonWorker, "#perform" do
   end
 
   it "makes a PUT content request to Publishing API for the Brexit taxon with 'cy' and 'en' locales" do
-    brexit_taxon_content_id = BrexitTaxon::BREXIT_TAXON_CONTENT_ID
+    transition_taxon_content_id = TransitionTaxon::TRANSITION_TAXON_CONTENT_ID
     taxon = taxon_with_details(
       "Transport",
       other_fields: {
-        content_id: brexit_taxon_content_id,
+        content_id: transition_taxon_content_id,
         base_path: "/imported-topic/topic/transport",
         publication_state: "draft",
       },
@@ -46,9 +46,9 @@ RSpec.describe UpdateTaxonWorker, "#perform" do
     publishing_api_has_expanded_links(taxon.slice(:content_id))
     stub_any_publishing_api_put_content
 
-    UpdateTaxonWorker.new.perform(brexit_taxon_content_id, base_path: "/base-path")
+    UpdateTaxonWorker.new.perform(transition_taxon_content_id, base_path: "/base-path")
 
-    assert_publishing_api_put_content(brexit_taxon_content_id, request_json_includes(locale: "en"))
-    assert_publishing_api_put_content(brexit_taxon_content_id, request_json_includes(locale: "cy"))
+    assert_publishing_api_put_content(transition_taxon_content_id, request_json_includes(locale: "en"))
+    assert_publishing_api_put_content(transition_taxon_content_id, request_json_includes(locale: "cy"))
   end
 end


### PR DESCRIPTION
We still have lots of references to the brexit taxon about. This has now been renamed to the transition taxon.

As part of our clearup we'd like to rename these references so their function is clearer to developers who might review and maintain this code in future.