### PR TITLE
WIP: Make it possible to add related links to coronavirus taxon

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -153,7 +153,13 @@ private
       uk_market_conformity_assessment_body
       utaac_decision
       written_statement
-    ].include?(document_type)
+    ].include?(document_type) || is_coronavirus_taxon?
+  end
+
+  def is_coronavirus_taxon?
+    # This is for the /education taxon and should be changed to whatever taxa we want to
+    # show related links for
+    document_type == "taxon" && %w(c58fdadd-7743-46d6-9629-90bb3ccc4ef0).include?(content_id)
   end
 
   def additional_temporary_blacklist


### PR DESCRIPTION
Exploration of making it easy to add custom links to a taxon page. `ordered_related_links` looks like a good short term way of doing this. This change makes it possible to add them to specified taxons. Tested on integration