### PR TITLE
Increase how long content tagger waits for publishing api

### DIFF
--- a/app/services/taxonomy/links_update.rb
+++ b/app/services/taxonomy/links_update.rb
@@ -9,7 +9,7 @@ module Taxonomy
 
     def call
       if @parent_taxon_id == GovukTaxonomy::ROOT_CONTENT_ID
-        Services.publishing_api.patch_links(
+        Services.publishing_api_with_long_timeout.patch_links(
           @content_id,
           links: {
             root_taxon: Array(@parent_taxon_id),
@@ -20,7 +20,7 @@ module Taxonomy
         )
 
       else
-        Services.publishing_api.patch_links(
+        Services.publishing_api_with_long_timeout.patch_links(
           @content_id,
           links: {
             root_taxon: [],

--- a/app/services/taxonomy/show_page.rb
+++ b/app/services/taxonomy/show_page.rb
@@ -65,7 +65,7 @@ module Taxonomy
       @tagged ||= begin
         return [] if taxon.unpublished?
 
-        Services.publishing_api.get_linked_items(
+        Services.publishing_api_with_long_timeout.get_linked_items(
           taxon.content_id,
           link_type: "taxons",
           fields: %w[title content_id base_path document_type],


### PR DESCRIPTION
On integration Publishing api is taking longer than 4 seconds to respond to get and patch link requests from content-tagger. 
There's no harm in increasing this on production where response times from publishing api are fine. 
