### PR TITLE
Add support for exporting smart answers content

### DIFF
--- a/lib/tasks/export_mainstream_taxons.rake
+++ b/lib/tasks/export_mainstream_taxons.rake
@@ -6,6 +6,7 @@ namespace :govuk do
       answer
       guide
       simple_smart_answer
+      smart_answer
       transaction
       completed_transaction
       travel_advice_index


### PR DESCRIPTION
This adds support for the new `smart_answer` schema when exporting taxons of mainstream content as CSV. Previously smart answers were represented by the transaction schema. This ensures the functionality doesn't break when Smart Answer flows are republished with the new schema.