### PR TITLE
Migrate from GdsApi::PublishingApiV2

### DIFF
--- a/app/lib/services.rb
+++ b/app/lib/services.rb
@@ -4,7 +4,7 @@ require "gds_api/content_store"
 
 module Services
   def self.publishing_api
-    @publishing_api ||= GdsApi::PublishingApiV2.new(
+    @publishing_api ||= GdsApi::PublishingApi.new(
       Plek.new.find("publishing-api"),
       disable_cache: true,
       bearer_token: ENV["PUBLISHING_API_BEARER_TOKEN"] || "example",

--- a/spec/controllers/taxons_controller_spec.rb
+++ b/spec/controllers/taxons_controller_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe TaxonsController, type: :controller do
       stub_publishing_api_publish(taxon.content_id, {}, status: 422)
       payload = Taxonomy::BuildTaxonPayload.call(taxon: taxon)
       stub_publishing_api_has_item(payload.merge(content_id: taxon.content_id))
-      publishing_api_has_expanded_links(content_id: taxon.content_id)
+      stub_publishing_api_has_expanded_links(content_id: taxon.content_id)
       publishing_api_has_lookups(taxon.base_path => SecureRandom.uuid)
 
       post :publish, params: { taxon_id: taxon.content_id }
@@ -152,7 +152,7 @@ RSpec.describe TaxonsController, type: :controller do
         "root", other_fields: { base_path: "/level-one", content_id: "CONTENT-ID-PARENT" }
       )
       stub_publishing_api_has_item(parent_taxon)
-      publishing_api_has_expanded_links(content_id: "CONTENT-ID-PARENT")
+      stub_publishing_api_has_expanded_links(content_id: "CONTENT-ID-PARENT")
 
       Timecop.freeze do
         payload = Taxonomy::BuildTaxonPayload.call(taxon: taxon)
@@ -179,7 +179,7 @@ RSpec.describe TaxonsController, type: :controller do
         }
 
         stub_publishing_api_has_item(payload.merge(content_id: taxon.content_id))
-        publishing_api_has_expanded_links(expanded_links.merge(content_id: taxon.content_id))
+        stub_publishing_api_has_expanded_links(expanded_links.merge(content_id: taxon.content_id))
         stub_publishing_api_put_content(taxon.content_id, payload)
         stub_publishing_api_patch_links(taxon.content_id, links.to_json)
 

--- a/spec/controllers/taxons_controller_spec.rb
+++ b/spec/controllers/taxons_controller_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe TaxonsController, type: :controller do
       taxon = build(:taxon, publication_state: "unpublished", content_id: SecureRandom.uuid)
       stub_publishing_api_publish(taxon.content_id, {}, status: 422)
       payload = Taxonomy::BuildTaxonPayload.call(taxon: taxon)
-      publishing_api_has_item(payload.merge(content_id: taxon.content_id))
+      stub_publishing_api_has_item(payload.merge(content_id: taxon.content_id))
       publishing_api_has_expanded_links(content_id: taxon.content_id)
       publishing_api_has_lookups(taxon.base_path => SecureRandom.uuid)
 
@@ -151,7 +151,7 @@ RSpec.describe TaxonsController, type: :controller do
       parent_taxon = taxon_with_details(
         "root", other_fields: { base_path: "/level-one", content_id: "CONTENT-ID-PARENT" }
       )
-      publishing_api_has_item(parent_taxon)
+      stub_publishing_api_has_item(parent_taxon)
       publishing_api_has_expanded_links(content_id: "CONTENT-ID-PARENT")
 
       Timecop.freeze do
@@ -178,7 +178,7 @@ RSpec.describe TaxonsController, type: :controller do
           },
         }
 
-        publishing_api_has_item(payload.merge(content_id: taxon.content_id))
+        stub_publishing_api_has_item(payload.merge(content_id: taxon.content_id))
         publishing_api_has_expanded_links(expanded_links.merge(content_id: taxon.content_id))
         stub_publishing_api_put_content(taxon.content_id, payload)
         stub_publishing_api_patch_links(taxon.content_id, links.to_json)

--- a/spec/controllers/taxons_controller_spec.rb
+++ b/spec/controllers/taxons_controller_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe TaxonsController, type: :controller do
       payload = Taxonomy::BuildTaxonPayload.call(taxon: taxon)
       stub_publishing_api_has_item(payload.merge(content_id: taxon.content_id))
       stub_publishing_api_has_expanded_links(content_id: taxon.content_id)
-      publishing_api_has_lookups(taxon.base_path => SecureRandom.uuid)
+      stub_publishing_api_has_lookups(taxon.base_path => SecureRandom.uuid)
 
       post :publish, params: { taxon_id: taxon.content_id }
 

--- a/spec/features/bulk_tagging_spec.rb
+++ b/spec/features/bulk_tagging_spec.rb
@@ -161,7 +161,7 @@ RSpec.feature "Bulk tagging", type: :feature do
   def when_i_create_tags
     publishing_api_has_links(content_id: "tax-doc-1", links: { taxons: [] })
     publishing_api_has_links(content_id: "tax-doc-2", links: { taxons: [] })
-    publishing_api_has_lookups(
+    stub_publishing_api_has_lookups(
       "/level-one/tax-doc-1" => "tax-doc-1",
       "/level-one/tax-doc-2" => "tax-doc-2",
     )
@@ -254,7 +254,7 @@ RSpec.feature "Bulk tagging", type: :feature do
       base_path: "/source-content",
     )
 
-    publishing_api_has_lookups(tag_mapping.content_base_path => "content-id")
+    stub_publishing_api_has_lookups(tag_mapping.content_base_path => "content-id")
     publishing_api_has_taxons(
       [
         basic_content_item(

--- a/spec/features/bulk_tagging_spec.rb
+++ b/spec/features/bulk_tagging_spec.rb
@@ -159,8 +159,8 @@ RSpec.feature "Bulk tagging", type: :feature do
   end
 
   def when_i_create_tags
-    publishing_api_has_links(content_id: "tax-doc-1", links: { taxons: [] })
-    publishing_api_has_links(content_id: "tax-doc-2", links: { taxons: [] })
+    stub_publishing_api_has_links(content_id: "tax-doc-1", links: { taxons: [] })
+    stub_publishing_api_has_links(content_id: "tax-doc-2", links: { taxons: [] })
     stub_publishing_api_has_lookups(
       "/level-one/tax-doc-1" => "tax-doc-1",
       "/level-one/tax-doc-2" => "tax-doc-2",
@@ -266,7 +266,7 @@ RSpec.feature "Bulk tagging", type: :feature do
         ),
       ],
     )
-    publishing_api_has_links(
+    stub_publishing_api_has_links(
       content_id: "content-id",
       links: { taxons: [] },
       version: 0,

--- a/spec/features/bulk_tagging_spec.rb
+++ b/spec/features/bulk_tagging_spec.rb
@@ -71,7 +71,7 @@ RSpec.feature "Bulk tagging", type: :feature do
       q: "browse",
     )
 
-    publishing_api_has_expanded_links(
+    stub_publishing_api_has_expanded_links(
       content_id: "collection-id",
       expanded_links: {
         documents: [

--- a/spec/features/bulk_tagging_spec.rb
+++ b/spec/features/bulk_tagging_spec.rb
@@ -87,7 +87,7 @@ RSpec.feature "Bulk tagging", type: :feature do
     stub_publishing_api_has_item(basic_content_item("Taxon 2"))
 
     # Used in the dropdown
-    publishing_api_has_linkables(
+    stub_publishing_api_has_linkables(
       [
         build_linkable(internal_name: "Taxon 1", content_id: "taxon-1"),
         build_linkable(internal_name: "Taxon 2", content_id: "taxon-2"),

--- a/spec/features/bulk_tagging_spec.rb
+++ b/spec/features/bulk_tagging_spec.rb
@@ -49,7 +49,7 @@ RSpec.feature "Bulk tagging", type: :feature do
       q: "Tax",
     )
 
-    publishing_api_has_item(document_collection)
+    stub_publishing_api_has_item(document_collection)
 
     publishing_api_has_content_items(
       [{
@@ -83,8 +83,8 @@ RSpec.feature "Bulk tagging", type: :feature do
   end
 
   def and_a_set_of_taxons
-    publishing_api_has_item(basic_content_item("Taxon 1"))
-    publishing_api_has_item(basic_content_item("Taxon 2"))
+    stub_publishing_api_has_item(basic_content_item("Taxon 1"))
+    stub_publishing_api_has_item(basic_content_item("Taxon 2"))
 
     # Used in the dropdown
     publishing_api_has_linkables(
@@ -247,7 +247,7 @@ RSpec.feature "Bulk tagging", type: :feature do
     tag_migration.tag_mappings << tag_mapping
     tag_migration.save!
 
-    publishing_api_has_item(
+    stub_publishing_api_has_item(
       content_id: tag_migration.source_content_id,
       title: "Source content",
       document_type: "taxon",

--- a/spec/features/bulk_updating_spec.rb
+++ b/spec/features/bulk_updating_spec.rb
@@ -44,14 +44,14 @@ RSpec.feature "Bulk updating", type: :feature do
 
     stub_requests_for_show_page(@parent_taxon)
 
-    publishing_api_has_links(
+    stub_publishing_api_has_links(
       content_id: @parent_content_id,
       links: {
         child_taxons: [@child_content_id],
       },
     )
 
-    publishing_api_has_links(
+    stub_publishing_api_has_links(
       content_id: @child_content_id,
       links: {
         parent: [@parent_content_id],

--- a/spec/features/bulk_updating_spec.rb
+++ b/spec/features/bulk_updating_spec.rb
@@ -95,8 +95,8 @@ RSpec.feature "Bulk updating", type: :feature do
 
     # We need to make a get request for each item to determine whether the taxon
     # is published or not
-    publishing_api_has_item(@parent_taxon)
-    publishing_api_has_item(@child_taxon)
+    stub_publishing_api_has_item(@parent_taxon)
+    stub_publishing_api_has_item(@child_taxon)
     stub_any_publishing_api_put_content
 
     click_button "Confirm bulk update"

--- a/spec/features/bulk_updating_spec.rb
+++ b/spec/features/bulk_updating_spec.rb
@@ -58,14 +58,14 @@ RSpec.feature "Bulk updating", type: :feature do
       },
     )
 
-    publishing_api_has_expanded_links(
+    stub_publishing_api_has_expanded_links(
       content_id: @parent_content_id,
       expanded_links: {
         child_taxons: [@child_taxon],
       },
     )
 
-    publishing_api_has_expanded_links(
+    stub_publishing_api_has_expanded_links(
       content_id: @child_content_id,
       expanded_links: {
         parent_taxons: [@parent_taxon],

--- a/spec/features/delete_taxon_spec.rb
+++ b/spec/features/delete_taxon_spec.rb
@@ -181,7 +181,7 @@ RSpec.feature "Delete Taxon", type: :feature do
 
   def when_i_confirm_deletion
     Sidekiq::Testing.inline! do
-      @get_content_request = publishing_api_has_item(stubbed_taxons[0])
+      @get_content_request = stub_publishing_api_has_item(stubbed_taxons[0])
       @unpublish_request = stub_publishing_api_unpublish(@taxon_content_id, body: { type: :redirect, alternative_path: "/alpha-taxonomy/vehicle-plating" }.to_json)
       click_on "Delete and redirect"
     end
@@ -191,7 +191,7 @@ RSpec.feature "Delete Taxon", type: :feature do
     parent_taxon = taxon_with_details(
       "root", other_fields: { base_path: "/level-one", content_id: "CONTENT-ID-PARENT" }
     )
-    publishing_api_has_item(parent_taxon)
+    stub_publishing_api_has_item(parent_taxon)
     publishing_api_has_links(content_id: "CONTENT-ID-PARENT")
 
     @put_content_request = stub_publishing_api_put_content(@taxon_content_id, {})

--- a/spec/features/delete_taxon_spec.rb
+++ b/spec/features/delete_taxon_spec.rb
@@ -305,7 +305,7 @@ private
 
   def add_tagged_content(fields:)
     content_item = basic_content_item("tagged content")
-    publishing_api_has_linked_items(
+    stub_publishing_api_has_linked_items(
       [content_item],
       content_id: @taxon_content_id,
       link_type: "taxons",

--- a/spec/features/delete_taxon_spec.rb
+++ b/spec/features/delete_taxon_spec.rb
@@ -312,7 +312,7 @@ private
       fields: fields,
     )
 
-    publishing_api_has_lookups(content_item[:base_path] => content_item[:content_id])
+    stub_publishing_api_has_lookups(content_item[:base_path] => content_item[:content_id])
 
     publishing_api_has_links(
       content_id: content_item[:content_id],

--- a/spec/features/delete_taxon_spec.rb
+++ b/spec/features/delete_taxon_spec.rb
@@ -260,13 +260,13 @@ private
         parent_taxons: [@parent_taxon_content_id],
       },
     )
-    publishing_api_has_expanded_links(
+    stub_publishing_api_has_expanded_links(
       content_id: @taxon_content_id,
       expanded_links: {
         parent_taxons: [@parent_taxon],
       },
     )
-    publishing_api_has_expanded_links(
+    stub_publishing_api_has_expanded_links(
       content_id: @parent_taxon_content_id,
       expanded_links: {
         child_taxons: [@taxon],
@@ -289,13 +289,13 @@ private
         child_taxons: [@child_taxon_content_id],
       },
     )
-    publishing_api_has_expanded_links(
+    stub_publishing_api_has_expanded_links(
       content_id: @taxon_content_id,
       expanded_links: {
         child_taxons: [@child_taxon],
       },
     )
-    publishing_api_has_expanded_links(
+    stub_publishing_api_has_expanded_links(
       content_id: @child_taxon_content_id,
       expanded_links: {
         parent_taxons: [@taxon],

--- a/spec/features/delete_taxon_spec.rb
+++ b/spec/features/delete_taxon_spec.rb
@@ -130,7 +130,7 @@ RSpec.feature "Delete Taxon", type: :feature do
 
     # Override the `links` call in stub_requests_for_show_page
     # TODO: extend stub_requests_for_show_page to make this easier
-    publishing_api_has_links(
+    stub_publishing_api_has_links(
       content_id: @taxon_content_id,
       links: {
         parent_taxons: %w[CONTENT-ID-PARENT],
@@ -192,7 +192,7 @@ RSpec.feature "Delete Taxon", type: :feature do
       "root", other_fields: { base_path: "/level-one", content_id: "CONTENT-ID-PARENT" }
     )
     stub_publishing_api_has_item(parent_taxon)
-    publishing_api_has_links(content_id: "CONTENT-ID-PARENT")
+    stub_publishing_api_has_links(content_id: "CONTENT-ID-PARENT")
 
     @put_content_request = stub_publishing_api_put_content(@taxon_content_id, {})
     @patch_links_request = stub_publishing_api_patch_links(@taxon_content_id, {})
@@ -254,7 +254,7 @@ private
     #
     # Stub realistic values for links and expanded links to correctly render
     # the tree on the taxon show page
-    publishing_api_has_links(
+    stub_publishing_api_has_links(
       content_id: @taxon_content_id,
       links: {
         parent_taxons: [@parent_taxon_content_id],
@@ -283,7 +283,7 @@ private
     #
     # Stub realistic values for links and expanded links to correctly render
     # the tree on the taxon show page
-    publishing_api_has_links(
+    stub_publishing_api_has_links(
       content_id: @taxon_content_id,
       links: {
         child_taxons: [@child_taxon_content_id],
@@ -314,7 +314,7 @@ private
 
     stub_publishing_api_has_lookups(content_item[:base_path] => content_item[:content_id])
 
-    publishing_api_has_links(
+    stub_publishing_api_has_links(
       content_id: content_item[:content_id],
       links: {
         taxons: [@taxon_content_id],

--- a/spec/features/download_tagged_content_spec.rb
+++ b/spec/features/download_tagged_content_spec.rb
@@ -51,7 +51,7 @@ RSpec.feature "Download taggings", type: :feature do
        },
     )
 
-    publishing_api_has_content(
+    stub_publishing_api_has_content(
       [{ "content_id" => "org-content-id", "title" => "org title" }],
       document_type: "organisation",
       fields: %w[content_id title],

--- a/spec/features/download_tagged_content_spec.rb
+++ b/spec/features/download_tagged_content_spec.rb
@@ -35,7 +35,7 @@ RSpec.feature "Download taggings", type: :feature do
       },
     )
 
-    publishing_api_has_linked_items(
+    stub_publishing_api_has_linked_items(
       [content_item],
       content_id: @content_id,
       link_type: "taxons",

--- a/spec/features/download_tagged_content_spec.rb
+++ b/spec/features/download_tagged_content_spec.rb
@@ -42,7 +42,7 @@ RSpec.feature "Download taggings", type: :feature do
       fields: Taxonomy::TaxonomyExport::COLUMNS,
     )
 
-    publishing_api_has_links_for_content_ids(
+    stub_publishing_api_has_links_for_content_ids(
       "tagged-content" =>
        {
          "links" => {

--- a/spec/features/move_content_between_taxons_spec.rb
+++ b/spec/features/move_content_between_taxons_spec.rb
@@ -97,7 +97,7 @@ RSpec.feature "Move content between Taxons", type: :feature do
     stub_publishing_api_has_item(@source_taxon)
     stub_publishing_api_has_item(@dest_taxon)
 
-    publishing_api_has_linkables(
+    stub_publishing_api_has_linkables(
       [@source_taxon_for_select, @dest_taxon_for_select],
       document_type: "taxon",
     )

--- a/spec/features/move_content_between_taxons_spec.rb
+++ b/spec/features/move_content_between_taxons_spec.rb
@@ -94,8 +94,8 @@ RSpec.feature "Move content between Taxons", type: :feature do
     )
 
     publishing_api_has_taxons([@source_taxon, @dest_taxon])
-    publishing_api_has_item(@source_taxon)
-    publishing_api_has_item(@dest_taxon)
+    stub_publishing_api_has_item(@source_taxon)
+    stub_publishing_api_has_item(@dest_taxon)
 
     publishing_api_has_linkables(
       [@source_taxon_for_select, @dest_taxon_for_select],

--- a/spec/features/move_content_between_taxons_spec.rb
+++ b/spec/features/move_content_between_taxons_spec.rb
@@ -81,7 +81,7 @@ RSpec.feature "Move content between Taxons", type: :feature do
       links: {},
       version: 1,
     )
-    publishing_api_has_expanded_links(
+    stub_publishing_api_has_expanded_links(
       content_id: @source_taxon[:content_id],
       expanded_links: {},
     )

--- a/spec/features/move_content_between_taxons_spec.rb
+++ b/spec/features/move_content_between_taxons_spec.rb
@@ -76,7 +76,7 @@ RSpec.feature "Move content between Taxons", type: :feature do
     @document1 = basic_content_item("Tagged content 1")
     @document2 = basic_content_item("Tagged content 2")
 
-    publishing_api_has_links(
+    stub_publishing_api_has_links(
       content_id: @source_taxon[:content_id],
       links: {},
       version: 1,
@@ -194,7 +194,7 @@ private
 
   def assert_content_items_have_been_moved_for_document(document, source, dest)
     # First we fetch existing links
-    publishing_api_has_links(
+    stub_publishing_api_has_links(
       content_id: document[:content_id],
       links: { taxons: [source[:content_id]] },
       version: 1,

--- a/spec/features/move_content_between_taxons_spec.rb
+++ b/spec/features/move_content_between_taxons_spec.rb
@@ -147,7 +147,7 @@ RSpec.feature "Move content between Taxons", type: :feature do
 
   def and_all_content_can_be_moved_when_i_start_the_content_move
     # Lookups to fetch the content ID based on existing base paths
-    publishing_api_has_lookups(
+    stub_publishing_api_has_lookups(
       @document1[:base_path] => @document1[:content_id],
       @document2[:base_path] => @document2[:content_id],
     )
@@ -166,7 +166,7 @@ RSpec.feature "Move content between Taxons", type: :feature do
   end
 
   def and_only_published_content_can_be_moved_when_i_start_the_content_move
-    publishing_api_has_lookups(
+    stub_publishing_api_has_lookups(
       @document2[:base_path] => @document2[:content_id],
     )
 

--- a/spec/features/project_spec.rb
+++ b/spec/features/project_spec.rb
@@ -183,7 +183,7 @@ RSpec.feature "Projects", type: :feature do
   end
 
   def and_the_publishing_api_can_find_the_content_items_in_the_remote_spreadsheet
-    publishing_api_has_lookups(
+    stub_publishing_api_has_lookups(
       "/vat-rates" => "f838c22a-b2aa-49be-bd95-153f593293a3",
       "/passport-fees" => "8b59b474-9775-4366-97ee-97a66740411c",
     )

--- a/spec/features/related_item_tagging_spec.rb
+++ b/spec/features/related_item_tagging_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe "Tagging content", type: :feature do
   def given_we_can_populate_the_dropdowns_with_content_from_publishing_api
     # In this test we don't care about empty dropdowns
     %w[topic taxon organisation mainstream_browse_page need].each do |document_type|
-      publishing_api_has_linkables([], document_type: document_type)
+      stub_publishing_api_has_linkables([], document_type: document_type)
     end
   end
 

--- a/spec/features/related_item_tagging_spec.rb
+++ b/spec/features/related_item_tagging_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "Tagging content", type: :feature do
   end
 
   def given_a_content_item_exists
-    publishing_api_has_lookups(
+    stub_publishing_api_has_lookups(
       "/my-content-item" => "MY-CONTENT-ID",
     )
 

--- a/spec/features/tag_a_page_spec.rb
+++ b/spec/features/tag_a_page_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe "Tagging content", type: :feature do
   context "with javascript disabled", type: :feature, js: false do
     scenario "the user sets a new related link" do
       given_there_is_a_content_item_with_expanded_links(ordered_related_items: [example_topic])
-      publishing_api_has_lookups(
+      stub_publishing_api_has_lookups(
         example_topic["base_path"] => example_topic["content_id"],
         "/pay-vat" => "a484eaea-eeb6-48fa-92a7-b67c6cd414f6",
       )
@@ -98,7 +98,7 @@ RSpec.describe "Tagging content", type: :feature do
 
     scenario "the user sets an invalid related link" do
       given_there_is_a_content_item_with_expanded_links(ordered_related_items: [example_topic])
-      publishing_api_has_lookups(
+      stub_publishing_api_has_lookups(
         example_topic["base_path"] => example_topic["content_id"],
       )
       and_i_am_on_the_page_for_the_item
@@ -111,7 +111,7 @@ RSpec.describe "Tagging content", type: :feature do
 
     scenario "the user sets a new valid and invalid related link" do
       given_there_is_a_content_item_with_expanded_links(ordered_related_items: [example_topic])
-      publishing_api_has_lookups(
+      stub_publishing_api_has_lookups(
         example_topic["base_path"] => example_topic["content_id"],
         "/pay-vat" => "a484eaea-eeb6-48fa-92a7-b67c6cd414f6",
       )
@@ -126,7 +126,7 @@ RSpec.describe "Tagging content", type: :feature do
 
     scenario "the user changes a suggested related link to be invalid" do
       given_there_is_a_content_item_with_expanded_links(suggested_ordered_related_items: [example_topic])
-      publishing_api_has_lookups(
+      stub_publishing_api_has_lookups(
         example_topic["base_path"] => example_topic["content_id"],
       )
       and_i_am_on_the_page_for_the_item
@@ -139,7 +139,7 @@ RSpec.describe "Tagging content", type: :feature do
 
     scenario "the user removes suggested related links" do
       given_there_is_a_content_item_with_expanded_links(suggested_ordered_related_items: [example_topic])
-      publishing_api_has_lookups(
+      stub_publishing_api_has_lookups(
         example_topic["base_path"] => example_topic["content_id"],
         "/pay-vat" => "a484eaea-eeb6-48fa-92a7-b67c6cd414f6",
       )
@@ -160,7 +160,7 @@ RSpec.describe "Tagging content", type: :feature do
 
     scenario "the user does not see suggested related links when no suggested links exist" do
       given_there_is_a_content_item_with_expanded_links(ordered_related_items: [])
-      publishing_api_has_lookups(
+      stub_publishing_api_has_lookups(
         example_topic["base_path"] => example_topic["content_id"],
         "/pay-vat" => "a484eaea-eeb6-48fa-92a7-b67c6cd414f6",
       )
@@ -188,7 +188,7 @@ RSpec.describe "Tagging content", type: :feature do
   end
 
   def given_there_is_a_content_item_with_expanded_links(**expanded_links)
-    publishing_api_has_lookups(
+    stub_publishing_api_has_lookups(
       "/my-content-item" => "MY-CONTENT-ID",
     )
 
@@ -217,7 +217,7 @@ RSpec.describe "Tagging content", type: :feature do
 
   def and_i_fill_a_unknown_base_path_to_my_content_item
     # Publishing API returns nothing if the content item doesn't exist.
-    publishing_api_has_lookups({})
+    stub_publishing_api_has_lookups({})
 
     fill_in "content_lookup_form_base_path", with: "/an-unknown-content-item"
     click_on I18n.t("taggings.search")

--- a/spec/features/tag_facets_to_a_page_spec.rb
+++ b/spec/features/tag_facets_to_a_page_spec.rb
@@ -175,7 +175,7 @@ RSpec.describe "Tagging content with facets", type: :feature do
   end
 
   def given_there_is_a_content_item_with_expanded_links(**expanded_links)
-    publishing_api_has_lookups(
+    stub_publishing_api_has_lookups(
       "/my-content-item" => "MY-CONTENT-ID",
     )
 

--- a/spec/features/tag_facets_to_a_page_spec.rb
+++ b/spec/features/tag_facets_to_a_page_spec.rb
@@ -288,7 +288,7 @@ RSpec.describe "Tagging content with facets", type: :feature do
   end
 
   def publishing_api_has_facet_values_linkables(labels)
-    publishing_api_has_linkables(
+    stub_publishing_api_has_linkables(
       stubbed_facet_values.select { |fv| labels.include?(fv["title"]) },
       document_type: "facet_value",
     )

--- a/spec/features/tag_importer_spec.rb
+++ b/spec/features/tag_importer_spec.rb
@@ -167,7 +167,7 @@ RSpec.feature "Tag importer", type: :feature do
   end
 
   def and_confirming_this_will_import_taggings
-    publishing_api_has_lookups(google_sheet_content_items)
+    stub_publishing_api_has_lookups(google_sheet_content_items)
     publishing_api_has_links(content_id: "content-2-cid", links: { taxons: [] })
     publishing_api_has_links(content_id: "content-1-cid", links: { taxons: [] })
     link_update1 = stub_publishing_api_patch_links(
@@ -195,7 +195,7 @@ RSpec.feature "Tag importer", type: :feature do
   end
 
   def and_confirming_only_valid_tags_will_be_imported
-    publishing_api_has_lookups(google_sheet_content_items_with_draft)
+    stub_publishing_api_has_lookups(google_sheet_content_items_with_draft)
     publishing_api_has_links(content_id: "content-2-cid", links: { taxons: [] })
     publishing_api_has_links(content_id: "content-1-cid", links: { taxons: [] })
     link_update1 = stub_publishing_api_patch_links(

--- a/spec/features/tag_importer_spec.rb
+++ b/spec/features/tag_importer_spec.rb
@@ -168,8 +168,8 @@ RSpec.feature "Tag importer", type: :feature do
 
   def and_confirming_this_will_import_taggings
     stub_publishing_api_has_lookups(google_sheet_content_items)
-    publishing_api_has_links(content_id: "content-2-cid", links: { taxons: [] })
-    publishing_api_has_links(content_id: "content-1-cid", links: { taxons: [] })
+    stub_publishing_api_has_links(content_id: "content-2-cid", links: { taxons: [] })
+    stub_publishing_api_has_links(content_id: "content-1-cid", links: { taxons: [] })
     link_update1 = stub_publishing_api_patch_links(
       "content-1-cid",
       links: {
@@ -196,8 +196,8 @@ RSpec.feature "Tag importer", type: :feature do
 
   def and_confirming_only_valid_tags_will_be_imported
     stub_publishing_api_has_lookups(google_sheet_content_items_with_draft)
-    publishing_api_has_links(content_id: "content-2-cid", links: { taxons: [] })
-    publishing_api_has_links(content_id: "content-1-cid", links: { taxons: [] })
+    stub_publishing_api_has_links(content_id: "content-2-cid", links: { taxons: [] })
+    stub_publishing_api_has_links(content_id: "content-1-cid", links: { taxons: [] })
     link_update1 = stub_publishing_api_patch_links(
       "content-1-cid",
       links: {

--- a/spec/features/tagging_during_migration_spec.rb
+++ b/spec/features/tagging_during_migration_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "Tagging content during migration", type: :feature do
   end
 
   def given_there_is_an_item_that_can_have_only_one_link_type
-    publishing_api_has_lookups(
+    stub_publishing_api_has_lookups(
       "/my-content-item" => "MY-CONTENT-ID",
     )
 

--- a/spec/features/tagging_history_spec.rb
+++ b/spec/features/tagging_history_spec.rb
@@ -61,7 +61,7 @@ private
   end
 
   def given_that_the_publishing_api_has_an_individual_taxon
-    publishing_api_has_item(individual_taxon)
+    stub_publishing_api_has_item(individual_taxon)
   end
 
   def given_there_are_some_link_changes_for_an_individual_taxon

--- a/spec/features/taxon_history_spec.rb
+++ b/spec/features/taxon_history_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature "Taxon history" do
   end
 
   def when_i_visit_the_taxon_edit_form
-    publishing_api_has_linked_items([], content_id: @taxon["content_id"], link_type: "taxons")
+    stub_publishing_api_has_linked_items([], content_id: @taxon["content_id"], link_type: "taxons")
     stub_request(:get, "https://publishing-api.test.gov.uk/v2/content/#{@taxon['content_id']}")
       .to_return(body: @taxon.to_json)
     stub_request(:get, "https://publishing-api.test.gov.uk/v2/expanded-links/#{@taxon['content_id']}")

--- a/spec/features/taxonomy_editing_spec.rb
+++ b/spec/features/taxonomy_editing_spec.rb
@@ -312,7 +312,7 @@ RSpec.feature "Taxonomy editing" do
     @publish_item = stub_request(:post, %r{https://publishing-api.test.gov.uk/v2/content/.*/publish})
       .to_return(status: 200, body: "", headers: {})
 
-    publishing_api_has_lookups("/legacy-taxon" => "CONTENT-ID-LEGACY-TAXON")
+    stub_publishing_api_has_lookups("/legacy-taxon" => "CONTENT-ID-LEGACY-TAXON")
 
     stub_publishing_api_has_expanded_links(
       content_id: @taxon1[:content_id],
@@ -453,7 +453,7 @@ RSpec.feature "Taxonomy editing" do
 
   def then_the_legacy_taxons_should_be_saved
     stub_any_publishing_api_put_content
-    publishing_api_has_lookups(
+    stub_publishing_api_has_lookups(
       "/legacy-taxon" => "CONTENT-ID-LEGACY-TAXON",
       "/another-legacy-taxon" => "CONTENT-ID-ANOTHER-LEGACY-TAXON",
     )

--- a/spec/features/taxonomy_editing_spec.rb
+++ b/spec/features/taxonomy_editing_spec.rb
@@ -215,7 +215,7 @@ RSpec.feature "Taxonomy editing" do
   end
 
   def when_i_visit_the_taxon_page
-    publishing_api_has_expanded_links(
+    stub_publishing_api_has_expanded_links(
       content_id: @taxon1[:content_id],
       expanded_links: {
         parent_taxons: [
@@ -242,7 +242,7 @@ RSpec.feature "Taxonomy editing" do
   end
 
   def when_i_visit_the_draft_taxon_page
-    publishing_api_has_expanded_links(
+    stub_publishing_api_has_expanded_links(
       content_id: @taxon2[:content_id],
       expanded_links: {},
     )
@@ -314,12 +314,12 @@ RSpec.feature "Taxonomy editing" do
 
     publishing_api_has_lookups("/legacy-taxon" => "CONTENT-ID-LEGACY-TAXON")
 
-    publishing_api_has_expanded_links(
+    stub_publishing_api_has_expanded_links(
       content_id: @taxon1[:content_id],
       expanded_links: {},
     )
 
-    publishing_api_has_expanded_links(
+    stub_publishing_api_has_expanded_links(
       content_id: @taxon2[:content_id],
       expanded_links: {},
     )

--- a/spec/features/taxonomy_editing_spec.rb
+++ b/spec/features/taxonomy_editing_spec.rb
@@ -192,7 +192,7 @@ RSpec.feature "Taxonomy editing" do
   end
 
   def given_there_are_taxons
-    publishing_api_has_linkables(
+    stub_publishing_api_has_linkables(
       [@linkable_taxon1, @linkable_taxon2, @linkable_taxon3],
       document_type: "taxon",
     )

--- a/spec/features/viewing_taxons_spec.rb
+++ b/spec/features/viewing_taxons_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe "Viewing taxons" do
   end
 
   def given_a_taxonomy
-    publishing_api_has_item(fruits)
+    stub_publishing_api_has_item(fruits)
     publishing_api_has_expanded_links(
       content_id: fruits["content_id"],
       expanded_links: {
@@ -137,7 +137,7 @@ RSpec.describe "Viewing taxons" do
       },
     )
 
-    publishing_api_has_item(apples)
+    stub_publishing_api_has_item(apples)
     publishing_api_has_expanded_links(
       content_id: apples["content_id"],
       expanded_links: {
@@ -150,7 +150,7 @@ RSpec.describe "Viewing taxons" do
   end
 
   def given_a_taxonomy_with_associated_taxons
-    publishing_api_has_item(fruits)
+    stub_publishing_api_has_item(fruits)
     publishing_api_has_expanded_links(
       content_id: fruits["content_id"],
       expanded_links: {
@@ -161,9 +161,9 @@ RSpec.describe "Viewing taxons" do
       },
     )
 
-    publishing_api_has_item(apples)
-    publishing_api_has_item(pears)
-    publishing_api_has_item(oranges)
+    stub_publishing_api_has_item(apples)
+    stub_publishing_api_has_item(pears)
+    stub_publishing_api_has_item(oranges)
     publishing_api_has_expanded_links(
       content_id: apples["content_id"],
       expanded_links: {
@@ -176,7 +176,7 @@ RSpec.describe "Viewing taxons" do
   end
 
   def given_a_previously_published_draft_taxon
-    publishing_api_has_item(previously_published)
+    stub_publishing_api_has_item(previously_published)
     publishing_api_has_expanded_links(
       content_id: previously_published["content_id"],
       expanded_links: {
@@ -230,7 +230,7 @@ RSpec.describe "Viewing taxons" do
   end
 
   def when_i_view_the_lowest_level_taxon
-    publishing_api_has_item(cox)
+    stub_publishing_api_has_item(cox)
     publishing_api_has_links(cox)
 
     publishing_api_has_expanded_links(

--- a/spec/features/viewing_taxons_spec.rb
+++ b/spec/features/viewing_taxons_spec.rb
@@ -231,7 +231,7 @@ RSpec.describe "Viewing taxons" do
 
   def when_i_view_the_lowest_level_taxon
     stub_publishing_api_has_item(cox)
-    publishing_api_has_links(cox)
+    stub_publishing_api_has_links(cox)
 
     stub_publishing_api_has_expanded_links(
       content_id: cox["content_id"],

--- a/spec/features/viewing_taxons_spec.rb
+++ b/spec/features/viewing_taxons_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe "Viewing taxons" do
 
   def given_a_taxonomy
     stub_publishing_api_has_item(fruits)
-    publishing_api_has_expanded_links(
+    stub_publishing_api_has_expanded_links(
       content_id: fruits["content_id"],
       expanded_links: {
         child_taxons: [
@@ -138,7 +138,7 @@ RSpec.describe "Viewing taxons" do
     )
 
     stub_publishing_api_has_item(apples)
-    publishing_api_has_expanded_links(
+    stub_publishing_api_has_expanded_links(
       content_id: apples["content_id"],
       expanded_links: {
         parent_taxons: [fruits],
@@ -151,7 +151,7 @@ RSpec.describe "Viewing taxons" do
 
   def given_a_taxonomy_with_associated_taxons
     stub_publishing_api_has_item(fruits)
-    publishing_api_has_expanded_links(
+    stub_publishing_api_has_expanded_links(
       content_id: fruits["content_id"],
       expanded_links: {
         child_taxons: [
@@ -164,7 +164,7 @@ RSpec.describe "Viewing taxons" do
     stub_publishing_api_has_item(apples)
     stub_publishing_api_has_item(pears)
     stub_publishing_api_has_item(oranges)
-    publishing_api_has_expanded_links(
+    stub_publishing_api_has_expanded_links(
       content_id: apples["content_id"],
       expanded_links: {
         parent_taxons: [fruits],
@@ -177,7 +177,7 @@ RSpec.describe "Viewing taxons" do
 
   def given_a_previously_published_draft_taxon
     stub_publishing_api_has_item(previously_published)
-    publishing_api_has_expanded_links(
+    stub_publishing_api_has_expanded_links(
       content_id: previously_published["content_id"],
       expanded_links: {
         parent_taxons: [fruits],
@@ -233,7 +233,7 @@ RSpec.describe "Viewing taxons" do
     stub_publishing_api_has_item(cox)
     publishing_api_has_links(cox)
 
-    publishing_api_has_expanded_links(
+    stub_publishing_api_has_expanded_links(
       content_id: cox["content_id"],
       expanded_links: {
         parent_taxons: [
@@ -246,7 +246,7 @@ RSpec.describe "Viewing taxons" do
       },
     )
 
-    publishing_api_has_expanded_links(
+    stub_publishing_api_has_expanded_links(
       content_id: apples["content_id"],
       expanded_links: {
         parent_taxons: [fruits],

--- a/spec/forms/content_lookup_form_spec.rb
+++ b/spec/forms/content_lookup_form_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe ContentLookupForm do
     end
 
     it "is invalid when the path not found on GOV.UK" do
-      publishing_api_has_lookups({})
+      stub_publishing_api_has_lookups({})
 
       form = ContentLookupForm.new(base_path: "/browse")
 
@@ -23,7 +23,7 @@ RSpec.describe ContentLookupForm do
     end
 
     it "is valid when the path is an absolute_path found on GOV.UK" do
-      publishing_api_has_lookups(
+      stub_publishing_api_has_lookups(
         "/browse" => "a96c1542-..",
       )
 
@@ -33,7 +33,7 @@ RSpec.describe ContentLookupForm do
     end
 
     it "treats paths and URLs the same" do
-      publishing_api_has_lookups(
+      stub_publishing_api_has_lookups(
         "/browse" => "a96c1542-..",
       )
 

--- a/spec/forms/new_project_form_spec.rb
+++ b/spec/forms/new_project_form_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe NewProjectForm, "#create" do
       https://www.gov.uk/path,Title,Description
     CSV
 
-    publishing_api_has_lookups("/path" => "f838c22a-b2aa-49be-bd95-153f593293a3")
+    stub_publishing_api_has_lookups("/path" => "f838c22a-b2aa-49be-bd95-153f593293a3")
 
     form = NewProjectForm.new(valid_params)
 
@@ -59,7 +59,7 @@ RSpec.describe NewProjectForm, "#create" do
       https://www.gov.uk/path,Title,Description
     CSV
 
-    publishing_api_has_lookups("/path" => "f838c22a-b2aa-49be-bd95-153f593293a3")
+    stub_publishing_api_has_lookups("/path" => "f838c22a-b2aa-49be-bd95-153f593293a3")
 
     form = NewProjectForm.new(valid_params)
 

--- a/spec/lib/description_remover_spec.rb
+++ b/spec/lib/description_remover_spec.rb
@@ -3,15 +3,15 @@ require "description_remover"
 require "gds_api/test_helpers/content_store"
 
 include ::GdsApi::TestHelpers::ContentStore
-include ::GdsApi::TestHelpers::PublishingApiV2
+include ::GdsApi::TestHelpers::PublishingApi
 
 RSpec.describe DescriptionRemover do
   context "appropriate taxons are updated" do
     before do
       content_store_has_item("/work", taxon.to_json, draft: true)
-      publishing_api_has_item(published_child_taxon)
-      publishing_api_has_item(published_child_taxon_with_draft)
-      publishing_api_has_item(draft_taxon)
+      stub_publishing_api_has_item(published_child_taxon)
+      stub_publishing_api_has_item(published_child_taxon_with_draft)
+      stub_publishing_api_has_item(draft_taxon)
 
       stub_any_publishing_api_put_content
       stub_any_publishing_api_publish

--- a/spec/lib/description_remover_spec.rb
+++ b/spec/lib/description_remover_spec.rb
@@ -8,7 +8,7 @@ include ::GdsApi::TestHelpers::PublishingApi
 RSpec.describe DescriptionRemover do
   context "appropriate taxons are updated" do
     before do
-      content_store_has_item("/work", taxon.to_json, draft: true)
+      stub_content_store_has_item("/work", taxon.to_json, draft: true)
       stub_publishing_api_has_item(published_child_taxon)
       stub_publishing_api_has_item(published_child_taxon_with_draft)
       stub_publishing_api_has_item(draft_taxon)

--- a/spec/lib/project_builder_spec.rb
+++ b/spec/lib/project_builder_spec.rb
@@ -24,13 +24,13 @@ RSpec.describe ProjectBuilder, ".call" do
   end
 
   it "creates a new project" do
-    publishing_api_has_lookups({})
+    stub_publishing_api_has_lookups({})
 
     expect { build_project }.to change { Project.count }.by(1)
   end
 
   it "creates new project content items" do
-    publishing_api_has_lookups(
+    stub_publishing_api_has_lookups(
       "/url_one" => SecureRandom.uuid,
       "/url_two" => SecureRandom.uuid,
     )
@@ -40,7 +40,7 @@ RSpec.describe ProjectBuilder, ".call" do
   end
 
   it "finds the content items' IDs from the Publishing API" do
-    publishing_api_has_lookups("/url_one" => "cbccfe81-8cff-4e0f-ad6f-d3631623a9a7")
+    stub_publishing_api_has_lookups("/url_one" => "cbccfe81-8cff-4e0f-ad6f-d3631623a9a7")
 
     expect { build_project(content_items: [{ url: "https://www.gov.uk/url_one" }]) }
       .to change { ProjectContentItem.count }.by(1)
@@ -56,7 +56,7 @@ RSpec.describe ProjectBuilder, ".call" do
   it "raises an error and rollbacks the transaction when attempting to import duplicate content" do
     create(:project_content_item, content_id: "cbccfe81-8cff-4e0f-ad6f-d3631623a9a7")
 
-    publishing_api_has_lookups("/url_one" => "cbccfe81-8cff-4e0f-ad6f-d3631623a9a7")
+    stub_publishing_api_has_lookups("/url_one" => "cbccfe81-8cff-4e0f-ad6f-d3631623a9a7")
 
     expect(Project.count).to eq(0)
     expect(ProjectContentItem.count).to eq(1)

--- a/spec/lib/tagged_content_exporter_spec.rb
+++ b/spec/lib/tagged_content_exporter_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe TaggedContentExporter do
           ],
         }.to_json)
 
-      publishing_api_has_expanded_links(
+      stub_publishing_api_has_expanded_links(
         "content_id" => "taxon-123",
         "expanded_links" => {
           "available_translations" => [

--- a/spec/lib/tagged_content_exporter_spec.rb
+++ b/spec/lib/tagged_content_exporter_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe TaggedContentExporter do
              content_id: "1b99def9-7eaa-4fb4-a0d0-ea76f0c5c370",
              url: "https://www.gov.uk/government/publications/great-western-franchise-2013")
 
-      publishing_api_has_links(
+      stub_publishing_api_has_links(
         content_id: "1b99def9-7eaa-4fb4-a0d0-ea76f0c5c370",
         links: {
           taxons: %w[

--- a/spec/lib/tasks/eu_exit_business_finder_spec.rb
+++ b/spec/lib/tasks/eu_exit_business_finder_spec.rb
@@ -4,7 +4,7 @@ require "gds_api/test_helpers/publishing_api_v2"
 require "gds_api/test_helpers/search"
 
 RSpec.describe "eu_exit_business_finder:retag_documents_to_facet_values" do
-  include GdsApi::TestHelpers::PublishingApiV2
+  include GdsApi::TestHelpers::PublishingApi
   include GdsApi::TestHelpers::Search
   include PublishingApiHelper
 

--- a/spec/lib/tasks/facets/facet_group_spec.rb
+++ b/spec/lib/tasks/facets/facet_group_spec.rb
@@ -4,7 +4,7 @@ require "gds_api/test_helpers/publishing_api_v2"
 require "gds_api/test_helpers/search"
 
 RSpec.describe "facets:patch_links_to_facet_group" do
-  include GdsApi::TestHelpers::PublishingApiV2
+  include GdsApi::TestHelpers::PublishingApi
   include GdsApi::TestHelpers::Search
   include ContentItemHelper
   include PublishingApiHelper

--- a/spec/lib/tasks/taxonomy/validate_taxons_base_paths_spec.rb
+++ b/spec/lib/tasks/taxonomy/validate_taxons_base_paths_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe "taxonomy:validate_taxons_base_paths" do
     )
 
     stub_publishing_api_has_item(taxon_attributes)
-    publishing_api_has_expanded_links(taxon_attributes.slice(:content_id))
+    stub_publishing_api_has_expanded_links(taxon_attributes.slice(:content_id))
     stub_any_publishing_api_put_content
 
     expect {
@@ -79,7 +79,7 @@ RSpec.describe "taxonomy:validate_taxons_base_paths" do
     )
 
     stub_publishing_api_has_item(taxon_attributes)
-    publishing_api_has_expanded_links(taxon_attributes.slice(:content_id))
+    stub_publishing_api_has_expanded_links(taxon_attributes.slice(:content_id))
     stub_any_publishing_api_put_content
 
     expect {
@@ -126,7 +126,7 @@ RSpec.describe "taxonomy:validate_taxons_base_paths" do
     )
 
     stub_publishing_api_has_item(taxon_attributes)
-    publishing_api_has_expanded_links(taxon_attributes.slice(:content_id))
+    stub_publishing_api_has_expanded_links(taxon_attributes.slice(:content_id))
     stub_any_publishing_api_put_content
       .to_return(status: 422, body:
         {

--- a/spec/lib/tasks/taxonomy/validate_taxons_base_paths_spec.rb
+++ b/spec/lib/tasks/taxonomy/validate_taxons_base_paths_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe "taxonomy:validate_taxons_base_paths" do
   # /level-one
   #   /level-one/level-two
   def content_store_has_valid_two_level_tree
-    content_store_has_item(
+    stub_content_store_has_item(
       "/",
       {
         "base_path" => "/",
@@ -180,7 +180,7 @@ RSpec.describe "taxonomy:validate_taxons_base_paths" do
       }.to_json, draft: true
     )
 
-    content_store_has_item(
+    stub_content_store_has_item(
       "/level-one",
       {
         "base_path" => "/level-one",
@@ -199,7 +199,7 @@ RSpec.describe "taxonomy:validate_taxons_base_paths" do
       }.to_json, draft: true
     )
 
-    content_store_has_item(
+    stub_content_store_has_item(
       "/level-one/level-two",
       {
         "base_path" => "/level-one/level-two",
@@ -213,7 +213,7 @@ RSpec.describe "taxonomy:validate_taxons_base_paths" do
   # /level-one
   #   /some-other-path/level-two
   def content_store_has_tree_with_invalid_level_one_prefix
-    content_store_has_item(
+    stub_content_store_has_item(
       "/",
       {
         "base_path" => "/",
@@ -231,7 +231,7 @@ RSpec.describe "taxonomy:validate_taxons_base_paths" do
       }.to_json, draft: true
     )
 
-    content_store_has_item(
+    stub_content_store_has_item(
       "/level-one",
       {
         "base_path" => "/level-one",
@@ -250,7 +250,7 @@ RSpec.describe "taxonomy:validate_taxons_base_paths" do
       }.to_json, draft: true
     )
 
-    content_store_has_item(
+    stub_content_store_has_item(
       "/some-other-path/level-two",
       {
         "base_path" => "/some-other-path/level-two",
@@ -264,7 +264,7 @@ RSpec.describe "taxonomy:validate_taxons_base_paths" do
   # /level-one
   #   /imported-topic/topic/level-one/level-two
   def content_store_has_tree_with_long_base_path_structure
-    content_store_has_item(
+    stub_content_store_has_item(
       "/",
       {
         "base_path" => "/",
@@ -282,7 +282,7 @@ RSpec.describe "taxonomy:validate_taxons_base_paths" do
       }.to_json, draft: true
     )
 
-    content_store_has_item(
+    stub_content_store_has_item(
       "/level-one",
       {
         "base_path" => "/level-one",
@@ -301,7 +301,7 @@ RSpec.describe "taxonomy:validate_taxons_base_paths" do
       }.to_json, draft: true
     )
 
-    content_store_has_item(
+    stub_content_store_has_item(
       "/imported-topic/topic/level-one/level-two",
       {
         "base_path" => "/imported-topic/topic/level-one/level-two",
@@ -315,7 +315,7 @@ RSpec.describe "taxonomy:validate_taxons_base_paths" do
   # /level-one/taxon
   #   /level-one/level-two
   def content_store_has_tree_with_invalid_level_one_base_path
-    content_store_has_item(
+    stub_content_store_has_item(
       "/",
       {
         "base_path" => "/",
@@ -333,7 +333,7 @@ RSpec.describe "taxonomy:validate_taxons_base_paths" do
       }.to_json, draft: true
     )
 
-    content_store_has_item(
+    stub_content_store_has_item(
       "/level-one/taxon",
       {
         "base_path" => "/level-one/taxon",
@@ -352,7 +352,7 @@ RSpec.describe "taxonomy:validate_taxons_base_paths" do
       }.to_json, draft: true
     )
 
-    content_store_has_item(
+    stub_content_store_has_item(
       "/level-one/level-two",
       {
         "base_path" => "/level-one/level-two",

--- a/spec/lib/tasks/taxonomy/validate_taxons_base_paths_spec.rb
+++ b/spec/lib/tasks/taxonomy/validate_taxons_base_paths_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "taxonomy:validate_taxons_base_paths" do
       },
     )
 
-    publishing_api_has_item(taxon_attributes)
+    stub_publishing_api_has_item(taxon_attributes)
     publishing_api_has_expanded_links(taxon_attributes.slice(:content_id))
     stub_any_publishing_api_put_content
 
@@ -78,7 +78,7 @@ RSpec.describe "taxonomy:validate_taxons_base_paths" do
       },
     )
 
-    publishing_api_has_item(taxon_attributes)
+    stub_publishing_api_has_item(taxon_attributes)
     publishing_api_has_expanded_links(taxon_attributes.slice(:content_id))
     stub_any_publishing_api_put_content
 
@@ -125,7 +125,7 @@ RSpec.describe "taxonomy:validate_taxons_base_paths" do
       },
     )
 
-    publishing_api_has_item(taxon_attributes)
+    stub_publishing_api_has_item(taxon_attributes)
     publishing_api_has_expanded_links(taxon_attributes.slice(:content_id))
     stub_any_publishing_api_put_content
       .to_return(status: 422, body:

--- a/spec/lib/taxon_description_updater_spec.rb
+++ b/spec/lib/taxon_description_updater_spec.rb
@@ -45,8 +45,8 @@ RSpec.describe TaxonDescriptionUpdater do
   end
 
   before do
-    publishing_api_has_content(with_dots, per_page: 5000, q: "...", search_in: %w[description], states: %w[published draft])
-    publishing_api_has_content(with_tbc, per_page: 5000, q: "tbc", search_in: %w[description], states: %w[published draft])
+    stub_publishing_api_has_content(with_dots, per_page: 5000, q: "...", search_in: %w[description], states: %w[published draft])
+    stub_publishing_api_has_content(with_tbc, per_page: 5000, q: "tbc", search_in: %w[description], states: %w[published draft])
     stub_any_publishing_api_put_content
     stub_any_publishing_api_publish
 

--- a/spec/models/bulk_tagging/tag_mapping_spec.rb
+++ b/spec/models/bulk_tagging/tag_mapping_spec.rb
@@ -14,7 +14,7 @@ module BulkTagging
     describe "#content_id" do
       it "finds the content id from the base path" do
         content_id = "content-1-ID"
-        publishing_api_has_lookups(tag_mapping.content_base_path => content_id)
+        stub_publishing_api_has_lookups(tag_mapping.content_base_path => content_id)
 
         expect(tag_mapping.content_id).to eq(content_id)
       end

--- a/spec/models/remote_taxons_spec.rb
+++ b/spec/models/remote_taxons_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe RemoteTaxons do
     let(:child_taxon) { instance_double(Taxon, parent_content_id: parent_taxon_id) }
 
     before do
-      publishing_api_has_item(parent_taxon)
+      stub_publishing_api_has_item(parent_taxon)
       publishing_api_has_expanded_links(content_id: parent_taxon_id)
     end
 

--- a/spec/models/remote_taxons_spec.rb
+++ b/spec/models/remote_taxons_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe RemoteTaxons do
 
     before do
       stub_publishing_api_has_item(parent_taxon)
-      publishing_api_has_expanded_links(content_id: parent_taxon_id)
+      stub_publishing_api_has_expanded_links(content_id: parent_taxon_id)
     end
 
     it "returns the parent taxon for a given taxon" do

--- a/spec/models/taxonomy/expanded_taxonomy_spec.rb
+++ b/spec/models/taxonomy/expanded_taxonomy_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe Taxonomy::ExpandedTaxonomy do
       @rootless_parent = FactoryBot.build(:taxon_hash, title: "Rootless Parent")
       @rootless_child = FactoryBot.build(:taxon_hash, title: "Rootless Child")
 
-      publishing_api_has_item(@rootless_parent)
-      publishing_api_has_item(@rootless_child)
+      stub_publishing_api_has_item(@rootless_parent)
+      stub_publishing_api_has_item(@rootless_child)
 
       publishing_api_has_expanded_links(
         content_id: @rootless_parent["content_id"],
@@ -56,8 +56,8 @@ RSpec.describe Taxonomy::ExpandedTaxonomy do
   end
 
   before :each do
-    publishing_api_has_item(home_page)
-    publishing_api_has_item(food)
+    stub_publishing_api_has_item(home_page)
+    stub_publishing_api_has_item(food)
 
     publishing_api_has_expanded_links(
       content_id: GovukTaxonomy::ROOT_CONTENT_ID,
@@ -73,7 +73,7 @@ RSpec.describe Taxonomy::ExpandedTaxonomy do
       },
     )
 
-    publishing_api_has_item(apples)
+    stub_publishing_api_has_item(apples)
 
     publishing_api_has_expanded_links(
       content_id: apples["content_id"],

--- a/spec/models/taxonomy/expanded_taxonomy_spec.rb
+++ b/spec/models/taxonomy/expanded_taxonomy_spec.rb
@@ -24,14 +24,14 @@ RSpec.describe Taxonomy::ExpandedTaxonomy do
       stub_publishing_api_has_item(@rootless_parent)
       stub_publishing_api_has_item(@rootless_child)
 
-      publishing_api_has_expanded_links(
+      stub_publishing_api_has_expanded_links(
         content_id: @rootless_parent["content_id"],
         expanded_links: {
           child_taxons: [@rootless_child],
         },
       )
 
-      publishing_api_has_expanded_links(
+      stub_publishing_api_has_expanded_links(
         content_id: @rootless_child["content_id"],
         expanded_links: {
           parent_taxons: [@rootless_parent],
@@ -59,14 +59,14 @@ RSpec.describe Taxonomy::ExpandedTaxonomy do
     stub_publishing_api_has_item(home_page)
     stub_publishing_api_has_item(food)
 
-    publishing_api_has_expanded_links(
+    stub_publishing_api_has_expanded_links(
       content_id: GovukTaxonomy::ROOT_CONTENT_ID,
       expanded_links: {
         level_one_taxons: [apples],
       },
     )
 
-    publishing_api_has_expanded_links(
+    stub_publishing_api_has_expanded_links(
       content_id: food["content_id"],
       expanded_links: {
         root_taxon: [GovukTaxonomy::ROOT_CONTENT_ID],
@@ -75,7 +75,7 @@ RSpec.describe Taxonomy::ExpandedTaxonomy do
 
     stub_publishing_api_has_item(apples)
 
-    publishing_api_has_expanded_links(
+    stub_publishing_api_has_expanded_links(
       content_id: apples["content_id"],
       expanded_links: {
         parent_taxons: [fruits],
@@ -83,14 +83,14 @@ RSpec.describe Taxonomy::ExpandedTaxonomy do
       },
     )
 
-    publishing_api_has_expanded_links(
+    stub_publishing_api_has_expanded_links(
       content_id: bramley["content_id"],
       expanded_links: {
         parent_taxons: [apples],
       },
     )
 
-    publishing_api_has_expanded_links(
+    stub_publishing_api_has_expanded_links(
       content_id: cox["content_id"],
       expanded_links: {
         parent_taxons: [apples],

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -29,7 +29,7 @@ Capybara.javascript_driver = :rack_test
 DatabaseCleaner.strategy = :transaction
 
 RSpec.configure do |config|
-  config.include GdsApi::TestHelpers::PublishingApiV2
+  config.include GdsApi::TestHelpers::PublishingApi
   config.include FactoryBot::Syntax::Methods
 
   config.fixture_path = "#{::Rails.root}/spec/fixtures"

--- a/spec/services/bulk_tagging/build_tag_migration_spec.rb
+++ b/spec/services/bulk_tagging/build_tag_migration_spec.rb
@@ -41,8 +41,8 @@ module BulkTagging
 
     context "with 2 valid taxons and 2 content base paths" do
       before do
-        publishing_api_has_item(basic_content_item("Taxon 1", other_fields: { base_path: "/foo", content_id: "taxon-1" }))
-        publishing_api_has_item(basic_content_item("Taxon 2", other_fields: { base_path: "/ha", content_id: "taxon-2" }))
+        stub_publishing_api_has_item(basic_content_item("Taxon 1", other_fields: { base_path: "/foo", content_id: "taxon-1" }))
+        stub_publishing_api_has_item(basic_content_item("Taxon 2", other_fields: { base_path: "/ha", content_id: "taxon-2" }))
       end
 
       let(:tag_migration) do

--- a/spec/services/bulk_tagging/document_type_tagger_spec.rb
+++ b/spec/services/bulk_tagging/document_type_tagger_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe BulkTagging::DocumentTypeTagger do
   end
   context "there is a taxon, some content and links" do
     before :each do
-      publishing_api_has_item(content_id: @taxon_content_id)
+      stub_publishing_api_has_item(content_id: @taxon_content_id)
       publishing_api_has_content([{ content_id: "c1" }, { content_id: "c2" }],
                                  page: 1,
                                  document_type: "document_type",

--- a/spec/services/bulk_tagging/document_type_tagger_spec.rb
+++ b/spec/services/bulk_tagging/document_type_tagger_spec.rb
@@ -14,9 +14,9 @@ RSpec.describe BulkTagging::DocumentTypeTagger do
     before :each do
       stub_publishing_api_has_item(content_id: @taxon_content_id)
       stub_publishing_api_has_content([{ content_id: "c1" }, { content_id: "c2" }],
-                                 page: 1,
-                                 document_type: "document_type",
-                                 fields: %w[content_id])
+                                      page: 1,
+                                      document_type: "document_type",
+                                      fields: %w[content_id])
 
       stub_publishing_api_has_links(
         content_id: "c1",

--- a/spec/services/bulk_tagging/document_type_tagger_spec.rb
+++ b/spec/services/bulk_tagging/document_type_tagger_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe BulkTagging::DocumentTypeTagger do
   context "there is a taxon, some content and links" do
     before :each do
       stub_publishing_api_has_item(content_id: @taxon_content_id)
-      publishing_api_has_content([{ content_id: "c1" }, { content_id: "c2" }],
+      stub_publishing_api_has_content([{ content_id: "c1" }, { content_id: "c2" }],
                                  page: 1,
                                  document_type: "document_type",
                                  fields: %w[content_id])

--- a/spec/services/bulk_tagging/document_type_tagger_spec.rb
+++ b/spec/services/bulk_tagging/document_type_tagger_spec.rb
@@ -18,14 +18,14 @@ RSpec.describe BulkTagging::DocumentTypeTagger do
                                  document_type: "document_type",
                                  fields: %w[content_id])
 
-      publishing_api_has_links(
+      stub_publishing_api_has_links(
         content_id: "c1",
         links: {
           taxons: %w[569a9ee5-c195-4b7f-b9dc-edc17a09113f],
         },
         version: 6,
       )
-      publishing_api_has_links(
+      stub_publishing_api_has_links(
         "content_id": "c2",
         "links": {},
         "version": 10,

--- a/spec/services/bulk_tagging/document_type_tagger_spec.rb
+++ b/spec/services/bulk_tagging/document_type_tagger_spec.rb
@@ -1,5 +1,5 @@
 require "rails_helper"
-include GdsApi::TestHelpers::PublishingApiV2
+include GdsApi::TestHelpers::PublishingApi
 
 RSpec.describe BulkTagging::DocumentTypeTagger do
   before :each do

--- a/spec/services/bulk_tagging/document_type_tagger_spec.rb
+++ b/spec/services/bulk_tagging/document_type_tagger_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe BulkTagging::DocumentTypeTagger do
     @taxon_content_id = "51ac4247-fd92-470a-a207-6b852a97f2db"
   end
   it "cannot find a taxon and raises an error" do
-    publishing_api_does_not_have_item(@taxon_content_id)
+    stub_publishing_api_does_not_have_item(@taxon_content_id)
     expect { BulkTagging::DocumentTypeTagger.call(taxon_content_id: @taxon_content_id, document_type: "document_type") }
             .to raise_error(GdsApi::HTTPNotFound, /not find content item with/)
   end

--- a/spec/services/bulk_tagging/publish_links_spec.rb
+++ b/spec/services/bulk_tagging/publish_links_spec.rb
@@ -9,7 +9,7 @@ module BulkTagging
     let(:content_id) { "a-content-id" }
     let(:tag_mapping) do
       mapping = build(:tag_mapping, tagging_source: build(:tag_migration))
-      publishing_api_has_lookups(
+      stub_publishing_api_has_lookups(
         mapping.content_base_path => content_id,
       )
       mapping

--- a/spec/services/bulk_tagging/publish_links_spec.rb
+++ b/spec/services/bulk_tagging/publish_links_spec.rb
@@ -17,7 +17,7 @@ module BulkTagging
 
     describe ".call" do
       it "adds the new links to the existing list of links" do
-        publishing_api_has_links(
+        stub_publishing_api_has_links(
           content_id: content_id,
           links: { taxons: %w[existing-content-id] },
           version: 10,
@@ -34,7 +34,7 @@ module BulkTagging
       end
 
       it "makes sure we don't duplicate the links" do
-        publishing_api_has_links(
+        stub_publishing_api_has_links(
           content_id: content_id,
           links: { taxons: [tag_mapping.link_content_id] },
           version: 10,
@@ -51,7 +51,7 @@ module BulkTagging
       end
 
       it "adds new links" do
-        publishing_api_has_links(
+        stub_publishing_api_has_links(
           content_id: content_id,
           links: { taxons: [] },
           version: 10,
@@ -72,7 +72,7 @@ module BulkTagging
         tagging_source.source_content_id = "source-content-id"
         tagging_source.delete_source_link = true
 
-        publishing_api_has_links(
+        stub_publishing_api_has_links(
           content_id: content_id,
           links: { taxons: %w[source-content-id] },
           version: 10,

--- a/spec/services/bulk_tagging/search_spec.rb
+++ b/spec/services/bulk_tagging/search_spec.rb
@@ -5,7 +5,7 @@ module BulkTagging
     include ContentItemHelper
 
     before do
-      publishing_api_has_content(
+      stub_publishing_api_has_content(
         [basic_content_item("A content item")],
         q: "tax",
         page: 1,

--- a/spec/services/linkables_spec.rb
+++ b/spec/services/linkables_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Linkables do
 
   context "there are linkables" do
     before do
-      publishing_api_has_linkables(
+      stub_publishing_api_has_linkables(
         [
           build_linkable(
             content_id: "invalid-1",
@@ -63,7 +63,7 @@ RSpec.describe Linkables do
 
   describe ".topics" do
     it "returns an array of hashes with title and content id pairs" do
-      publishing_api_has_linkables(
+      stub_publishing_api_has_linkables(
         [
           {
             "public_updated_at" => "2016-04-07 10:34:05",
@@ -97,7 +97,7 @@ RSpec.describe Linkables do
 
   describe ".organisations" do
     it "returns an array of arrays with title and content id pairs" do
-      publishing_api_has_linkables(
+      stub_publishing_api_has_linkables(
         [
           {
             "public_updated_at" => "2014-10-15 14:35:22",
@@ -118,7 +118,7 @@ RSpec.describe Linkables do
   describe ".facet_values" do
     it "returns an array of arrays with title and content id pairs grouped by facet title" do
       stub_facet_group_lookup
-      publishing_api_has_linkables(
+      stub_publishing_api_has_linkables(
         stubbed_facet_values,
         document_type: "facet_value",
       )

--- a/spec/services/metrics/content_coverage_metrics_spec.rb
+++ b/spec/services/metrics/content_coverage_metrics_spec.rb
@@ -38,13 +38,13 @@ module Metrics
             },
           ).to_return(body: JSON.dump(total: 400))
 
-        publishing_api_has_expanded_links(
+        stub_publishing_api_has_expanded_links(
           content_id: GovukTaxonomy::ROOT_CONTENT_ID,
           expanded_links: {
             level_one_taxons: level_one_taxons,
           },
         )
-        publishing_api_has_expanded_links(
+        stub_publishing_api_has_expanded_links(
           {
             content_id: GovukTaxonomy::ROOT_CONTENT_ID,
             expanded_links: {

--- a/spec/services/metrics/content_distribution_metrics_spec.rb
+++ b/spec/services/metrics/content_distribution_metrics_spec.rb
@@ -9,8 +9,8 @@ module Metrics
   RSpec.describe ContentDistributionMetrics do
     describe "#level_taggings" do
       before :each do
-        content_store_has_item("/", root_taxon.to_json, draft: true)
-        content_store_has_item("/taxons/root_taxon", child_taxons.to_json, draft: true)
+        stub_content_store_has_item("/", root_taxon.to_json, draft: true)
+        stub_content_store_has_item("/taxons/root_taxon", child_taxons.to_json, draft: true)
 
         allow(Services.search_api).to receive(:search_enum).with(include(filter_taxons: %w[root_id]))
                                       .and_return content_items_enum(5)

--- a/spec/services/metrics/taxons_per_level_metrics_spec.rb
+++ b/spec/services/metrics/taxons_per_level_metrics_spec.rb
@@ -7,8 +7,8 @@ module Metrics
   RSpec.describe TaxonsPerLevelMetrics do
     describe "#count_taxons_per_level" do
       before do
-        content_store_has_item("/", root_taxon.to_json, draft: true)
-        content_store_has_item("/taxons/level_one_taxon", multi_level_child_taxons.to_json, draft: true)
+        stub_content_store_has_item("/", root_taxon.to_json, draft: true)
+        stub_content_store_has_item("/taxons/level_one_taxon", multi_level_child_taxons.to_json, draft: true)
       end
       it "sends the correct values to statsd" do
         expect(Metrics.statsd).to receive(:gauge)

--- a/spec/services/tagging/common_ancestor_finder_spec.rb
+++ b/spec/services/tagging/common_ancestor_finder_spec.rb
@@ -5,7 +5,7 @@ include ::GdsApi::TestHelpers::Search
 RSpec.describe Tagging::CommonAncestorFinder do
   context "there is one taxon" do
     def has_paths(paths)
-      publishing_api_has_expanded_links(Support::TaxonHelper.expanded_link_hash("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", paths))
+      stub_publishing_api_has_expanded_links(Support::TaxonHelper.expanded_link_hash("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", paths))
     end
 
     before :each do
@@ -56,14 +56,14 @@ RSpec.describe Tagging::CommonAncestorFinder do
 
   it "rejects empty content_ids" do
     stub_any_search.to_return(body: { "results" => [{ "content_id" => "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" }, {}] }.to_json)
-    publishing_api_has_expanded_links(Support::TaxonHelper.expanded_link_hash("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", [[1], [1, 2]]))
+    stub_publishing_api_has_expanded_links(Support::TaxonHelper.expanded_link_hash("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", [[1], [1, 2]]))
     expect(Tagging::CommonAncestorFinder.new.find_all.force.length).to eq(1)
   end
 
   it "includes title and content_id" do
     stub_any_search.to_return(body: { "results" => [{ "content_id" => "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
                                                       "title" => "my title" }] }.to_json)
-    publishing_api_has_expanded_links(Support::TaxonHelper.expanded_link_hash("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", [[1], [1, 2]]))
+    stub_publishing_api_has_expanded_links(Support::TaxonHelper.expanded_link_hash("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", [[1], [1, 2]]))
     result_hash = Tagging::CommonAncestorFinder.new.find_all.force.first
     expect(result_hash[:title]).to eq("my title")
     expect(result_hash[:content_id]).to eq("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
@@ -71,7 +71,7 @@ RSpec.describe Tagging::CommonAncestorFinder do
 
   it "rejects empty results" do
     stub_any_search.to_return(body: { "results" => [{ "content_id" => "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" }] }.to_json)
-    publishing_api_has_expanded_links(Support::TaxonHelper.expanded_link_hash("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", [[]]))
+    stub_publishing_api_has_expanded_links(Support::TaxonHelper.expanded_link_hash("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", [[]]))
     expect(Tagging::CommonAncestorFinder.new.find_all.force).to be_empty
   end
 

--- a/spec/services/tagging/tagger_spec.rb
+++ b/spec/services/tagging/tagger_spec.rb
@@ -9,14 +9,14 @@ RSpec.describe Tagging::Tagger do
 
   describe "#tag" do
     it "tags content to a taxon" do
-      publishing_api_has_links(content_id: @content_id, links: { taxons: %w[aaa bbb] }, version: 5)
+      stub_publishing_api_has_links(content_id: @content_id, links: { taxons: %w[aaa bbb] }, version: 5)
       stub_any_publishing_api_patch_links
       subject.add_tags(@content_id, %w[ccc ddd])
       assert_publishing_api_patch_links(@content_id, links: { taxons: %w[aaa bbb ccc ddd] }, previous_version: 5, bulk_publishing: true)
     end
 
     it "retries 3 times" do
-      publishing_api_has_links(content_id: @content_id, links: { taxons: %w[aaa bbb] }, version: 5)
+      stub_publishing_api_has_links(content_id: @content_id, links: { taxons: %w[aaa bbb] }, version: 5)
 
       stub_any_publishing_api_patch_links.and_raise(GdsApi::HTTPConflict).times(2).then.to_return(body: "{}")
       expect { subject.add_tags(@content_id, %w[ccc]) }.to_not raise_error

--- a/spec/services/tagging/untagger_spec.rb
+++ b/spec/services/tagging/untagger_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Tagging::Untagger do
     @content_id = "51ac4247-fd92-470a-a207-6b852a97f2db"
   end
   it "untags a taxon" do
-    publishing_api_has_links(
+    stub_publishing_api_has_links(
       "content_id" => @content_id,
       "version" => 5,
       "links" => {
@@ -20,7 +20,7 @@ RSpec.describe Tagging::Untagger do
     assert_publishing_api_patch_links(@content_id, "previous_version" => 5, "links" => { "taxons" => %w[bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb] })
   end
   it "retries 3 times" do
-    publishing_api_has_links(content_id: @content_id, links: { taxons: %w[aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa] }, version: 5)
+    stub_publishing_api_has_links(content_id: @content_id, links: { taxons: %w[aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa] }, version: 5)
 
     stub_any_publishing_api_patch_links.and_raise(GdsApi::HTTPConflict).times(2).then.to_return(body: "{}")
     expect { Tagging::Untagger.call(@content_id, %w[aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa]) }.to_not raise_error

--- a/spec/services/tagging/untagger_spec.rb
+++ b/spec/services/tagging/untagger_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 require "gds_api/test_helpers/publishing_api_v2"
-include ::GdsApi::TestHelpers::PublishingApiV2
+include ::GdsApi::TestHelpers::PublishingApi
 
 RSpec.describe Tagging::Untagger do
   before :each do

--- a/spec/services/taxonomy/build_taxon_spec.rb
+++ b/spec/services/taxonomy/build_taxon_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Taxonomy::BuildTaxon do
     let(:taxon) { Taxonomy::BuildTaxon.call(content_id: content_id) }
 
     before do
-      publishing_api_has_item(content)
+      stub_publishing_api_has_item(content)
       publishing_api_has_expanded_links(
         content_id: content_id,
         expanded_links: {

--- a/spec/services/taxonomy/build_taxon_spec.rb
+++ b/spec/services/taxonomy/build_taxon_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe Taxonomy::BuildTaxon do
 
     context "with an invalid taxon" do
       before do
-        publishing_api_does_not_have_item(content_id)
+        stub_publishing_api_does_not_have_item(content_id)
       end
 
       it "raises an exception" do

--- a/spec/services/taxonomy/build_taxon_spec.rb
+++ b/spec/services/taxonomy/build_taxon_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Taxonomy::BuildTaxon do
 
     before do
       stub_publishing_api_has_item(content)
-      publishing_api_has_expanded_links(
+      stub_publishing_api_has_expanded_links(
         content_id: content_id,
         expanded_links: {
           topics: [],
@@ -87,7 +87,7 @@ RSpec.describe Taxonomy::BuildTaxon do
 
     context "without taxon parents" do
       before do
-        publishing_api_has_expanded_links(
+        stub_publishing_api_has_expanded_links(
           content_id: content_id,
           expanded_links: {
             topics: [],
@@ -103,7 +103,7 @@ RSpec.describe Taxonomy::BuildTaxon do
     context "with existing links" do
       let(:parent_taxon_id) { "CONTENT-ID-RTI" }
       before do
-        publishing_api_has_expanded_links(
+        stub_publishing_api_has_expanded_links(
           content_id: content_id,
           expanded_links: {
             topics: [],
@@ -121,7 +121,7 @@ RSpec.describe Taxonomy::BuildTaxon do
 
     context "root taxon" do
       before do
-        publishing_api_has_expanded_links(
+        stub_publishing_api_has_expanded_links(
           content_id: content_id,
           expanded_links: {
             topics: [],

--- a/spec/services/taxonomy/level_one_taxons_retrieval_spec.rb
+++ b/spec/services/taxonomy/level_one_taxons_retrieval_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Taxonomy::LevelOneTaxonsRetrieval do
   let(:child_contents) { Array.new(2) { { "content_id" => SecureRandom.uuid } } }
 
   before :each do
-    publishing_api_has_expanded_links(
+    stub_publishing_api_has_expanded_links(
       "content_id" => GovukTaxonomy::ROOT_CONTENT_ID,
       "expanded_links" => {
         "level_one_taxons" => child_contents,

--- a/spec/services/taxonomy/links_update_spec.rb
+++ b/spec/services/taxonomy/links_update_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Taxonomy::LinksUpdate do
   let(:legacy_taxon_id) { SecureRandom.uuid }
 
   before :each do
-    publishing_api_has_item(content_id: content_id, title: "content")
+    stub_publishing_api_has_item(content_id: content_id, title: "content")
     stub_any_publishing_api_patch_links
   end
 

--- a/spec/services/taxonomy/organisation_count_spec.rb
+++ b/spec/services/taxonomy/organisation_count_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe Taxonomy::OrganisationCount do
     let(:taxon_ids) { [SecureRandom.uuid, SecureRandom.uuid] }
 
     before :each do
-      content_store_has_item("/", level_one_taxons.to_json, draft: true)
-      content_store_has_item("/taxons/level_one", single_level_child_taxons.to_json, draft: true)
+      stub_content_store_has_item("/", level_one_taxons.to_json, draft: true)
+      stub_content_store_has_item("/taxons/level_one", single_level_child_taxons.to_json, draft: true)
       stub_search_api({ "aggregate_primary_publishing_organisation" => %r{\d+},  "filter_taxons" => [taxon_ids.first] },
                       search_api_body([{ slug: "organisation1", count: 1 },
                                        { slug: "organisation2", count: 2 },

--- a/spec/services/taxonomy/save_taxon_version_spec.rb
+++ b/spec/services/taxonomy/save_taxon_version_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Taxonomy::SaveTaxonVersion, ".call" do
       phase: "beta",
     )
 
-    publishing_api_does_not_have_item(taxon.content_id)
+    stub_publishing_api_does_not_have_item(taxon.content_id)
 
     described_class.call(taxon, "A new taxon")
 

--- a/spec/services/taxonomy/taxon_tree_export_spec.rb
+++ b/spec/services/taxonomy/taxon_tree_export_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Taxonomy::TaxonTreeExport do
     subject { described_class.new(taxon_id) }
 
     it "should return a ExpandedTaxonomy instance" do
-      publishing_api_has_item(content_id: taxon_id, title: "content")
+      stub_publishing_api_has_item(content_id: taxon_id, title: "content")
       expect(subject.expanded_taxon).to be_an_instance_of(ExpandedTaxonomy)
     end
   end
@@ -106,9 +106,9 @@ RSpec.describe Taxonomy::TaxonTreeExport do
   end
 
   def fake_taxonomy_tree(level_1_taxon, level_2_taxon, level_3_taxon)
-    publishing_api_has_item(level_1_taxon)
-    publishing_api_has_item(level_2_taxon)
-    publishing_api_has_item(level_3_taxon)
+    stub_publishing_api_has_item(level_1_taxon)
+    stub_publishing_api_has_item(level_2_taxon)
+    stub_publishing_api_has_item(level_3_taxon)
 
     publishing_api_has_expanded_links(
       content_id: level_1_taxon["content_id"],

--- a/spec/services/taxonomy/taxon_tree_export_spec.rb
+++ b/spec/services/taxonomy/taxon_tree_export_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe Taxonomy::TaxonTreeExport do
     stub_publishing_api_has_item(level_2_taxon)
     stub_publishing_api_has_item(level_3_taxon)
 
-    publishing_api_has_expanded_links(
+    stub_publishing_api_has_expanded_links(
       content_id: level_1_taxon["content_id"],
       expanded_links: {
         root_taxon: [GovukTaxonomy::ROOT_CONTENT_ID],
@@ -118,7 +118,7 @@ RSpec.describe Taxonomy::TaxonTreeExport do
       },
     )
 
-    publishing_api_has_expanded_links(
+    stub_publishing_api_has_expanded_links(
       content_id: level_2_taxon["content_id"],
       expanded_links: {
         parent_taxons: [level_1_taxon],
@@ -126,7 +126,7 @@ RSpec.describe Taxonomy::TaxonTreeExport do
       },
     )
 
-    publishing_api_has_expanded_links(
+    stub_publishing_api_has_expanded_links(
       content_id: level_3_taxon["content_id"],
       expanded_links: {
         parent_taxons: [level_2_taxon],

--- a/spec/services/taxonomy/taxon_unpublisher_spec.rb
+++ b/spec/services/taxonomy/taxon_unpublisher_spec.rb
@@ -51,8 +51,8 @@ RSpec.describe Taxonomy::TaxonUnpublisher do
       stub_publishing_api_has_lookups("/base/path1" => tagged_content_id1, "/base/path2" => tagged_content_id2)
 
       # each content item has links to child taxon
-      publishing_api_has_links(content_id: tagged_content_id1, links: { taxons: [taxon_content_id] }, version: version)
-      publishing_api_has_links(content_id: tagged_content_id2, links: { taxons: [taxon_content_id] }, version: version)
+      stub_publishing_api_has_links(content_id: tagged_content_id1, links: { taxons: [taxon_content_id] }, version: version)
+      stub_publishing_api_has_links(content_id: tagged_content_id2, links: { taxons: [taxon_content_id] }, version: version)
     end
 
     it "unpublishes a level one taxon with a redirect" do

--- a/spec/services/taxonomy/taxon_unpublisher_spec.rb
+++ b/spec/services/taxonomy/taxon_unpublisher_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Taxonomy::TaxonUnpublisher do
         link_type: "taxons",
         fields: %w[base_path],
       )
-      publishing_api_has_lookups("/base/path1" => tagged_content_id1, "/base/path2" => tagged_content_id2)
+      stub_publishing_api_has_lookups("/base/path1" => tagged_content_id1, "/base/path2" => tagged_content_id2)
 
       # each content item has links to child taxon
       publishing_api_has_links(content_id: tagged_content_id1, links: { taxons: [taxon_content_id] }, version: version)

--- a/spec/services/taxonomy/taxon_unpublisher_spec.rb
+++ b/spec/services/taxonomy/taxon_unpublisher_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Taxonomy::TaxonUnpublisher do
     stub_publishing_api_has_item("content_id" => redirect_content_id, "base_path" => "/path/to/redirect")
 
     # link parent taxon to child taxon
-    publishing_api_has_expanded_links(expanded_links(taxon_content_id, parent_taxon_content_id))
+    stub_publishing_api_has_expanded_links(expanded_links(taxon_content_id, parent_taxon_content_id))
     stub_any_publishing_api_unpublish
   end
 
@@ -56,7 +56,7 @@ RSpec.describe Taxonomy::TaxonUnpublisher do
     end
 
     it "unpublishes a level one taxon with a redirect" do
-      publishing_api_has_expanded_links("content_id" => taxon_content_id, "expanded_links" => {})
+      stub_publishing_api_has_expanded_links("content_id" => taxon_content_id, "expanded_links" => {})
       unpublish(taxon_content_id, redirect_content_id)
       assert_publishing_api_unpublish(taxon_content_id, type: "redirect", alternative_path: "/path/to/redirect")
     end
@@ -92,7 +92,7 @@ RSpec.describe Taxonomy::TaxonUnpublisher do
   context "Transition taxon" do
     it "unpublishes the Transition taxon with 'cy' locale" do
       transition_taxon_content_id = TransitionTaxon::TRANSITION_TAXON_CONTENT_ID
-      publishing_api_has_expanded_links("content_id" => transition_taxon_content_id, "expanded_links" => {})
+      stub_publishing_api_has_expanded_links("content_id" => transition_taxon_content_id, "expanded_links" => {})
 
       unpublish(transition_taxon_content_id, redirect_content_id)
       assert_publishing_api_unpublish(transition_taxon_content_id,

--- a/spec/services/taxonomy/taxon_unpublisher_spec.rb
+++ b/spec/services/taxonomy/taxon_unpublisher_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Taxonomy::TaxonUnpublisher do
   context "the taxon is not tagged to any content items" do
     before :each do
       # no content items are tagged to child taxon
-      publishing_api_has_linked_items(
+      stub_publishing_api_has_linked_items(
         [],
         content_id: taxon_content_id,
         link_type: "taxons",
@@ -41,7 +41,7 @@ RSpec.describe Taxonomy::TaxonUnpublisher do
   context "the taxon is tagged to two content items" do
     before :each do
       # content items are tagged to child taxon
-      publishing_api_has_linked_items(
+      stub_publishing_api_has_linked_items(
         [{ "base_path" => "/base/path1" },
          { "base_path" => "/base/path2" }],
         content_id: taxon_content_id,

--- a/spec/services/taxonomy/taxon_unpublisher_spec.rb
+++ b/spec/services/taxonomy/taxon_unpublisher_spec.rb
@@ -13,9 +13,9 @@ RSpec.describe Taxonomy::TaxonUnpublisher do
 
   before :each do
     # parent and child taxon, redirect taxon exist
-    publishing_api_has_item(FactoryBot.build(:taxon_hash, content_id: taxon_content_id))
-    publishing_api_has_item(FactoryBot.build(:taxon_hash, content_id: parent_taxon_content_id))
-    publishing_api_has_item("content_id" => redirect_content_id, "base_path" => "/path/to/redirect")
+    stub_publishing_api_has_item(FactoryBot.build(:taxon_hash, content_id: taxon_content_id))
+    stub_publishing_api_has_item(FactoryBot.build(:taxon_hash, content_id: parent_taxon_content_id))
+    stub_publishing_api_has_item("content_id" => redirect_content_id, "base_path" => "/path/to/redirect")
 
     # link parent taxon to child taxon
     publishing_api_has_expanded_links(expanded_links(taxon_content_id, parent_taxon_content_id))

--- a/spec/services/taxonomy/taxon_unpublisher_spec.rb
+++ b/spec/services/taxonomy/taxon_unpublisher_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-include ::GdsApi::TestHelpers::PublishingApiV2
+include ::GdsApi::TestHelpers::PublishingApi
 include TransitionTaxon
 
 RSpec.describe Taxonomy::TaxonUnpublisher do

--- a/spec/services/taxonomy/taxonomy_query_spec.rb
+++ b/spec/services/taxonomy/taxonomy_query_spec.rb
@@ -95,11 +95,11 @@ RSpec.describe Taxonomy::TaxonomyQuery do
       before :each do
         stub_content_store_has_item("/", level_one_taxons.to_json, draft: true)
         stub_content_store_has_item("/taxons/root_taxon_a",
-                               single_level_child_taxons("root_taxon_a", "child_a_1", "child_a_2").to_json,
-                               draft: true)
+                                    single_level_child_taxons("root_taxon_a", "child_a_1", "child_a_2").to_json,
+                                    draft: true)
         stub_content_store_has_item("/taxons/root_taxon_b",
-                               single_level_child_taxons("root_taxon_b", "child_b_1", "child_b_2"),
-                               draft: true)
+                                    single_level_child_taxons("root_taxon_b", "child_b_1", "child_b_2"),
+                                    draft: true)
       end
 
       it "returns root taxons in the first array" do

--- a/spec/services/taxonomy/taxonomy_query_spec.rb
+++ b/spec/services/taxonomy/taxonomy_query_spec.rb
@@ -12,11 +12,11 @@ RSpec.describe Taxonomy::TaxonomyQuery do
 
   describe "#parent" do
     it "returns nil because the taxon is a level one taxon" do
-      publishing_api_has_expanded_links("content_id" => "llllllll-llll-llll-llll-llllllllllll", "expanded_links" => {})
+      stub_publishing_api_has_expanded_links("content_id" => "llllllll-llll-llll-llll-llllllllllll", "expanded_links" => {})
       expect(query.parent("llllllll-llll-llll-llll-llllllllllll")).to be_nil
     end
     it "returns a parent" do
-      publishing_api_has_expanded_links(expanded_links)
+      stub_publishing_api_has_expanded_links(expanded_links)
       expect(query.parent("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")).to eq("base_path" => "/path/base",
                                                                          "content_id" => "bbbbbbbb-bbbb-bbbbb-bbbbb-bbbbbbbbbbbb")
     end

--- a/spec/services/taxonomy/taxonomy_query_spec.rb
+++ b/spec/services/taxonomy/taxonomy_query_spec.rb
@@ -3,7 +3,7 @@ require "gds_api/test_helpers/content_store"
 
 include Taxonomy
 include ::GdsApi::TestHelpers::ContentStore
-include ::GdsApi::TestHelpers::PublishingApiV2
+include ::GdsApi::TestHelpers::PublishingApi
 
 RSpec.describe Taxonomy::TaxonomyQuery do
   def query

--- a/spec/services/taxonomy/taxonomy_query_spec.rb
+++ b/spec/services/taxonomy/taxonomy_query_spec.rb
@@ -24,12 +24,12 @@ RSpec.describe Taxonomy::TaxonomyQuery do
 
   describe "#level_one_taxons" do
     it "returns an empty array" do
-      content_store_has_item("/", no_taxons.to_json, draft: true)
+      stub_content_store_has_item("/", no_taxons.to_json, draft: true)
       expect(query.level_one_taxons).to be_empty
     end
 
     it "returns root taxons" do
-      content_store_has_item("/", level_one_taxons.to_json, draft: true)
+      stub_content_store_has_item("/", level_one_taxons.to_json, draft: true)
       expect(query.level_one_taxons)
         .to match_array [{ "content_id" => "rrrr_aaaa", "base_path" => "/taxons/root_taxon_a" },
                          { "content_id" => "rrrr_bbbb", "base_path" => "/taxons/root_taxon_b" }]
@@ -38,17 +38,17 @@ RSpec.describe Taxonomy::TaxonomyQuery do
 
   describe "#child_taxons" do
     it "returns an empty array" do
-      content_store_has_item("/taxons/root_taxon", no_taxons.to_json, draft: true)
+      stub_content_store_has_item("/taxons/root_taxon", no_taxons.to_json, draft: true)
       expect(query.child_taxons("/taxons/root_taxon")).to be_empty
     end
     it "returns an single level of taxons" do
-      content_store_has_item("/taxons/root_taxon", single_level_child_taxons("rrrr", "aaaa", "bbbb").to_json, draft: true)
+      stub_content_store_has_item("/taxons/root_taxon", single_level_child_taxons("rrrr", "aaaa", "bbbb").to_json, draft: true)
       expect(query.child_taxons("/taxons/root_taxon"))
         .to match_array [{ "content_id" => "aaaa", "base_path" => "/taxons/aaaa", "parent_content_id" => "rrrr" },
                          { "content_id" => "bbbb", "base_path" => "/taxons/bbbb", "parent_content_id" => "rrrr" }]
     end
     it "returns multiple levels of taxons" do
-      content_store_has_item("/taxons/root_taxon", multi_level_child_taxons.to_json, draft: true)
+      stub_content_store_has_item("/taxons/root_taxon", multi_level_child_taxons.to_json, draft: true)
       expect(query.child_taxons("/taxons/root_taxon"))
         .to match_array [{ "content_id" => "aaaa", "base_path" => "/root_taxon/taxon_a", "parent_content_id" => "rrrr" },
                          { "content_id" => "aaaa_1111", "base_path" => "/root_taxon/taxon_1", "parent_content_id" => "aaaa" },
@@ -93,11 +93,11 @@ RSpec.describe Taxonomy::TaxonomyQuery do
 
     context "there are root taxons and one level of children" do
       before :each do
-        content_store_has_item("/", level_one_taxons.to_json, draft: true)
-        content_store_has_item("/taxons/root_taxon_a",
+        stub_content_store_has_item("/", level_one_taxons.to_json, draft: true)
+        stub_content_store_has_item("/taxons/root_taxon_a",
                                single_level_child_taxons("root_taxon_a", "child_a_1", "child_a_2").to_json,
                                draft: true)
-        content_store_has_item("/taxons/root_taxon_b",
+        stub_content_store_has_item("/taxons/root_taxon_b",
                                single_level_child_taxons("root_taxon_b", "child_b_1", "child_b_2"),
                                draft: true)
       end
@@ -119,8 +119,8 @@ RSpec.describe Taxonomy::TaxonomyQuery do
 
     context "there are root taxons and two levels of children" do
       before :each do
-        content_store_has_item("/", root_taxon.to_json, draft: true)
-        content_store_has_item("/taxons/root_taxon", multi_level_child_taxons.to_json, draft: true)
+        stub_content_store_has_item("/", root_taxon.to_json, draft: true)
+        stub_content_store_has_item("/taxons/root_taxon", multi_level_child_taxons.to_json, draft: true)
       end
       it "returns three levels" do
         expect(query.taxons_per_level.size).to eq(3)

--- a/spec/services/taxonomy/taxons_with_content_count_spec.rb
+++ b/spec/services/taxonomy/taxons_with_content_count_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Taxonomy::TaxonsWithContentCount do
       stub_request(:get, "https://publishing-api.test.gov.uk/v2/expanded-links/b92079ac-f1d9-44c8-bc78-772d54377ee2")
         .to_return(body: EXPANDED_LINKS_FIXTURE.to_json)
 
-      publishing_api_has_item(
+      stub_publishing_api_has_item(
         content_id: "b92079ac-f1d9-44c8-bc78-772d54377ee2",
         title: "title",
       )

--- a/spec/services/taxonomy/update_taxon_spec.rb
+++ b/spec/services/taxonomy/update_taxon_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe Taxonomy::UpdateTaxon do
       end
 
       it "raises an error with a generic message and notifies GovukError if it is not a base path conflict" do
-        publishing_api_has_lookups("")
+        stub_publishing_api_has_lookups("")
         expect(GovukError).to receive(:notify).with(error)
         expect { publish }.to raise_error(
           Taxonomy::UpdateTaxon::InvalidTaxonError,
@@ -115,7 +115,7 @@ RSpec.describe Taxonomy::UpdateTaxon do
       end
 
       it "raises an error with a specific message if it is a base path conflict" do
-        publishing_api_has_lookups(SecureRandom.uuid)
+        stub_publishing_api_has_lookups(SecureRandom.uuid)
         allow(Services.publishing_api).to receive(:lookup_content_id).and_return(SecureRandom.uuid)
         expect { publish }.to raise_error(
           Taxonomy::UpdateTaxon::InvalidTaxonError,

--- a/spec/services/taxonomy/update_taxon_spec.rb
+++ b/spec/services/taxonomy/update_taxon_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Taxonomy::UpdateTaxon do
     parent_taxon = taxon_with_details(
       "root", other_fields: { base_path: "/level-one", content_id: "CONTENT-ID-PARENT" }
     )
-    publishing_api_has_item(parent_taxon)
+    stub_publishing_api_has_item(parent_taxon)
     publishing_api_has_expanded_links(content_id: "CONTENT-ID-PARENT")
   end
   let(:publish) { described_class.call(taxon: @taxon) }

--- a/spec/services/taxonomy/update_taxon_spec.rb
+++ b/spec/services/taxonomy/update_taxon_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Taxonomy::UpdateTaxon do
       "root", other_fields: { base_path: "/level-one", content_id: "CONTENT-ID-PARENT" }
     )
     stub_publishing_api_has_item(parent_taxon)
-    publishing_api_has_expanded_links(content_id: "CONTENT-ID-PARENT")
+    stub_publishing_api_has_expanded_links(content_id: "CONTENT-ID-PARENT")
   end
   let(:publish) { described_class.call(taxon: @taxon) }
 

--- a/spec/support/publishing_api_helper.rb
+++ b/spec/support/publishing_api_helper.rb
@@ -23,7 +23,7 @@ module PublishingApiHelper
 
     stub_publishing_api_has_item(taxon)
     publishing_api_has_links(content_id: content_id, links: {})
-    publishing_api_has_expanded_links(content_id: content_id, expanded_links: {})
+    stub_publishing_api_has_expanded_links(content_id: content_id, expanded_links: {})
     publishing_api_has_linked_items([], content_id: content_id, link_type: "taxons")
     stub_email_requests_for_show_page
   end

--- a/spec/support/publishing_api_helper.rb
+++ b/spec/support/publishing_api_helper.rb
@@ -24,7 +24,7 @@ module PublishingApiHelper
     stub_publishing_api_has_item(taxon)
     stub_publishing_api_has_links(content_id: content_id, links: {})
     stub_publishing_api_has_expanded_links(content_id: content_id, expanded_links: {})
-    publishing_api_has_linked_items([], content_id: content_id, link_type: "taxons")
+    stub_publishing_api_has_linked_items([], content_id: content_id, link_type: "taxons")
     stub_email_requests_for_show_page
   end
 

--- a/spec/support/publishing_api_helper.rb
+++ b/spec/support/publishing_api_helper.rb
@@ -85,35 +85,35 @@ module PublishingApiHelper
   end
 
   def publishing_api_has_taxon_linkables(base_paths)
-    publishing_api_has_linkables(
+    stub_publishing_api_has_linkables(
       select_by_base_path(stubbed_taxons, base_paths),
       document_type: "taxon",
     )
   end
 
   def publishing_api_has_topic_linkables(base_paths)
-    publishing_api_has_linkables(
+    stub_publishing_api_has_linkables(
       select_by_base_path(stubbed_topics, base_paths),
       document_type: "topic",
     )
   end
 
   def publishing_api_has_organisation_linkables(base_paths)
-    publishing_api_has_linkables(
+    stub_publishing_api_has_linkables(
       select_by_base_path(stubbed_organisations, base_paths),
       document_type: "organisation",
     )
   end
 
   def publishing_api_has_need_linkables(base_paths)
-    publishing_api_has_linkables(
+    stub_publishing_api_has_linkables(
       select_by_base_path(stubbed_needs, base_paths),
       document_type: "need",
     )
   end
 
   def publishing_api_has_mainstream_browse_page_linkables(base_paths)
-    publishing_api_has_linkables(
+    stub_publishing_api_has_linkables(
       select_by_base_path(stubbed_mainstream_browse_pages, base_paths),
       document_type: "mainstream_browse_page",
     )

--- a/spec/support/publishing_api_helper.rb
+++ b/spec/support/publishing_api_helper.rb
@@ -22,7 +22,7 @@ module PublishingApiHelper
     content_id = taxon.fetch("content_id")
 
     stub_publishing_api_has_item(taxon)
-    publishing_api_has_links(content_id: content_id, links: {})
+    stub_publishing_api_has_links(content_id: content_id, links: {})
     stub_publishing_api_has_expanded_links(content_id: content_id, expanded_links: {})
     publishing_api_has_linked_items([], content_id: content_id, link_type: "taxons")
     stub_email_requests_for_show_page

--- a/spec/support/publishing_api_helper.rb
+++ b/spec/support/publishing_api_helper.rb
@@ -37,7 +37,7 @@ module PublishingApiHelper
       search_in: %i[title base_path details.internal_name],
     }
 
-    publishing_api_has_content(
+    stub_publishing_api_has_content(
       items,
       default_options.merge(options),
     )
@@ -54,7 +54,7 @@ module PublishingApiHelper
       states: %w[published],
     }
 
-    publishing_api_has_content(taxons, default_options.merge(options))
+    stub_publishing_api_has_content(taxons, default_options.merge(options))
   end
 
   def publishing_api_has_draft_taxons(taxons, options = {})
@@ -67,7 +67,7 @@ module PublishingApiHelper
       states: %w[draft],
     }
 
-    publishing_api_has_content(taxons, default_options.merge(options))
+    stub_publishing_api_has_content(taxons, default_options.merge(options))
   end
 
   def publishing_api_has_deleted_taxons(taxons, options = {})
@@ -81,7 +81,7 @@ module PublishingApiHelper
       states: %w[unpublished],
     }
 
-    publishing_api_has_content(taxons, default_options.merge(options))
+    stub_publishing_api_has_content(taxons, default_options.merge(options))
   end
 
   def publishing_api_has_taxon_linkables(base_paths)

--- a/spec/support/publishing_api_helper.rb
+++ b/spec/support/publishing_api_helper.rb
@@ -21,7 +21,7 @@ module PublishingApiHelper
   def stub_requests_for_show_page(taxon)
     content_id = taxon.fetch("content_id")
 
-    publishing_api_has_item(taxon)
+    stub_publishing_api_has_item(taxon)
     publishing_api_has_links(content_id: content_id, links: {})
     publishing_api_has_expanded_links(content_id: content_id, expanded_links: {})
     publishing_api_has_linked_items([], content_id: content_id, link_type: "taxons")

--- a/spec/support/taxonomy_helper.rb
+++ b/spec/support/taxonomy_helper.rb
@@ -31,10 +31,10 @@ module TaxonomyHelper
 
     root_taxon_expanded_links = {}
 
-    publishing_api_has_expanded_links({ content_id: root_content_id }, with_drafts: false)
-    publishing_api_has_expanded_links(content_id: root_content_id, expanded_links: draft_level_one_taxons)
+    stub_publishing_api_has_expanded_links({ content_id: root_content_id }, with_drafts: false)
+    stub_publishing_api_has_expanded_links(content_id: root_content_id, expanded_links: draft_level_one_taxons)
     stub_publishing_api_has_item(root_taxon_content)
-    publishing_api_has_expanded_links(content_id: valid_taxon_uuid, expanded_links: root_taxon_expanded_links)
+    stub_publishing_api_has_expanded_links(content_id: valid_taxon_uuid, expanded_links: root_taxon_expanded_links)
   end
 
   def stub_tag_content(content_id, success: true)

--- a/spec/support/taxonomy_helper.rb
+++ b/spec/support/taxonomy_helper.rb
@@ -33,7 +33,7 @@ module TaxonomyHelper
 
     publishing_api_has_expanded_links({ content_id: root_content_id }, with_drafts: false)
     publishing_api_has_expanded_links(content_id: root_content_id, expanded_links: draft_level_one_taxons)
-    publishing_api_has_item(root_taxon_content)
+    stub_publishing_api_has_item(root_taxon_content)
     publishing_api_has_expanded_links(content_id: valid_taxon_uuid, expanded_links: root_taxon_expanded_links)
   end
 

--- a/spec/workers/taxonomy_health/child_taxon_count_metric_spec.rb
+++ b/spec/workers/taxonomy_health/child_taxon_count_metric_spec.rb
@@ -29,8 +29,8 @@ RSpec.describe TaxonomyHealth::ChildTaxonCountMetric do
     stub_publishing_api_has_item(vegetables)
     stub_publishing_api_has_item(meats)
 
-    publishing_api_has_expanded_links(home_page)
-    publishing_api_has_expanded_links(food)
+    stub_publishing_api_has_expanded_links(home_page)
+    stub_publishing_api_has_expanded_links(food)
   end
 
   it "records no failing taxons" do

--- a/spec/workers/taxonomy_health/child_taxon_count_metric_spec.rb
+++ b/spec/workers/taxonomy_health/child_taxon_count_metric_spec.rb
@@ -23,11 +23,11 @@ RSpec.describe TaxonomyHealth::ChildTaxonCountMetric do
   let(:meats) { FactoryBot.build(:taxon_hash, title: "Meats") }
 
   before :each do
-    publishing_api_has_item(home_page)
-    publishing_api_has_item(food)
-    publishing_api_has_item(fruits)
-    publishing_api_has_item(vegetables)
-    publishing_api_has_item(meats)
+    stub_publishing_api_has_item(home_page)
+    stub_publishing_api_has_item(food)
+    stub_publishing_api_has_item(fruits)
+    stub_publishing_api_has_item(vegetables)
+    stub_publishing_api_has_item(meats)
 
     publishing_api_has_expanded_links(home_page)
     publishing_api_has_expanded_links(food)

--- a/spec/workers/taxonomy_health/content_count_metric_spec.rb
+++ b/spec/workers/taxonomy_health/content_count_metric_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe TaxonomyHealth::ContentCountMetric do
   before :each do
     stub_publishing_api_has_item(home_page)
     stub_publishing_api_has_item(food)
-    publishing_api_has_expanded_links(home_page)
-    publishing_api_has_expanded_links(food)
+    stub_publishing_api_has_expanded_links(home_page)
+    stub_publishing_api_has_expanded_links(food)
   end
 
   it "records no failing taxons" do

--- a/spec/workers/taxonomy_health/content_count_metric_spec.rb
+++ b/spec/workers/taxonomy_health/content_count_metric_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe TaxonomyHealth::ContentCountMetric do
   let(:fruits) { FactoryBot.build(:taxon_hash, title: "Fruits") }
 
   before :each do
-    publishing_api_has_item(home_page)
-    publishing_api_has_item(food)
+    stub_publishing_api_has_item(home_page)
+    stub_publishing_api_has_item(food)
     publishing_api_has_expanded_links(home_page)
     publishing_api_has_expanded_links(food)
   end

--- a/spec/workers/taxonomy_health/maximum_depth_metric_spec.rb
+++ b/spec/workers/taxonomy_health/maximum_depth_metric_spec.rb
@@ -15,11 +15,11 @@ RSpec.describe TaxonomyHealth::MaximumDepthMetric do
   let(:pears) { FactoryBot.build(:taxon_hash, title: "Pears") }
 
   before :each do
-    publishing_api_has_item(home_page)
-    publishing_api_has_item(food)
-    publishing_api_has_item(fruits)
-    publishing_api_has_item(apples)
-    publishing_api_has_item(pears)
+    stub_publishing_api_has_item(home_page)
+    stub_publishing_api_has_item(food)
+    stub_publishing_api_has_item(fruits)
+    stub_publishing_api_has_item(apples)
+    stub_publishing_api_has_item(pears)
     publishing_api_has_expanded_links(home_page)
     publishing_api_has_expanded_links(food)
   end

--- a/spec/workers/taxonomy_health/maximum_depth_metric_spec.rb
+++ b/spec/workers/taxonomy_health/maximum_depth_metric_spec.rb
@@ -20,8 +20,8 @@ RSpec.describe TaxonomyHealth::MaximumDepthMetric do
     stub_publishing_api_has_item(fruits)
     stub_publishing_api_has_item(apples)
     stub_publishing_api_has_item(pears)
-    publishing_api_has_expanded_links(home_page)
-    publishing_api_has_expanded_links(food)
+    stub_publishing_api_has_expanded_links(home_page)
+    stub_publishing_api_has_expanded_links(food)
   end
 
   it "records no failing taxons" do

--- a/spec/workers/update_taxon_worker_spec.rb
+++ b/spec/workers/update_taxon_worker_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe UpdateTaxonWorker, "#perform" do
       },
     )
 
-    publishing_api_has_item(taxon)
+    stub_publishing_api_has_item(taxon)
     publishing_api_has_expanded_links(taxon.slice(:content_id))
     stub_any_publishing_api_put_content
 
@@ -42,7 +42,7 @@ RSpec.describe UpdateTaxonWorker, "#perform" do
         publication_state: "draft",
       },
     )
-    publishing_api_has_item(taxon)
+    stub_publishing_api_has_item(taxon)
     publishing_api_has_expanded_links(taxon.slice(:content_id))
     stub_any_publishing_api_put_content
 

--- a/spec/workers/update_taxon_worker_spec.rb
+++ b/spec/workers/update_taxon_worker_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe UpdateTaxonWorker, "#perform" do
     )
 
     stub_publishing_api_has_item(taxon)
-    publishing_api_has_expanded_links(taxon.slice(:content_id))
+    stub_publishing_api_has_expanded_links(taxon.slice(:content_id))
     stub_any_publishing_api_put_content
 
     expect(Version.count).to eq(0)
@@ -43,7 +43,7 @@ RSpec.describe UpdateTaxonWorker, "#perform" do
       },
     )
     stub_publishing_api_has_item(taxon)
-    publishing_api_has_expanded_links(taxon.slice(:content_id))
+    stub_publishing_api_has_expanded_links(taxon.slice(:content_id))
     stub_any_publishing_api_put_content
 
     UpdateTaxonWorker.new.perform(transition_taxon_content_id, base_path: "/base-path")


### PR DESCRIPTION
When running tests to tidy up facet groups and business finder code. I noticed a lot of warnings about old test APIs that will be deprecated in future.

Thought, as I'm in here, I'll tidy up.

Followed CLI guidance to move over to new API.