### PR TITLE
Remove cookie rotation following Rails 7 upgrade

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -20,22 +20,5 @@ module ContentTagger
     config.blacklisted_tag_types = config_for(:blacklisted_tag_types)
 
     config.active_record.belongs_to_required_by_default = false
-
-    # Rotate SHA1 cookies to SHA256 (the new Rails 7 default)
-    # TODO: Remove this after existing user sessions have been rotated
-    # https://guides.rubyonrails.org/v7.0/upgrading_ruby_on_rails.html#key-generator-digest-class-changing-to-use-sha256
-    Rails.application.config.action_dispatch.cookies_rotations.tap do |cookies|
-      salt = Rails.application.config.action_dispatch.authenticated_encrypted_cookie_salt
-      secret_key_base = Rails.application.secrets.secret_key_base
-      next if secret_key_base.blank?
-
-      key_generator = ActiveSupport::KeyGenerator.new(
-        secret_key_base, iterations: 1000, hash_digest_class: OpenSSL::Digest::SHA1
-      )
-      key_len = ActiveSupport::MessageEncryptor.key_len
-      secret = key_generator.generate_key(salt, key_len)
-
-      cookies.rotate :encrypted, secret
-    end
   end
 end


### PR DESCRIPTION
A cookie rotation was used to upgrade encrypted cookies from SHA1 to SHA256 digests to avoid active sessions being lost during the Rails 7 upgrade.

It's now safe to remove this, on the assumption that active sessions have now been upgraded and inactive sessions would have expired by now anyway.

Trello card: https://trello.com/c/VUqyCoQ3