### PR TITLE
Add 'GdsApi::HTTPInternalServerError' to data sync errors

### DIFF
--- a/config/initializers/govuk_error.rb
+++ b/config/initializers/govuk_error.rb
@@ -1,0 +1,3 @@
+GovukError.configure do |config|
+  config.data_sync_excluded_exceptions << "GdsApi::HTTPInternalServerError"
+end


### PR DESCRIPTION
We had 68 events in Sentry overnight:

```
GdsApi::HTTPInternalServerError
URL: https://publishing-api.staging.govuk-internal.digital/v2/content/f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a
Response body:
{"status":500,"error":"Internal Server Error"}
```

Looking at the [event history], these errors only happen around
3-4am during the nightly [data sync], and should be ignored.

[data sync]: https://docs.publishing.service.gov.uk/manual/govuk-env-sync.html
[event history]: https://sentry.io/organizations/govuk/issues/483695973/events/?project=202218&statsPeriod=24h

Trello: https://trello.com/c/rAlvGlSp/2123-5-ignore-data-sync-errors-in-govukappconfig