### PR TITLE
Use PostgreSQL 13 in Continuous Integration

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,4 +8,7 @@ node {
     publishingE2ETests: true,
     brakeman: true,
   )
+
+  // Run against the PostgreSQL 13 Docker instance on GOV.UK CI
+  govuk.setEnvar("TEST_DATABASE_URL", "postgresql://postgres@127.0.0.1:54313/content_tagger_test")
 }

--- a/config/database.yml
+++ b/config/database.yml
@@ -12,6 +12,6 @@ development:
 test:
   <<: *default
   database: content_tagger_test
-  url: <%= ENV["DATABASE_URL"].try(:sub, /([-_]development)?$/, '_test') %>
+  url: <%= ENV["TEST_DATABASE_URL"] %>
 
 # In production the `DATABASE_URL` environment variable is automatically used.


### PR DESCRIPTION
In CI, [PostgreSQL 13 is available at port 54313](https://docs.publishing.service.gov.uk/manual/test-and-build-a-project-on-jenkins-ci.html#specifying-which-database-to-use).

Previously we were using the default port of 5432, which is running PostgreSQL 9.6.

[Trello card](https://trello.com/c/zVdVJqFM)