### PR TITLE
Always print code coverage after running tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,6 @@ group :development, :test do
   gem "rspec-rails"
   gem "rubocop-govuk"
   gem "simplecov", require: false
-  gem "simplecov-rcov", require: false
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -364,8 +364,6 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
     simplecov-html (0.12.2)
-    simplecov-rcov (0.2.3)
-      simplecov (>= 0.4.1)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -444,7 +442,6 @@ DEPENDENCIES
   select2-rails
   simple_form
   simplecov
-  simplecov-rcov
   timecop
   uglifier
   web-console

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,9 +1,5 @@
-if ENV["USE_COVERAGE"]
-  require "simplecov"
-  require "simplecov-rcov"
-  SimpleCov.formatter = SimpleCov::Formatter::RcovFormatter
-  SimpleCov.start "rails"
-end
+require "simplecov"
+SimpleCov.start "rails"
 
 ENV["RAILS_ENV"] = "test"
 ENV["GOVUK_APP_DOMAIN"] = "test.gov.uk"


### PR DESCRIPTION
https://trello.com/c/epNWudCR/176-write-an-rfc-for-continuous-deployment-and-seek-review

Note that the RCov formatter is optional. We can still see a page
with a detailed report of the coverage.