### PR TITLE
Fix deprecation warning about using << on error

### DIFF
--- a/app/forms/content_lookup_form.rb
+++ b/app/forms/content_lookup_form.rb
@@ -24,14 +24,14 @@ private
   def content_item_should_have_been_found!
     return true if content_id
 
-    errors[:base_path] << "No page found with this path"
+    errors.add(:base_path, message: "No page found with this path")
     false
   end
 
   def strip_host
     self.base_path = URI.parse(base_path).path
   rescue URI::InvalidURIError
-    errors[:base_path] << "This is not a valid URL or path"
+    errors.add(:base_path, message: "This is not a valid URL or path")
     false
   end
 end

--- a/app/forms/new_project_form.rb
+++ b/app/forms/new_project_form.rb
@@ -30,7 +30,7 @@ class NewProjectForm
 
     true
   rescue RemoteCsv::ParsingError, ActiveModel::UnknownAttributeError => e
-    errors[:remote_url] << e.message
+    errors.add(:remote_url, message: e.message)
     false
   rescue ProjectBuilder::DuplicateContentItemsError => e
     errors[:base] << [e.message, e.conflicting_items_urls]

--- a/app/validators/taxon_path_prefix_validator.rb
+++ b/app/validators/taxon_path_prefix_validator.rb
@@ -7,6 +7,6 @@ class TaxonPathPrefixValidator < ActiveModel::Validator
 
     return if record.path_prefix == parent_taxon.path_prefix
 
-    record.errors[:base_path] << "must start with /#{parent_taxon.path_prefix}"
+    record.errors.add(:base_path, message: "must start with /#{parent_taxon.path_prefix}")
   end
 end


### PR DESCRIPTION
Change `errors <<` to `errors.add` instead to prevent the following 
deprecation warning
 `Calling << to an ActiveModel::Errors message array in order to add an 
error is deprecated. Please call ActiveModel::Errors#add instead.`