### PR TITLE
Allow bulk tagging travel advice to organisation

### DIFF
--- a/app/services/tagging/csv_tagger.rb
+++ b/app/services/tagging/csv_tagger.rb
@@ -6,7 +6,7 @@ module Tagging
       grouped_tags.each do |content_id, grouped_taggings|
         taxon_ids = grouped_taggings.map { |t| t["taxon_id"] }
         yield(content_id: content_id, taxon_ids: taxon_ids) if block_given?
-        Tagging::Tagger.add_tags(content_id, grouped_taggings.map { |t| t["taxon_id"] })
+        Tagging::Tagger.add_tags(content_id, grouped_taggings.map { |t| t["taxon_id"] }, :taxons)
       end
     end
   end

--- a/app/services/tagging/tagger.rb
+++ b/app/services/tagging/tagger.rb
@@ -1,10 +1,11 @@
 module Tagging
   class Tagger
-    def self.add_tags(content_id, taxon_ids)
+    def self.add_tags(content_id, link_ids, link_type)
       link_content = Services.publishing_api.get_links(content_id)
       version = link_content["version"]
-      taxons = (link_content.dig("links", "taxons") || []) + taxon_ids
-      Services.publishing_api.patch_links(content_id, links: { taxons: taxons.uniq }, previous_version: version, bulk_publishing: true)
+      current_links = Array(link_content.dig("links", link_type.to_s))
+      links = (current_links + link_ids).uniq
+      Services.publishing_api.patch_links(content_id, links: { "#{link_type}": links }, previous_version: version, bulk_publishing: true)
     rescue GdsApi::HTTPConflict, GdsApi::HTTPGatewayTimeout, GdsApi::TimedOutException
       retries ||= 0
       retry if (retries += 1) < 3

--- a/lib/tasks/travel_advice/tag_to_organisation.rake
+++ b/lib/tasks/travel_advice/tag_to_organisation.rake
@@ -1,0 +1,24 @@
+namespace :travel_advice do
+  desc "Tag a travel advice edition to an organisation"
+  task :tag_edition_to_organisation, %i[content_id org_id] => :environment do |_, args|
+    content_id = args.content_id
+    org_id = args.org_id
+
+    Tagging::Tagger.add_tags(content_id, [org_id], :organisations)
+  end
+
+  desc "Tag all published travel advice editions to an organisation"
+  task :tag_editions_to_organisation, %i[org_id] => :environment do |_, args|
+    org_id = args.org_id
+    response = Services.publishing_api.get_editions(
+      per_page: 300,
+      publishing_app: "travel-advice-publisher",
+      document_types: %w[travel_advice],
+      states: %w[published],
+    )
+
+    response["results"].each do |edition|
+      Tagging::Tagger.add_tags(edition["content_id"], [org_id], :organisations)
+    end
+  end
+end

--- a/spec/services/tagging/csv_tagger_spec.rb
+++ b/spec/services/tagging/csv_tagger_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe Tagging::Tagger do
     CSV
   end
   it "adds tags from the spreadsheet" do
-    expect(Tagging::Tagger).to receive(:add_tags).with("aaa", %w[1 3])
-    expect(Tagging::Tagger).to receive(:add_tags).with("bbb", %w[2])
+    expect(Tagging::Tagger).to receive(:add_tags).with("aaa", %w[1 3], :taxons)
+    expect(Tagging::Tagger).to receive(:add_tags).with("bbb", %w[2], :taxons)
 
     Tagging::CsvTagger.do_tagging("http://example.com/sheet.csv")
   end

--- a/spec/services/tagging/tagger_spec.rb
+++ b/spec/services/tagging/tagger_spec.rb
@@ -7,22 +7,29 @@ RSpec.describe Tagging::Tagger do
     @content_id = "64aadc14-9bca-40d9-abb4-4f21f9792a05"
   end
 
-  describe "#tag" do
-    it "tags content to a taxon" do
+  describe ".add_tags" do
+    it "tags content to taxons" do
       stub_publishing_api_has_links(content_id: @content_id, links: { taxons: %w[aaa bbb] }, version: 5)
       stub_any_publishing_api_patch_links
-      subject.add_tags(@content_id, %w[ccc ddd])
+      subject.add_tags(@content_id, %w[ccc ddd], :taxons)
       assert_publishing_api_patch_links(@content_id, links: { taxons: %w[aaa bbb ccc ddd] }, previous_version: 5, bulk_publishing: true)
+    end
+
+    it "tags content to organisations" do
+      stub_publishing_api_has_links(content_id: @content_id, links: { organisations: %w[gds fco] }, version: 5)
+      stub_any_publishing_api_patch_links
+      subject.add_tags(@content_id, %w[dfid dwp], :organisations)
+      assert_publishing_api_patch_links(@content_id, links: { organisations: %w[gds fco dfid dwp] }, previous_version: 5, bulk_publishing: true)
     end
 
     it "retries 3 times" do
       stub_publishing_api_has_links(content_id: @content_id, links: { taxons: %w[aaa bbb] }, version: 5)
 
       stub_any_publishing_api_patch_links.and_raise(GdsApi::HTTPConflict).times(2).then.to_return(body: "{}")
-      expect { subject.add_tags(@content_id, %w[ccc]) }.to_not raise_error
+      expect { subject.add_tags(@content_id, %w[ccc], :taxons) }.to_not raise_error
 
       stub_any_publishing_api_patch_links.and_raise(GdsApi::HTTPConflict).times(3).then.to_return(body: "{}")
-      expect { subject.add_tags(@content_id, %w[ccc]) }.to raise_error(GdsApi::HTTPConflict)
+      expect { subject.add_tags(@content_id, %w[ccc], :taxons) }.to raise_error(GdsApi::HTTPConflict)
     end
   end
 end


### PR DESCRIPTION
This adds two rake tasks:
- `travel_advice:tag_edition_to_organisation[content_id,org_id]` ([example](https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/171000/console))
- `travel_advice:tag_editions_to_organisation[org_id]` ([example](https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/171001/console))

The first allows passing the `content_id` of a travel advice edition and the `content_id` of an organisation to which the edition will be tagged. The second allows passing the `content_id` of an organisation to which all published travel advice editions will be tagged.

This is part of the work around the Machinery of Government changes that will see FCO and DFID merge to become a new department. It will make it possible to tag documents to organisations without republishing them.

The existing `Tagging::Tagger.add_tags` has been made more generic so that it can be used in these two rake tasks as well.

Trello card: https://trello.com/c/OLlCzb7K/2096-spike-bulk-retagging-travel-advice-organisation-tagging-to-fcdo