### PR TITLE
Fix broken taxonomy health check rake task

### DIFF
--- a/lib/tasks/taxonomy/health_checks.rake
+++ b/lib/tasks/taxonomy/health_checks.rake
@@ -5,9 +5,9 @@ namespace :taxonomy do
   task health_checks: [:environment] do
     Taxonomy::HealthWarning.delete_all
     ContentTagger::Application.config_for(:health_checks)["metrics"].each do |metric|
-      puts %(Name: #{metric['name']}; Arguments: #{(metric['arguments'] || []).map { |k, v| "#{k}: #{v}" }.join(', ')})
-      klazz = "TaxonomyHealth::#{metric['class']}".constantize
-      klazz.perform_async(metric["arguments"])
+      puts %(Name: #{metric[:name]}; Arguments: #{(metric[:arguments] || []).map { |k, v| "#{k}: #{v}" }.join(', ')})
+      klazz = "TaxonomyHealth::#{metric[:class]}".constantize
+      klazz.perform_async(metric[:arguments])
     end
   end
 end

--- a/spec/lib/tasks/taxonomy/health_checks_spec.rb
+++ b/spec/lib/tasks/taxonomy/health_checks_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+require "gds_api/test_helpers/content_store"
+
+RSpec.describe "taxonomy:health_checks" do
+  include ::GdsApi::TestHelpers::ContentStore
+  include PublishingApiHelper
+  include ContentItemHelper
+  include RakeTaskHelper
+  include ActiveJob::TestHelper
+
+  it "queues the expected jobs" do
+    ActiveJob::Base.queue_adapter = :test
+
+    expect {
+      rake "taxonomy:health_checks"
+    }.to change(TaxonomyHealth::MaximumDepthMetric.jobs, :size).by(1)
+    .and change(TaxonomyHealth::ContentCountMetric.jobs, :size).by(1)
+    .and change(TaxonomyHealth::ChildTaxonCountMetric.jobs, :size).by(1)
+  end
+end


### PR DESCRIPTION
There is a rake task that checks the taxonomy health which does not work. This task is run in production multiple times every day.

The task attempts to access the configuration using string keys, but they should be symbols. This means the task fails and an error is reported to Sentry every day.

Fixing this so the task now works and errors will no longer be reported to Sentry.

[Example run of the rake task](https://deploy.blue.production.govuk.digital/job/automated-rake-task/11680/console)
[Sentry error](https://sentry.io/organizations/govuk/issues/2709683878/?project=202218)
[Trello card](https://trello.com/c/uiHoaYUc/269-content-tagger-taxonomy-health-checks-arent-running-correctly)