### PR TITLE
Make Dockerfile more production focused

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,21 +2,24 @@ FROM ruby:2.7.2
 RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y build-essential nodejs && apt-get clean
 RUN gem install foreman
 
+# This image is only intended to be able to run this app in a production RAILS_ENV
+ENV RAILS_ENV production
+
 ENV DATABASE_URL postgresql://postgres@postgres/content-tagger
 ENV GOVUK_APP_NAME content-tagger
 ENV PORT 3116
-ENV RAILS_ENV development
-ENV REDIS_HOST redis
 
 ENV APP_HOME /app
 RUN mkdir $APP_HOME
 
 WORKDIR $APP_HOME
 ADD Gemfile* $APP_HOME/
-RUN bundle install
+RUN bundle config set deployment 'true'
+RUN bundle config set without 'development test'
+RUN bundle install --jobs 4
 ADD . $APP_HOME
 
-RUN GOVUK_APP_DOMAIN=www.gov.uk GOVUK_APP_DOMAIN_EXTERNAL=www.gov.uk RAILS_ENV=production bundle exec rails assets:precompile
+RUN GOVUK_APP_DOMAIN=www.gov.uk GOVUK_APP_DOMAIN_EXTERNAL=www.gov.uk bundle exec rails assets:precompile
 
 HEALTHCHECK CMD curl --silent --fail localhost:$PORT || exit 1
 


### PR DESCRIPTION
This removes REDIS_HOST as GOV.UK no longer use that env var to
configure Redis. The rest of the Dockerfile is then updated in a
consistent manner to static [1], where it's tailored towards production
running - reflecting that no-one can use this for test environments (and
potentially development ones).

[1]: https://github.com/alphagov/static/pull/2327