### PR TITLE
Use consistent language to describe tagging and topic pages

### DIFF
--- a/app/services/linkables.rb
+++ b/app/services/linkables.rb
@@ -39,7 +39,7 @@ private
   end
 
   def for_nested_document_type(document_type)
-    # In Topics and Browse pages, the "internal name" is generated in the
+    # In Specialist topic pages and Mainstream Browse pages, the "internal name" is generated in the
     # form: "Parent title / Child title". Because currently we only show
     # documents on child-topic pages (like /topic/animal-welfare/pets), we
     # only allow tagging to those tags in this application. That's why we

--- a/app/views/taggings/_form_for_mainstream_browse_pages.html.erb
+++ b/app/views/taggings/_form_for_mainstream_browse_pages.html.erb
@@ -9,6 +9,5 @@
   Mainstream browse pages live under <a href="https://www.gov.uk/browse">/browse</a>.
   Examples: <a href="https://www.gov.uk/browse/working">Working</a> or
   <a href="https://www.gov.uk/browse/business">Business</a>.
-  They are used to organise mainstream content. Formerly called
-  <i>sections and subsections</i>.
+  They are used to organise curated content.
 </p>

--- a/app/views/taggings/_form_for_organisations.html.erb
+++ b/app/views/taggings/_form_for_organisations.html.erb
@@ -6,6 +6,6 @@
     input_html: { multiple: true, class: :select2 } %>
 
 <p class='explain'>
-  Tagging a page to an organisation will make it show up in search.
+  Tagging a page to an organisation will make it show up in search when filtered to the organisation(s). 
   Example: <a href="https://www.gov.uk/search?q=taxes&filter_organisations%5B%5D=hm-revenue-customs">search for documents published by HMRC</a>.
 </p>

--- a/app/views/taggings/_form_for_taxons.html.erb
+++ b/app/views/taggings/_form_for_taxons.html.erb
@@ -1,4 +1,4 @@
-<h3>Taxons</h3>
+<h3>Topic taxonomy tags</h3>
 
 <%= f.input :taxons,
     collection: linkables.taxons,
@@ -6,5 +6,5 @@
     input_html: { multiple: true, class: :select2 } %>
 
 <p class="explain">
-  This taxonomy is currently being developed.
+  Tagging to the topic taxonomy supports search filtering and content management
 </p>

--- a/app/views/taggings/_form_for_topics.html.erb
+++ b/app/views/taggings/_form_for_topics.html.erb
@@ -1,16 +1,15 @@
-<h3>Topics</h3>
+<h3>Specialist topic pages</h3>
 
 <%= f.input :topics,
     collection: linkables.topics, as: :grouped_select, group_method: :last,
-    placeholder: "Choose Topics...",
+    placeholder: "Choose specialist topic pages...",
     input_html: { multiple: true, include_blank: true, class: :select2 } %>
 
 <p class='explain'>
-  Topic pages live under <a href="https://www.gov.uk/topic">/topic</a>.
-  They contain collections of pages on GOV.UK. Example:
+  Specialist topic pages live under <a href="https://www.gov.uk/topic">/topic</a>.
+  They contain pages on GOV.UK that have been tagged to the specialist topic. Example:
   <a href="https://www.gov.uk/topic/business-tax">Business Tax</a> or
   <a href="https://www.gov.uk/topic/animal-welfare/pets">Animal Welfare / Pets</a>.
-  Publishing a page with a topic may send out an
+  Publishing a page with a specialist topic tag may send out an
   <a href="https://www.gov.uk/topic/business-tax/vat/email-signup">email alert to subscribers</a>.
-  Formerly called <i>specialist sectors</i>.
 </p>

--- a/config/blacklisted_tag_types.yml
+++ b/config/blacklisted_tag_types.yml
@@ -16,7 +16,7 @@ default: &default
     - parent
 
   whitehall:
-    # Topics and the parent (breadcrumb) are managed in Whitehall itself. This
+    # Specialist topic pages and the parent (breadcrumb) are managed in Whitehall itself. This
     # will stay that way because Whitehall is too complex to make a half-way
     # change to a system where topics and breadcrumb are read & written from
     # the publishing-api.


### PR DESCRIPTION
## Context 
Clear consistent language in the publishing apps will help publishers tag content better, and understand the implications of this. Better tagging will make their content more findable.

Edit taxonomy flow is out of scope

Trello: https://trello.com/c/8urAxFrT/927-content-tagger-update-copy-based-on-jenns-doc

## Changes proposed 

Update the copy as per this doc: https://docs.google.com/spreadsheets/d/1OLw4B46ZqTgsuo762Kjxb-M6_rfX_dW23qp8bNhZrMo/edit#gid=994922232

| Before  | After |
| ------------- | ------------- |
| <img width="773" alt="Screenshot 2022-04-26 at 17 35 03" src="https://user-images.githubusercontent.com/38078064/165349444-e23f251f-458e-4e73-bafc-d194c65bee1a.png"> | <img width="773" alt="Screenshot 2022-04-26 at 17 27 30" src="https://user-images.githubusercontent.com/38078064/165348246-24655d61-815f-49c2-b248-3785038752d5.png"> |
| <img width="771" alt="Screenshot 2022-04-26 at 17 35 16" src="https://user-images.githubusercontent.com/38078064/165349460-445caf57-ae88-45e0-94b7-531bed518fa2.png"> | <img width="768" alt="Screenshot 2022-04-26 at 17 28 03" src="https://user-images.githubusercontent.com/38078064/165348839-2e30291f-c49a-4744-ba0e-2e671b274812.png"> |

## How to review this

- visit `/tagging/:content_id` path
