### PR TITLE
Relax URL override regex

### DIFF
--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -1,5 +1,6 @@
 class Taxon
-  PATH_COMPONENTS_REGEX = %r{\A/(?<prefix>[A-z0-9\-]+)(?:/(?<slug>[A-z0-9\-]+))?\z}.freeze
+  PATH_COMPONENTS_REGEX          = %r{\A/(?<prefix>[A-z0-9\-]+)(?:/(?<slug>[A-z0-9\-]+))?\z}.freeze
+  OVERRIDE_PATH_COMPONENTS_REGEX = %r{\A/(?<prefix>[A-z0-9\-]+)(?:/(?<slug>[A-z0-9\-]+))*\z}.freeze
 
   attr_accessor(
     :title,
@@ -20,7 +21,7 @@ class Taxon
   validates :title, :internal_name, :base_path, presence: true
   validates_with CircularDependencyValidator
   validates :base_path, format: { with: PATH_COMPONENTS_REGEX, message: "must be in the format '/highest-level-taxon-name/taxon-name'" }
-  validates :url_override, format: { with: PATH_COMPONENTS_REGEX, message: "must be in the format '/prefix/slug' or '/slug'" }, allow_blank: true
+  validates :url_override, format: { with: OVERRIDE_PATH_COMPONENTS_REGEX, message: "must be in the format '/prefix/slug' or '/slug'" }, allow_blank: true
   validates_with TaxonPathPrefixValidator
 
   def draft?

--- a/spec/models/taxon_spec.rb
+++ b/spec/models/taxon_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Taxon do
         title: "Title",
         description: "Description",
         base_path: "/education",
-        url_override: "/guidance/education-is-fun",
+        url_override: "/guidance/something/education-is-fun",
       )
 
       invalid_taxon = described_class.new(


### PR DESCRIPTION
We were using the same regex as taxons use, which is limited to two path
segements:
- /foo
- /foo/bar

The URL override path shouldn't be limited in this way, as we should be
allowed deeper - many Whitehall URLs are several layers deep. This change (switching the last `?` to a `*`)
should allow:
- /foo
- /foo/bar
- /foo/bar/something/else

I indented the regexes to emphasise how similar they are as they only differ by one character.