### PR TITLE
Add filtering for browse page derived topics

### DIFF
--- a/app/services/linkables.rb
+++ b/app/services/linkables.rb
@@ -1,5 +1,7 @@
 # Used by Tagging & Bulk Tagging to populate the available tags.
 class Linkables
+  CACHE_OPTIONS = { expires_in: 15.minutes, race_condition_ttl: 30.seconds }.freeze
+
   def topics
     @topics ||= for_nested_document_type("topic")
   end
@@ -49,7 +51,25 @@ private
     items = get_tags_of_type(document_type)
       .select { |item| item.fetch("internal_name").include?(" / ") }
 
+    items = filter_browse_topics(items)
+
     organise_items(present_items(items))
+  end
+
+  # While we're migrating the Browse pages to topics we will briefly have a combination of the
+  # two in our model. We need to filter out the pages we brought across from the results.
+  def filter_browse_topics(all_topics)
+    return all_topics if all_topics.empty? || all_topics.first.fetch("base_path").exclude?("/topic/")
+
+    # Get topics that are not mainstream browse copies
+    valid_topics ||= Rails.cache.fetch("valid_topics", CACHE_OPTIONS) do
+      Services.publishing_api.get_content_items(document_type: "topic", per_page: 10_000, fields: %w[content_id details])["results"].select do |item|
+        item.dig("details", "mainstream_browse_origin").nil?
+      end
+    end
+
+    # Filter the invalid topics out of the items collection
+    all_topics.select { |item| valid_topics.any? { |topic| topic.fetch("content_id") == item.fetch("content_id") } }
   end
 
   def present_items(items)

--- a/spec/features/tag_a_page_spec.rb
+++ b/spec/features/tag_a_page_spec.rb
@@ -328,6 +328,16 @@ RSpec.describe "Tagging content", type: :feature do
         "/browse/driving/car-tax-discs",
       ],
     )
+
+    stub_publishing_api_has_content(
+      [
+        { base_path: "/already-tagged", content_id: "ID-OF-ALREADY-TAGGED" },
+        { base_path: "/topic/business-tax/pension-scheme-administration", content_id: "e1d6b771-a692-4812-a4e7-7562214286ef" },
+      ],
+      document_type: "topic",
+      per_page: 10_000,
+      fields: %w[content_id details],
+    )
   end
 
   def example_topic

--- a/spec/features/tagging_during_migration_spec.rb
+++ b/spec/features/tagging_during_migration_spec.rb
@@ -31,6 +31,16 @@ RSpec.describe "Tagging content during migration", type: :feature do
         "/needs/apply-for-a-copy-of-a-marriage-certificate",
       ],
     )
+
+    stub_publishing_api_has_content(
+      [
+        { base_path: "/already-tagged", content_id: "ID-OF-ALREADY-TAGGED" },
+        { base_path: "/topic/business-tax/pension-scheme-administration", content_id: "e1d6b771-a692-4812-a4e7-7562214286ef" },
+      ],
+      document_type: "topic",
+      per_page: 10_000,
+      fields: %w[content_id details],
+    )
   end
 
   def given_there_is_an_item_that_can_have_only_one_link_type

--- a/spec/services/linkables_spec.rb
+++ b/spec/services/linkables_spec.rb
@@ -4,6 +4,10 @@ RSpec.describe Linkables do
   include ContentItemHelper
   include PublishingApiHelper
 
+  before(:each) do
+    stub_the_publishing_content
+  end
+
   let(:linkables) { Linkables.new }
 
   context "there are linkables" do
@@ -81,9 +85,17 @@ RSpec.describe Linkables do
             "base_path" => "/topic/redirect",
             "internal_name" => nil,
           },
+          {
+            "base_path" => "/topic/employing-people-mainstream-copy/contracts-mainstream-copy",
+            "internal_name" => "Employing People / Contracts",
+            "publication_state" => "published",
+            "content_id" => "CONTENT-ID-EMPLOYING-COPY",
+          },
         ],
         document_type: "topic",
       )
+
+      stub_the_publishing_content
 
       expected = {
         "Business tax" => [
@@ -113,5 +125,49 @@ RSpec.describe Linkables do
 
       expect(linkables.organisations).to eq [["Student Loans Company", "9a9111aa-1db8-4025-8dd2-e08ec3175e72"]]
     end
+  end
+
+  def stub_the_publishing_content
+    stub_publishing_api_has_content(
+      [
+        {
+          "public_updated_at" => "2016-04-07 10:34:05",
+          "title" => "Pension scheme administration",
+          "content_id" => "e1d6b771-a692-4812-a4e7-7562214286ef",
+          "publication_state" => "published",
+          "base_path" => "/topic/business-tax/pension-scheme-administration",
+          "internal_name" => "Business tax / Pension scheme administration",
+        },
+        {
+          "public_updated_at" => "2016-04-07 10:34:05",
+          "title" => nil,
+          "content_id" => "3535b8ad-7209-4c97-9dac-e25c25d9c27c",
+          "publication_state" => "published",
+          "base_path" => "/topic/redirect",
+          "internal_name" => nil,
+        },
+        {
+          "base_path" => "/topic/employing-people-mainstream-copy/contracts-mainstream-copy",
+          "internal_name" => "Employing People / Contracts",
+          "publication_state" => "published",
+          "content_id" => "CONTENT-ID-EMPLOYING-COPY",
+          "details" => {
+            "mainstream_browse_origin" => "notnil",
+          },
+        },
+        {
+          "base_path" => "/topic/disabilities-mainstream-copy/benefits-mainstream-copy",
+          "internal_name" => "Disabilities / Benefits",
+          "publication_state" => "draft",
+          "content_id" => "CCONTENT-ID-BENEFIT-COPY",
+          "details" => {
+            "mainstream_browse_origin" => "",
+          },
+        },
+      ],
+      document_type: "topic",
+      per_page: 10_000,
+      fields: %w[content_id details],
+    )
   end
 end


### PR DESCRIPTION
While migrating Mainstream Browse pages to topics we need to prevent
the migrated clones from being visible to the user. Here we're adding
filtering to prevent items being show if the relevant field doesn't
exist or is true.

https://trello.com/c/m13ffUVc/292-update-publishing-apps-that-know-of-specialist-topics-to-hide-new-synced-ones