### PR TITLE
Revert select2-rails from 4.0.13 to 3.5.11

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem "kaminari"
 gem "pg"
 gem "rack-proxy"
 gem "sassc-rails"
-gem "select2-rails"
+gem "select2-rails", "~> 3.5.11"
 gem "simple_form"
 gem "uglifier"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -349,7 +349,7 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    select2-rails (4.0.13)
+    select2-rails (3.5.11)
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
@@ -447,7 +447,7 @@ DEPENDENCIES
   rspec-rails
   rubocop-govuk
   sassc-rails
-  select2-rails
+  select2-rails (~> 3.5.11)
   simple_form
   simplecov
   timecop


### PR DESCRIPTION
Version 4 (introduced in https://github.com/alphagov/content-tagger/pull/1234) of `select2-rails` removes `s2id_*` prefixed from IDs of select2 elements.  This broke an end-to-end tests.  Although [fixed](https://github.com/alphagov/publishing-e2e-tests/pull/427), this may cause unintended issues elsewhere.  Additionally, there appear to be some subtle visual changes to the `select2` elements in version 4.

Therefore reverting the dependency to an earlier version which resolves the problem https://github.com/alphagov/content-tagger/pull/1234 was trying to solve (i.e. remove the dependency on `thor (~> 0.14)`, but retains the `s2id` prefixed IDs for the elements.

[Trello card](https://trello.com/c/V56Gndqj)