### PR TITLE
Add rake task to update travel advice related links

### DIFF
--- a/lib/tasks/travel_advice/tmp_add_step_by_step.rake
+++ b/lib/tasks/travel_advice/tmp_add_step_by_step.rake
@@ -1,0 +1,27 @@
+namespace :travel_advice do
+  desc "Adds step-by-step to related links"
+  task add_step_by_step: :environment do
+    link_to_add = "8c0c7b83-5e0b-4bed-9121-1c394e2f96f3"
+    position = 1
+
+    response = Services.publishing_api.get_editions(
+      per_page: 300,
+      publishing_app: "travel-advice-publisher",
+      document_types: %w[travel_advice],
+      states: %w[published],
+    )
+
+    response["results"].each do |edition|
+      links = Services.publishing_api.get_links(edition["content_id"])["links"]
+      next unless links && links["ordered_related_items"]
+
+      links["ordered_related_items"].insert(position, link_to_add)
+
+      Services.publishing_api.patch_links(
+        edition["content_id"],
+        links: links,
+        bulk_publishing: true,
+      )
+    end
+  end
+end

--- a/spec/lib/tasks/travel_advice/tmp_add_step_by_step_spec.rb
+++ b/spec/lib/tasks/travel_advice/tmp_add_step_by_step_spec.rb
@@ -1,0 +1,73 @@
+require "rails_helper"
+
+RSpec.describe "travel_advice:add_step_by_step" do
+  include PublishingApiHelper
+  include RakeTaskHelper
+
+  let(:edition) do
+    {
+      content_id: SecureRandom.uuid,
+      document_type: "travel_advice",
+      publishing_app: "travel-advice-publisher",
+      links: {
+        ordered_related_items: %w[
+          850ce029-b884-4c1f-8410-7f8fe7e49426
+          98c68202-8c31-405c-b2dc-ad3c00eda687
+        ],
+      },
+    }
+  end
+
+  before do
+    stub_publishing_api_get_editions(
+      [edition],
+      per_page: 300,
+      publishing_app: "travel-advice-publisher",
+      document_types: %w[travel_advice],
+      states: %w[published],
+    )
+
+    stub_publishing_api_has_links(
+      {
+        content_id: edition[:content_id],
+        links: edition[:links],
+      },
+    )
+
+    stub_any_publishing_api_patch_links
+  end
+
+  it "adds a link in the second position of ordered_related_items for travel advice" do
+    rake "travel_advice:add_step_by_step"
+
+    assert_publishing_api_patch_links(
+      edition[:content_id],
+      links: {
+        "ordered_related_items" => %w[
+          850ce029-b884-4c1f-8410-7f8fe7e49426
+          8c0c7b83-5e0b-4bed-9121-1c394e2f96f3
+          98c68202-8c31-405c-b2dc-ad3c00eda687
+        ],
+      },
+      bulk_publishing: true,
+    )
+  end
+
+  it "does not add a link in the second position of ordered_related_items for other content types" do
+    edition[:document_type] = "publication"
+
+    rake "travel_advice:add_step_by_step"
+
+    refute(assert_publishing_api_patch_links(
+             edition[:content_id],
+             links: {
+               "ordered_related_items" => %w[
+                 850ce029-b884-4c1f-8410-7f8fe7e49426
+                 8c0c7b83-5e0b-4bed-9121-1c394e2f96f3
+                 98c68202-8c31-405c-b2dc-ad3c00eda687
+               ],
+             },
+             bulk_publishing: true,
+           ))
+  end
+end


### PR DESCRIPTION
This updates the related links on all travel advice pages to include the "Travel abroad: step by step" as the second item in the related links.

These updates would normally be made through the Content Tagger UI, but there are 226 pages to update, so this would be a time consuming process.

This rake task has been [tested in the integration environment](https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/229638/console) and it can be removed after it has been run in production.

Trello card: https://trello.com/c/xu5zaFcw