### PR TITLE
Add override url to the taxon class

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -28,11 +28,13 @@ private
     :user_can_administer_taxonomy?,
     :user_can_manage_taxonomy?,
     :user_can_access_tagathon_tools?,
+    :user_can_override_taxon_url?,
   )
 
   delegate :user_can_administer_taxonomy?,
            :user_can_manage_taxonomy?,
            :user_can_access_tagathon_tools?,
+           :user_can_override_taxon_url?,
            to: :permission_checker
 
   def ensure_user_can_administer_taxonomy!

--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -21,7 +21,7 @@ class TaxonsController < ApplicationController
   end
 
   def new
-    render :new, locals: { page: Taxonomy::EditPage.new(Taxon.new(taxon_params)) }
+    render :new, locals: { page: Taxonomy::EditPage.new(Taxon.new(taxon_params), url_override_permission) }
   end
 
   def create
@@ -33,11 +33,11 @@ class TaxonsController < ApplicationController
     else
       error_messages = taxon.errors.full_messages.join("; ")
       flash.now[:danger] = error_messages
-      render :new, locals: { page: Taxonomy::EditPage.new(taxon) }
+      render :new, locals: { page: Taxonomy::EditPage.new(taxon, url_override_permission) }
     end
   rescue Taxonomy::UpdateTaxon::InvalidTaxonError => e
     flash.now[:danger] = e.message
-    render :new, locals: { page: Taxonomy::EditPage.new(taxon) }
+    render :new, locals: { page: Taxonomy::EditPage.new(taxon, url_override_permission) }
   end
 
   def show
@@ -67,7 +67,7 @@ class TaxonsController < ApplicationController
   end
 
   def edit
-    render :edit, locals: { page: Taxonomy::EditPage.new(taxon) }
+    render :edit, locals: { page: Taxonomy::EditPage.new(taxon, url_override_permission) }
   end
 
   def update
@@ -80,11 +80,11 @@ class TaxonsController < ApplicationController
     else
       error_messages = taxon.errors.full_messages.join("; ")
       flash.now[:danger] = error_messages
-      render :edit, locals: { page: Taxonomy::EditPage.new(taxon) }
+      render :edit, locals: { page: Taxonomy::EditPage.new(taxon, url_override_permission) }
     end
   rescue Taxonomy::UpdateTaxon::InvalidTaxonError => e
     flash.now[:danger] = e.message
-    render :edit, locals: { page: Taxonomy::EditPage.new(taxon) }
+    render :edit, locals: { page: Taxonomy::EditPage.new(taxon, url_override_permission) }
   end
 
   def destroy
@@ -167,7 +167,7 @@ class TaxonsController < ApplicationController
       flash.now[:danger] = I18n.t("errors.invalid_taxon")
     end
 
-    render :edit, locals: { page: Taxonomy::EditPage.new(taxon) }
+    render :edit, locals: { page: Taxonomy::EditPage.new(taxon, url_override_permission) }
   end
 
   def confirm_discard
@@ -220,6 +220,10 @@ private
 
   def taxon
     @taxon ||= Taxonomy::BuildTaxon.call(content_id: content_id)
+  end
+
+  def url_override_permission
+    user_can_override_taxon_url?
   end
 
   helper_method :visualisation_to_render

--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -201,6 +201,7 @@ private
     params.fetch(:taxon, {}).permit(
       :content_id,
       :base_path,
+      :url_override,
       :internal_name,
       :title,
       :description,

--- a/app/lib/permission_checker.rb
+++ b/app/lib/permission_checker.rb
@@ -2,6 +2,7 @@ class PermissionChecker
   GDS_EDITOR_PERMISSION = "GDS Editor".freeze
   TAGATHON_PARTICIPANT_PERMISSION = "Tagathon participant".freeze
   MANAGING_EDITOR_PERMISSION = "Managing Editor".freeze
+  UNRELEASED_FEATURE_PERMISSION = "Unreleased feature".freeze
 
   def initialize(user)
     @user = user
@@ -19,6 +20,10 @@ class PermissionChecker
     gds_editor? || managing_editor? || tagathon_participant?
   end
 
+  def user_can_override_taxon_url?
+    user_can_administer_taxonomy? && unreleased_feature_editor?
+  end
+
 private
 
   attr_reader :user
@@ -33,5 +38,9 @@ private
 
   def tagathon_participant?
     user.has_permission?(TAGATHON_PARTICIPANT_PERMISSION)
+  end
+
+  def unreleased_feature_editor?
+    user.has_permission?(UNRELEASED_FEATURE_PERMISSION)
   end
 end

--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -12,7 +12,7 @@ class Taxon
     :redirect_to,
     :associated_taxons,
   )
-  attr_writer :content_id, :notes_for_editors, :internal_name
+  attr_writer :content_id, :notes_for_editors, :internal_name, :url_override
   attr_reader :base_path, :path_prefix, :path_slug, :legacy_taxons
 
   include ActiveModel::Model
@@ -20,6 +20,7 @@ class Taxon
   validates :title, :internal_name, :base_path, presence: true
   validates_with CircularDependencyValidator
   validates :base_path, format: { with: PATH_COMPONENTS_REGEX, message: "must be in the format '/highest-level-taxon-name/taxon-name'" }
+  validates :url_override, format: { with: PATH_COMPONENTS_REGEX, message: "must be in the format '/prefix/slug'" }, allow_blank: true
   validates_with TaxonPathPrefixValidator
 
   def draft?
@@ -85,6 +86,10 @@ class Taxon
 
   def notes_for_editors
     @notes_for_editors || ""
+  end
+
+  def url_override
+    @url_override || ""
   end
 
   # Lets talk about this.

--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -20,7 +20,7 @@ class Taxon
   validates :title, :internal_name, :base_path, presence: true
   validates_with CircularDependencyValidator
   validates :base_path, format: { with: PATH_COMPONENTS_REGEX, message: "must be in the format '/highest-level-taxon-name/taxon-name'" }
-  validates :url_override, format: { with: PATH_COMPONENTS_REGEX, message: "must be in the format '/prefix/slug'" }, allow_blank: true
+  validates :url_override, format: { with: PATH_COMPONENTS_REGEX, message: "must be in the format '/prefix/slug' or '/slug'" }, allow_blank: true
   validates_with TaxonPathPrefixValidator
 
   def draft?

--- a/app/services/taxonomy/build_taxon.rb
+++ b/app/services/taxonomy/build_taxon.rb
@@ -26,6 +26,7 @@ module Taxonomy
         phase: content_item["phase"],
         internal_name: content_item["details"]["internal_name"],
         notes_for_editors: content_item["details"]["notes_for_editors"],
+        url_override: content_item["details"]["url_override"],
         parent_content_id: parent,
         associated_taxons: links.dig("associated_taxons"),
         legacy_taxons: legacy_taxon_paths,

--- a/app/services/taxonomy/build_taxon_payload.rb
+++ b/app/services/taxonomy/build_taxon_payload.rb
@@ -21,6 +21,7 @@ module Taxonomy
         details: {
           internal_name: internal_name,
           notes_for_editors: notes_for_editors,
+          url_override: url_override,
           visible_to_departmental_editors: visible_to_departmental_editors,
         },
         routes: [
@@ -41,12 +42,14 @@ module Taxonomy
     end
 
     attr_reader :taxon
+
     delegate(
       :base_path,
       :title,
       :description,
       :internal_name,
       :notes_for_editors,
+      :url_override,
       :phase,
       :visible_to_departmental_editors,
       to: :taxon,

--- a/app/services/taxonomy/edit_page.rb
+++ b/app/services/taxonomy/edit_page.rb
@@ -2,15 +2,16 @@ module Taxonomy
   class EditPage
     delegate :published?, to: :taxon
 
-    attr_reader :taxon
+    attr_reader :taxon, :url_override_permission
 
-    def initialize(taxon)
+    def initialize(taxon, url_override_permission = nil)
       @taxon = taxon
+      @url_override_permission = url_override_permission
     end
 
     delegate :content_id, to: :taxon, prefix: true
 
-    delegate :title, to: :taxon
+    delegate :title, :url_override, to: :taxon
 
     def taxons_for_select
       Linkables.new.taxons_including_root(exclude_ids: taxon.content_id)
@@ -20,8 +21,12 @@ module Taxonomy
       taxon.parent_content_id == GovukTaxonomy::ROOT_CONTENT_ID
     end
 
-    def show_url_override_field?
-      true
+    def show_url_override_input_field?
+      url_override_permission
+    end
+
+    def show_url_override?
+      url_override.present? && !show_url_override_input_field?
     end
   end
 end

--- a/app/services/taxonomy/edit_page.rb
+++ b/app/services/taxonomy/edit_page.rb
@@ -19,5 +19,9 @@ module Taxonomy
     def show_visibilty_checkbox?
       taxon.parent_content_id == GovukTaxonomy::ROOT_CONTENT_ID
     end
+
+    def show_url_override_field?
+      true
+    end
   end
 end

--- a/app/services/taxonomy/update_taxon.rb
+++ b/app/services/taxonomy/update_taxon.rb
@@ -3,6 +3,7 @@ module Taxonomy
     include TransitionTaxon
 
     attr_reader :taxon
+
     delegate :content_id, :parent_content_id, :associated_taxons, :legacy_taxons, to: :taxon
 
     class InvalidTaxonError < StandardError; end

--- a/app/views/taxons/_form_fields.html.erb
+++ b/app/views/taxons/_form_fields.html.erb
@@ -1,11 +1,17 @@
 <div data-module="parent-taxon-prefix-preview">
   <%= f.input :parent_content_id, collection: page.taxons_for_select, label: 'Parent',
     input_html: { class: 'js-parent-taxon form-control', include_blank: true } %>
-  <% if page.show_url_override_field? %>
+
+  <% if page.show_url_override_input_field? %>
     <%= f.input :url_override, input_html: { class: 'form-control' },
       label: I18n.t('views.taxons.url_override'),
       hint: I18n.t('views.taxons.url_override_hint') %>
   <% end %>
+  <% if page.show_url_override? %>
+    <label>URL override</label>
+    <p class="help-block"><%= page.url_override %></p>
+  <% end %>
+
   <%= f.input :base_path, input_html: { class: 'form-control' },
     placeholder: 'e.g. /highest-level-taxon-name/taxon-name' %>
 

--- a/app/views/taxons/_form_fields.html.erb
+++ b/app/views/taxons/_form_fields.html.erb
@@ -1,7 +1,11 @@
 <div data-module="parent-taxon-prefix-preview">
   <%= f.input :parent_content_id, collection: page.taxons_for_select, label: 'Parent',
     input_html: { class: 'js-parent-taxon form-control', include_blank: true } %>
-
+  <% if page.show_url_override_field? %>
+    <%= f.input :url_override, input_html: { class: 'form-control' },
+      label: I18n.t('views.taxons.url_override'),
+      hint: I18n.t('views.taxons.url_override_hint') %>
+  <% end %>
   <%= f.input :base_path, input_html: { class: 'form-control' },
     placeholder: 'e.g. /highest-level-taxon-name/taxon-name' %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -108,6 +108,8 @@ en:
       visible_to_departmental_editors_hint: 'Affects the visiblity of level one taxons only'
       associated_taxons: Associated taxons
       metadata: Taxon metadata
+      url_override: 'Override URL'
+      url_override_hint: 'Set a custom URL to overide the default base path'
     projects:
       flags:
         help-needed: 'Flagged: needs publisher review'

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -15,5 +15,9 @@ FactoryBot.define do
     trait :tagathon_participant do
       permissions { ["signin", "Tagathon participant"] }
     end
+
+    trait :unreleased_feature_editor do
+      permissions { ["signin", "GDS Editor", "Unreleased feature"] }
+    end
   end
 end

--- a/spec/features/taxonomy_editing_spec.rb
+++ b/spec/features/taxonomy_editing_spec.rb
@@ -136,7 +136,7 @@ RSpec.feature "Taxonomy editing" do
     then_a_taxon_with_associated_taxons_is_created
   end
 
-  scenario "User creates a taxon with an override url" do
+  scenario "User with unreleased_feature_editor permissions creates taxon with override url", type: :unreleased_feature do
     given_there_are_taxons
     when_i_visit_the_taxonomy_page
     and_i_click_on_the_new_taxon_button

--- a/spec/lib/permission_checker_spec.rb
+++ b/spec/lib/permission_checker_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe PermissionChecker do
     it { is_expected.not_to have_permission(:user_can_administer_taxonomy?) }
     it { is_expected.not_to have_permission(:user_can_manage_taxonomy?) }
     it { is_expected.not_to have_permission(:user_can_access_tagathon_tools?) }
+    it { is_expected.not_to have_permission(:user_can_override_taxon_url?) }
   end
 
   context "when the user has the Gds Editor permission" do
@@ -21,6 +22,7 @@ RSpec.describe PermissionChecker do
     it { is_expected.to have_permission(:user_can_administer_taxonomy?) }
     it { is_expected.to have_permission(:user_can_manage_taxonomy?) }
     it { is_expected.to have_permission(:user_can_access_tagathon_tools?) }
+    it { is_expected.not_to have_permission(:user_can_override_taxon_url?) }
   end
 
   context "when the user has the Managing Editor permission" do
@@ -30,7 +32,9 @@ RSpec.describe PermissionChecker do
         .with("Managing Editor")
         .and_return(true)
     end
+
     it { is_expected.not_to have_permission(:user_can_administer_taxonomy?) }
+    it { is_expected.not_to have_permission(:user_can_override_taxon_url?) }
     it { is_expected.to have_permission(:user_can_manage_taxonomy?) }
     it { is_expected.to have_permission(:user_can_access_tagathon_tools?) }
   end
@@ -45,6 +49,35 @@ RSpec.describe PermissionChecker do
 
     it { is_expected.not_to have_permission(:user_can_administer_taxonomy?) }
     it { is_expected.not_to have_permission(:user_can_manage_taxonomy?) }
+    it { is_expected.not_to have_permission(:user_can_override_taxon_url?) }
     it { is_expected.to have_permission(:user_can_access_tagathon_tools?) }
+  end
+
+  context "when the user has the Unreleased feature permission" do
+    before do
+      allow(user)
+        .to receive(:has_permission?)
+        .with("Unreleased feature")
+        .and_return(true)
+    end
+
+    it { is_expected.not_to have_permission(:user_can_access_tagathon_tools?) }
+    it { is_expected.not_to have_permission(:user_can_administer_taxonomy?) }
+    it { is_expected.not_to have_permission(:user_can_manage_taxonomy?) }
+    it { is_expected.not_to have_permission(:user_can_override_taxon_url?) }
+
+    context "AND gds_editor permissions" do
+      before do
+        allow(user)
+          .to receive(:has_permission?)
+          .with("GDS Editor")
+          .and_return(true)
+      end
+
+      it { is_expected.to have_permission(:user_can_access_tagathon_tools?) }
+      it { is_expected.to have_permission(:user_can_administer_taxonomy?) }
+      it { is_expected.to have_permission(:user_can_manage_taxonomy?) }
+      it { is_expected.to have_permission(:user_can_override_taxon_url?) }
+    end
   end
 end

--- a/spec/models/taxon_spec.rb
+++ b/spec/models/taxon_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe Taxon do
       expect(valid_taxon).to be_valid
       expect(invalid_taxon).to_not be_valid
       expect(invalid_taxon.errors[:url_override]).to include(
-        "must be in the format '/prefix/slug'",
+        "must be in the format '/prefix/slug' or '/slug'",
       )
     end
   end

--- a/spec/models/taxon_spec.rb
+++ b/spec/models/taxon_spec.rb
@@ -46,6 +46,38 @@ RSpec.describe Taxon do
     end
   end
 
+  context "without url_override set" do
+    it "returns an empty string to comply with the schema definition" do
+      taxon = described_class.new
+
+      expect(taxon.url_override).to eq("")
+    end
+  end
+
+  context "with url_override set" do
+    it "must have the correct format" do
+      valid_taxon = described_class.new(
+        title: "Title",
+        description: "Description",
+        base_path: "/education",
+        url_override: "/guidance/education-is-fun",
+      )
+
+      invalid_taxon = described_class.new(
+        title: "Title",
+        description: "Description",
+        base_path: "/education",
+        url_override: "education-is-b@d!",
+      )
+
+      expect(valid_taxon).to be_valid
+      expect(invalid_taxon).to_not be_valid
+      expect(invalid_taxon.errors[:url_override]).to include(
+        "must be in the format '/prefix/slug'",
+      )
+    end
+  end
+
   it "must have a base path with at most two segments" do
     level_one_taxon = described_class.new(
       title: "Title",

--- a/spec/services/taxonomy/build_taxon_payload_spec.rb
+++ b/spec/services/taxonomy/build_taxon_payload_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Taxonomy::BuildTaxonPayload do
       Taxon,
       title: "My Title",
       base_path: "/taxons/my-taxon",
+      url_override: "/taxons-are-fun",
       description: "This is a taxon.",
       internal_name: "Internal title",
       notes_for_editors: "Use this taxon wisely.",

--- a/spec/services/taxonomy/build_taxon_spec.rb
+++ b/spec/services/taxonomy/build_taxon_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe Taxonomy::BuildTaxon do
           internal_name: "Internal name",
           notes_for_editors: "Notes for editors",
           visible_to_departmental_editors: true,
+          url_override: "",
         },
       }
     end
@@ -79,6 +80,10 @@ RSpec.describe Taxonomy::BuildTaxon do
 
     it "assigns the notes_for_editors correctly" do
       expect(taxon.notes_for_editors).to eq("Notes for editors")
+    end
+
+    it "assigns the url_override correctly" do
+      expect(taxon.url_override).to eq("")
     end
 
     it "assigns the visible_to_departmental_editors flag correctly" do

--- a/spec/services/taxonomy/edit_page_spec.rb
+++ b/spec/services/taxonomy/edit_page_spec.rb
@@ -16,4 +16,51 @@ RSpec.describe Taxonomy::EditPage do
       expect(result).to be false
     end
   end
+
+  describe "#show_url_override_input_field?" do
+    it "returns true when the url_override_permission is true" do
+      taxon = instance_double(Taxon)
+      result = Taxonomy::EditPage.new(taxon, true).show_url_override_input_field?
+
+      expect(result).to be true
+    end
+
+    it "returns false when the url_override_permission is false" do
+      taxon = instance_double(Taxon)
+      url_override_permission = false
+      page = Taxonomy::EditPage.new(taxon, url_override_permission)
+      result = page.show_url_override_input_field?
+
+      expect(result).to be false
+    end
+  end
+
+  describe "#show_url_override?" do
+    it "returns false if the user has url_override_permission" do
+      taxon = instance_double(Taxon, url_override: "")
+      url_override_permission = true
+      page = Taxonomy::EditPage.new(taxon, url_override_permission)
+      result = page.show_url_override?
+
+      expect(result).to be false
+    end
+
+    it "returns false if the user has no url_override_permission and url_override is empty" do
+      taxon = instance_double(Taxon, url_override: "")
+      url_override_permission = false
+      page = Taxonomy::EditPage.new(taxon, url_override_permission)
+      result = page.show_url_override?
+
+      expect(result).to be false
+    end
+
+    it "returns true if user has no url_override_permission and the url_override is present" do
+      taxon = instance_double(Taxon, url_override: "/foo")
+      url_override_permission = false
+      page = Taxonomy::EditPage.new(taxon, url_override_permission)
+      result = page.show_url_override?
+
+      expect(result).to be true
+    end
+  end
 end

--- a/spec/support/authentication_helpers.rb
+++ b/spec/support/authentication_helpers.rb
@@ -25,8 +25,16 @@ module AuthenticationFeatureHelpers
     @stub_user ||= FactoryBot.create(:user, :gds_editor)
   end
 
+  def unreleased_feature_editor
+    @unreleased_feature_editor ||= FactoryBot.create(:user, :unreleased_feature_editor)
+  end
+
   def login_as_stub_user
     login_as stub_user
+  end
+
+  def login_as_unreleased_feature_editor
+    login_as unreleased_feature_editor
   end
 end
 
@@ -39,6 +47,10 @@ RSpec.configure do |config|
   config.include AuthenticationFeatureHelpers, type: :feature
   config.before(:each, type: :feature) do
     login_as_stub_user
+  end
+
+  config.before(:example, type: :unreleased_feature) do
+    login_as_unreleased_feature_editor
   end
 
   config.include AuthenticationFeatureHelpers, type: :request


### PR DESCRIPTION
## What

Make it possible to add an override_url field to taxons in content tagger.

- New input field on the Edit taxon page of content tagger.

### A user with Unreleased feature signon permissions:

<img width="1218" alt="Screenshot 2021-05-21 at 13 41 16" src="https://user-images.githubusercontent.com/17908089/119138959-6331a700-ba3a-11eb-9a7e-e35cf7693893.png">

### A user without Unreleased feature signon permissions:

<img width="1212" alt="Screenshot 2021-05-21 at 13 44 38" src="https://user-images.githubusercontent.com/17908089/119139347-d1766980-ba3a-11eb-8b9e-2f36fe3376c3.png">

### Field in [content item](https://www.integration.publishing.service.gov.uk/api/content/world/brexit-norway):


<img width="470" alt="Screenshot 2021-05-21 at 13 46 31" src="https://user-images.githubusercontent.com/17908089/119139505-01257180-ba3b-11eb-94e4-9bd4195945d8.png">


Related https://github.com/alphagov/govuk-content-schemas/pull/1059

[Trello](https://trello.com/c/V2nmHHA6/1516-add-overrideurl-to-taxons) 