### PR TITLE
Use RestClient to get bulk upload CSVs

### DIFF
--- a/app/lib/remote_csv.rb
+++ b/app/lib/remote_csv.rb
@@ -29,6 +29,6 @@ private
   end
 
   def response
-    Net::HTTP.get_response(URI(@csv_url))
+    RestClient.get @csv_url
   end
 end

--- a/app/services/bulk_tagging/fetch_remote_data.rb
+++ b/app/services/bulk_tagging/fetch_remote_data.rb
@@ -15,13 +15,12 @@ module BulkTagging
     end
 
     def call
-      unless valid_response?
-        GovukError.notify(RuntimeError.new(response.body))
-        return [spreadsheet_download_error]
-      end
-
+      response
       process_spreadsheet
       errors
+    rescue RestClient::Exception => e
+      GovukError.notify(e)
+      [spreadsheet_download_error]
     end
 
   private
@@ -57,12 +56,8 @@ module BulkTagging
       I18n.t("errors.spreadsheet_download_error")
     end
 
-    def valid_response?
-      response.code == "200"
-    end
-
     def response
-      @response ||= Net::HTTP.get_response(URI(tagging_spreadsheet.url))
+      @response ||= RestClient.get tagging_spreadsheet.url
     end
 
     def sheet_data

--- a/spec/lib/remote_csv_spec.rb
+++ b/spec/lib/remote_csv_spec.rb
@@ -26,14 +26,14 @@ RSpec.describe RemoteCsv, "#rows_with_headers" do
 
   it "raises an error when the URI is invalid" do
     expect { RemoteCsv.new("not a URL").rows_with_headers }
-      .to raise_error RemoteCsv::ParsingError, 'URI::InvalidURIError: bad URI(is not URI?): "not a URL"'
+      .to raise_error RemoteCsv::ParsingError, 'URI::InvalidURIError: bad URI(is not URI?): "http://not a URL"'
   end
 
   it "raises an error when the connection failed" do
     stub_request(:get, csv_url).to_timeout
 
     expect { RemoteCsv.new(csv_url).rows_with_headers }
-      .to raise_error RemoteCsv::ParsingError, "Net::OpenTimeout: execution expired"
+      .to raise_error RemoteCsv::ParsingError, "RestClient::Exceptions::OpenTimeout: Timed out connecting to server"
   end
 
   it "raises an error when the CSV is malformed" do

--- a/spec/services/bulk_tagging/fetch_remote_data_spec.rb
+++ b/spec/services/bulk_tagging/fetch_remote_data_spec.rb
@@ -5,19 +5,12 @@ module BulkTagging
     include GoogleSheetHelper
 
     describe ".call" do
-      let(:url) { URI(tagging_spreadsheet.url) }
+      let(:url) { tagging_spreadsheet.url }
       let(:tagging_spreadsheet) { create(:tagging_spreadsheet) }
 
       context "with a valid response" do
         before do
-          good_response = double(code: "200", body: google_sheet_fixture)
-          allow(Net::HTTP).to receive(:get_response).with(url).and_return(good_response)
-        end
-
-        it "retrieves data from the tagging spreadsheet URL" do
-          expect(Net::HTTP).to receive(:get_response).with(url)
-
-          FetchRemoteData.call(tagging_spreadsheet)
+          stub_request(:get, url).to_return(body: google_sheet_fixture, status: 200)
         end
 
         it "creates tag mappings based on the retrieved data" do
@@ -38,8 +31,7 @@ module BulkTagging
               ),
             ],
           )
-          response = double("DodgyResponse", code: "200", body: dodgy_spreadsheet_data)
-          allow(Net::HTTP).to receive(:get_response).with(url).and_return(response)
+          stub_request(:get, url).to_return(body: dodgy_spreadsheet_data, status: 200)
 
           FetchRemoteData.new(tagging_spreadsheet).call
 
@@ -66,8 +58,7 @@ module BulkTagging
             ],
           )
 
-          good_response = double(code: "200", body: google_sheet_data)
-          allow(Net::HTTP).to receive(:get_response).with(url).and_return(good_response)
+          stub_request(:get, url).to_return(body: google_sheet_data, status: 200)
         end
 
         it "saves each record per row" do
@@ -80,8 +71,7 @@ module BulkTagging
 
       context "with an invalid response" do
         before do
-          bad_response = double(code: "400", body: "<html>a long page</html>")
-          allow(Net::HTTP).to receive(:get_response).with(url).and_return(bad_response)
+          stub_request(:get, url).to_return(body: "<html>a long page</html>", status: 400)
         end
 
         it "does not create any taggings" do


### PR DESCRIPTION
RestClient follows redirects by default. It looks like the behaviour for  published CSV docs has changed recently in that the published URL redirects to another short-lived location. Unfortunately, this breaks the workflow in this app because Net/HTTP doesn't follow redirects automatically.

This means we end up with lots of [errors in sentry](https://sentry.io/organizations/govuk/issues/2457278761/?project=202218&query=is%3Aunresolved) instead of tagged documents.

I've flipped some of the tests to use webmock instead of artificially producing results from Net/Http or whatever. It means we're less tied to an implementation and more accurately reflects how the system is behaving.

https://trello.com/c/0TPeCsrG/1525-create-two-brexit-child-taxons-for-businesses-and-citizens-and-tag-content-displaying-the-superbreadcrumb-to-relevant-child-taxo