### PR TITLE
Remove logic around updating /brexit.cy

### DIFF
--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -1,6 +1,4 @@
 class TaxonsController < ApplicationController
-  include TransitionTaxon
-
   VISUALISATIONS = %w[list bubbles taxonomy_tree].freeze
 
   before_action(
@@ -145,9 +143,6 @@ class TaxonsController < ApplicationController
 
   def publish
     Services.publishing_api.publish(content_id)
-    if transition_taxon?(content_id)
-      Services.publishing_api.publish(content_id, nil, locale: "cy")
-    end
 
     redirect_to taxon_path(content_id), success: "You have successfully published the taxon"
   rescue GdsApi::HTTPUnprocessableEntity => e
@@ -176,10 +171,6 @@ class TaxonsController < ApplicationController
 
   def discard_draft
     Services.publishing_api.discard_draft(content_id)
-
-    if transition_taxon?(content_id)
-      Services.publishing_api.discard_draft(content_id, locale: "cy")
-    end
 
     redirect_to taxons_path, success: t("controllers.taxons.discard_draft_success")
   end

--- a/app/lib/transition_taxon.rb
+++ b/app/lib/transition_taxon.rb
@@ -1,7 +1,0 @@
-module TransitionTaxon
-  TRANSITION_TAXON_CONTENT_ID = "d6c2de5d-ef90-45d1-82d4-5f2438369eea".freeze
-
-  def transition_taxon?(content_id)
-    content_id == TRANSITION_TAXON_CONTENT_ID
-  end
-end

--- a/app/services/taxonomy/taxon_unpublisher.rb
+++ b/app/services/taxonomy/taxon_unpublisher.rb
@@ -1,7 +1,5 @@
 module Taxonomy
   class TaxonUnpublisher
-    include TransitionTaxon
-
     def self.call(taxon_content_id:, redirect_to_content_id:, user:, retag: true)
       new.unpublish(
         taxon_content_id: taxon_content_id,
@@ -37,9 +35,6 @@ module Taxonomy
     def unpublish_taxon(taxon_content_id, redirect_to_content_id)
       redirect_to_taxon = Services.publishing_api.get_content(redirect_to_content_id)
       publishing_api_unpublish(taxon_content_id, redirect_to_taxon["base_path"])
-      return unless transition_taxon?(taxon_content_id)
-
-      publishing_api_unpublish(taxon_content_id, redirect_to_taxon["base_path"], "cy")
     end
 
     def tagged_content_base_paths(content_id)

--- a/app/services/taxonomy/update_taxon.rb
+++ b/app/services/taxonomy/update_taxon.rb
@@ -1,7 +1,5 @@
 module Taxonomy
   class UpdateTaxon
-    include TransitionTaxon
-
     attr_reader :taxon
 
     delegate :content_id, :parent_content_id, :associated_taxons, :legacy_taxons, to: :taxon
@@ -69,9 +67,6 @@ module Taxonomy
 
     def publishing_api_put_content_request(content_id)
       Services.publishing_api.put_content(content_id, payload)
-      return unless transition_taxon?(content_id)
-
-      Services.publishing_api.put_content(content_id, payload("cy"))
     end
   end
 end

--- a/app/workers/publish_taxon_worker.rb
+++ b/app/workers/publish_taxon_worker.rb
@@ -1,13 +1,8 @@
 class PublishTaxonWorker
   include Sidekiq::Worker
-  include TransitionTaxon
 
   def perform(taxon_content_id)
     Services.publishing_api.publish(taxon_content_id)
-
-    if transition_taxon?(taxon_content_id)
-      Services.publishing_api.publish(taxon_content_id, nil, locale: "cy")
-    end
   rescue GdsApi::HTTPConflict => e # Ignore attempts to publish already published content
     Rails.logger.warn "409 #{e.message}"
   end

--- a/app/workers/update_taxon_worker.rb
+++ b/app/workers/update_taxon_worker.rb
@@ -1,6 +1,5 @@
 class UpdateTaxonWorker
   include Sidekiq::Worker
-  include TransitionTaxon
 
   def perform(content_id, attributes)
     previous_taxon = Taxonomy::BuildTaxon.call(content_id: content_id)
@@ -20,8 +19,5 @@ private
 
   def publishing_api_put_content_request(content_id, taxon)
     Services.publishing_api.put_content(content_id, payload(taxon))
-    return unless transition_taxon?(content_id)
-
-    Services.publishing_api.put_content(content_id, payload(taxon, "cy"))
   end
 end

--- a/spec/controllers/taxons_controller_spec.rb
+++ b/spec/controllers/taxons_controller_spec.rb
@@ -4,9 +4,6 @@ RSpec.describe TaxonsController, type: :controller do
   include EmailAlertApiHelper
   include PublishingApiHelper
   include ContentItemHelper
-  include TransitionTaxon
-
-  let(:transition_taxon_content_id) { TransitionTaxon::TRANSITION_TAXON_CONTENT_ID }
 
   describe "#index" do
     it "renders index" do
@@ -123,16 +120,6 @@ RSpec.describe TaxonsController, type: :controller do
 
       expect(flash.now[:danger]).to match(/<a href="(.+)">taxon<\/a> with this slug already exists/)
     end
-
-    it "sends additional publish request to Publishing API for the Brexit taxon with 'cy' locale" do
-      build(:taxon, publication_state: "unpublished", content_id: transition_taxon_content_id)
-      stub_any_publishing_api_publish
-
-      post :publish, params: { taxon_id: transition_taxon_content_id }
-
-      assert_publishing_api_publish(transition_taxon_content_id, update_type: nil)
-      assert_publishing_api_publish(transition_taxon_content_id, update_type: nil, locale: "cy")
-    end
   end
 
   describe "#confirm_bulk_publish" do
@@ -208,15 +195,6 @@ RSpec.describe TaxonsController, type: :controller do
 
       delete :discard_draft, params: { taxon_id: taxon.content_id }
       expect(WebMock).to have_requested(:post, "https://publishing-api.test.gov.uk/v2/content/#{taxon.content_id}/discard-draft")
-    end
-
-    it "sends a request to Publishing API to delete a draft Brexit taxon with 'cy' locale" do
-      taxon = build(:taxon, publication_state: "draft", content_id: transition_taxon_content_id)
-      publishing_api_has_taxons([taxon])
-      stub_any_publishing_api_discard_draft
-
-      delete :discard_draft, params: { taxon_id: transition_taxon_content_id }
-      assert_publishing_api_discard_draft(transition_taxon_content_id, locale: "cy")
     end
   end
 

--- a/spec/services/taxonomy/taxon_unpublisher_spec.rb
+++ b/spec/services/taxonomy/taxon_unpublisher_spec.rb
@@ -88,21 +88,6 @@ RSpec.describe Taxonomy::TaxonUnpublisher do
     end
   end
 
-  context "Transition taxon" do
-    it "unpublishes the Transition taxon with 'cy' locale" do
-      transition_taxon_content_id = TransitionTaxon::TRANSITION_TAXON_CONTENT_ID
-      stub_publishing_api_has_expanded_links({ "content_id" => transition_taxon_content_id, "expanded_links" => {} })
-
-      unpublish(transition_taxon_content_id, redirect_content_id)
-      assert_publishing_api_unpublish(
-        transition_taxon_content_id,
-        type: "redirect",
-        alternative_path: "/path/to/redirect",
-        locale: "cy",
-      )
-    end
-  end
-
   def unpublish(taxon_content_id, redirect_to_content_id, retag: true)
     Sidekiq::Testing.inline! do
       Taxonomy::TaxonUnpublisher.call(taxon_content_id: taxon_content_id, redirect_to_content_id: redirect_to_content_id, user: User.new, retag: retag)

--- a/spec/services/taxonomy/update_taxon_spec.rb
+++ b/spec/services/taxonomy/update_taxon_spec.rb
@@ -2,7 +2,6 @@ require "rails_helper"
 
 RSpec.describe Taxonomy::UpdateTaxon do
   include ContentItemHelper
-  include TransitionTaxon
 
   before do
     @taxon = Taxon.new(
@@ -133,20 +132,6 @@ RSpec.describe Taxonomy::UpdateTaxon do
           Taxonomy::UpdateTaxon::InvalidTaxonError,
           /<a href="(.+)">taxon<\/a> with this slug already exists/,
         )
-      end
-    end
-
-    context "with the Brexit taxon" do
-      it "publishes the document in the 'en' and 'cy' locale via the Publishing API" do
-        stub_any_publishing_api_put_content
-        stub_any_publishing_api_patch_links
-
-        @taxon.content_id = TransitionTaxon::TRANSITION_TAXON_CONTENT_ID
-
-        described_class.call(taxon: @taxon)
-
-        assert_publishing_api_put_content(@taxon.content_id, request_json_includes(locale: "en"))
-        assert_publishing_api_put_content(@taxon.content_id, request_json_includes(locale: "cy"))
       end
     end
   end

--- a/spec/workers/update_taxon_worker_spec.rb
+++ b/spec/workers/update_taxon_worker_spec.rb
@@ -3,7 +3,6 @@ require "rails_helper"
 RSpec.describe UpdateTaxonWorker, "#perform" do
   include PublishingApiHelper
   include ContentItemHelper
-  include TransitionTaxon
 
   it "records the changes that have been made" do
     taxon = taxon_with_details(
@@ -30,25 +29,5 @@ RSpec.describe UpdateTaxonWorker, "#perform" do
         ["~", "base_path", "/imported-topic/topic/transport", "/transport"],
       ],
     )
-  end
-
-  it "makes a PUT content request to Publishing API for the Brexit taxon with 'cy' and 'en' locales" do
-    transition_taxon_content_id = TransitionTaxon::TRANSITION_TAXON_CONTENT_ID
-    taxon = taxon_with_details(
-      "Transport",
-      other_fields: {
-        content_id: transition_taxon_content_id,
-        base_path: "/imported-topic/topic/transport",
-        publication_state: "draft",
-      },
-    )
-    stub_publishing_api_has_item(taxon)
-    stub_publishing_api_has_expanded_links(taxon.slice(:content_id))
-    stub_any_publishing_api_put_content
-
-    UpdateTaxonWorker.new.perform(transition_taxon_content_id, base_path: "/base-path")
-
-    assert_publishing_api_put_content(transition_taxon_content_id, request_json_includes(locale: "en"))
-    assert_publishing_api_put_content(transition_taxon_content_id, request_json_includes(locale: "cy"))
   end
 end


### PR DESCRIPTION
This is the only Welsh taxon. It's not even a real taxon, it's just here to provide a route. 

It has been manually unpublished and redirected because we don't need it anymore, but we need to unpick this link so that we don't resurrect it accidentally by updating the English Brexit taxon.
