### PR TITLE
Add a config for Dependabot

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,14 @@
+version: 1
+update_configs:
+  - package_manager: ruby:bundler
+    directory: /
+    update_schedule: daily
+    allowed_updates:
+      - match:
+          update_type: security
+      - match:
+          dependency_name: gds-api-adapters
+      - match:
+          dependency_name: govuk_publishing_components
+      - match:
+          dependency_name: rubocop-govuk


### PR DESCRIPTION
This repo isn't in active development and therefore we don't often have the time to review the Dependabot PRs and then make deploy the changes. Instead the PRs tend to be left stale for long periods of time.

This PR introduces a configure for Dependabot that means only Gems which require updating for security reasons or Gems that we own will have a PR raised against them.

I'm going to try this on a few of our inactive repos and see how it goes. If we think it's the right decision we can configure [govuk-saas-config](https://github.com/alphagov/govuk-saas-config) to do this automatically for us.