### PR TITLE
Update labelling of pinned select-2 gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem "kaminari"
 gem "pg"
 gem "rack-proxy"
 gem "sassc-rails"
-gem "select2-rails", "~> 3.5.11"
+gem "select2-rails", "< 4" # There are unresolved visual and HTML changes with select2-rails 4
 gem "simple_form"
 gem "sprockets-rails"
 gem "uglifier"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -503,7 +503,7 @@ DEPENDENCIES
   rspec-rails
   rubocop-govuk
   sassc-rails
-  select2-rails (~> 3.5.11)
+  select2-rails (< 4)
   simple_form
   simplecov
   sprockets-rails


### PR DESCRIPTION
This updates the pinning approach to be consistent with that from GOV.UK
Rails conventions [1]. The reason this app can't use select2-rails 4 is
recorded in https://github.com/alphagov/content-tagger/pull/1237:

> Version 4 (introduced in #1234) of select2-rails removes s2id_* prefixed
> from IDs of select2 elements. This broke an end-to-end tests. Although
> fixed, this may cause unintended issues elsewhere. Additionally,
> there appear to be some subtle visual changes to the select2 elements
> in version 4.
>
> Therefore reverting the dependency to an earlier version which resolves
> the problem #1234 was trying to solve (i.e. remove the dependency on
> thor (~> 0.14), but retains the s2id prefixed IDs for the elements.

[1]: https://docs.publishing.service.gov.uk/manual/conventions-for-rails-applications.html#gemfile-organisation