### PR TITLE
Improve test coverage for continuous deployment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ end
 
 group :test do
   gem "database_cleaner"
+  gem "fakefs", require: "fakefs/safe"
   gem "govuk_test"
   gem "timecop"
   gem "webmock"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,6 +120,7 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
+    fakefs (1.8.0)
     faraday (2.2.0)
       faraday-net_http (~> 2.0)
       ruby2_keywords (>= 0.0.4)
@@ -462,6 +463,7 @@ DEPENDENCIES
   bootstrap-kaminari-views
   database_cleaner
   factory_bot_rails
+  fakefs
   gds-api-adapters
   gds-sso
   govuk_admin_template

--- a/lib/tasks/taxonomy/untag.rake
+++ b/lib/tasks/taxonomy/untag.rake
@@ -4,8 +4,7 @@ namespace :taxonomy do
   task :untag, %i[content_id untag] => :environment do |_, args|
     taxon_content_id = args[:content_id]
     if taxon_content_id.nil?
-      puts "Please supply the content id of the taxon to untag."
-      return
+      abort "Please supply the content id of the taxon to untag."
     end
 
     GdsApi::Base.default_options = { timeout: 30 }

--- a/spec/lib/tasks/content_tagged_to_ancestors_spec.rb
+++ b/spec/lib/tasks/content_tagged_to_ancestors_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+require "gds_api/test_helpers/search"
+
+RSpec.describe "content:tagged_to_ancestor", type: :task do
+  include RakeTaskHelper
+  include ::GdsApi::TestHelpers::Search
+
+  def has_paths(paths)
+    stub_publishing_api_has_expanded_links(Support::TaxonHelper.expanded_link_hash(
+                                             "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", paths
+                                           ))
+  end
+
+  before :each do
+    stub_any_search.to_return(body: { "results" => [{ "content_id" => "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" }] }.to_json)
+  end
+
+  it "does nothing if there's nothing to do" do
+    has_paths []
+    expect { rake("content:tagged_to_ancestor") }.not_to raise_error
+  end
+
+  it "produces output if there's a common ancestor" do
+    has_paths [[1, 2, 3, 4], [1, 2, 3]]
+    expect {
+      rake("content:tagged_to_ancestor")
+    }.to output(/^Document .* content_id: aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa has common ancestors tagged to: $/).to_stdout
+  end
+
+  it "optionally invokes untagger" do
+    has_paths [[1, 2, 3, 4], [1, 2, 3]]
+
+    untagger = double(Tagging::Untagger)
+    expect(untagger).to receive(:call)
+    stub_const("Tagging::Untagger", untagger)
+
+    rake("content:tagged_to_ancestor", "untag")
+  end
+end

--- a/spec/lib/tasks/export_content_by_organisations_spec.rb
+++ b/spec/lib/tasks/export_content_by_organisations_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+require "gds_api/test_helpers/search"
+
+RSpec.describe "govuk:export_content_by_organisations", type: :task do
+  include RakeTaskHelper
+  include ::GdsApi::TestHelpers::Search
+
+  before :each do
+    stub_any_search.to_return(body: { "results" => [{ "content_id" => "1b99def9-7eaa-4fb4-a0d0-ea76f0c5c370",
+                                                      "primary_publishing_organisation" => "department-for-transport",
+                                                      "organisations" => [{
+                                                        "slug" => "department-for-transport",
+                                                      }] }] }.to_json)
+  end
+
+  it "creates a file" do
+    create(
+      :user,
+      uid: "user-1234",
+      organisation_slug: "department-for-transport",
+    )
+
+    project = create(:project, taxonomy_branch: "a4038b29-b332-4f13-98b1-1c9709e216bc")
+
+    create(
+      :project_content_item,
+      project: project,
+      content_id: "1b99def9-7eaa-4fb4-a0d0-ea76f0c5c370",
+      url: "https://www.gov.uk/government/publications/great-western-franchise-2013",
+    )
+
+    FakeFS do
+      rake("govuk:export_content_by_organisations", "department-for-transport")
+      expect(open("department-for-transport.csv").read.length).to be > 0
+    end
+  end
+end

--- a/spec/lib/tasks/export_mainstream_taxons_spec.rb
+++ b/spec/lib/tasks/export_mainstream_taxons_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+require "gds_api/test_helpers/search"
+
+RSpec.describe "govuk:export_content_by_organisations", type: :task do
+  include RakeTaskHelper
+  include ::GdsApi::TestHelpers::Search
+
+  before :each do
+    stub_any_search.to_return(body: { "results" => [{ "content_id" => "1b99def9-7eaa-4fb4-a0d0-ea76f0c5c370",
+                                                      "primary_publishing_organisation" => "department-for-transport",
+                                                      "organisations" => [{
+                                                        "slug" => "department-for-transport",
+                                                      }] }] }.to_json)
+  end
+
+  it "creates a file" do
+    stub_request(:get, "https://content-store.test.gov.uk/content")
+     .to_return(status: 200, body: "{}", headers: {})
+
+    FakeFS do
+      FileUtils.mkdir_p("tmp")
+      rake("govuk:export_mainstream_taxons", "department-for-transport")
+      expect(open("tmp/mainstream.csv").read.length).to be > 0
+    end
+  end
+end

--- a/spec/lib/tasks/taxonomy/untag_spec.rb
+++ b/spec/lib/tasks/taxonomy/untag_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe "taxonomy:untag", type: :task do
+  include RakeTaskHelper
+
+  it "invokes untagger" do
+    stub_request(:get, "https://publishing-api.test.gov.uk/v2/linked/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa?fields%5B%5D=content_id&fields%5B%5D=title&link_type=taxons")
+     .to_return(status: 200, body: [{ "content_id" => "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb" }].to_json, headers: {})
+
+    untagger = double(Tagging::Untagger)
+    expect(untagger).to receive(:call).with("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", %w[aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa])
+    stub_const("Tagging::Untagger", untagger)
+
+    rake("taxonomy:untag", %w[aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa untag])
+  end
+
+  it "does nothing if no arguments are given" do
+    untagger = double(Tagging::Untagger)
+    expect(untagger).not_to receive(:call)
+    stub_const("Tagging::Untagger", untagger)
+
+    begin
+      expect { rake("taxonomy:untag") }.to raise_exception(SystemExit)
+    rescue SystemExit # rubocop:disable Lint/SuppressedException
+    end
+  end
+end

--- a/spec/lib/tasks/taxonomy_metrics_spec.rb
+++ b/spec/lib/tasks/taxonomy_metrics_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+require "gds_api/test_helpers/search"
+
+RSpec.describe "metrics:taxonomy", type: :task do
+  include RakeTaskHelper
+  include ::GdsApi::TestHelpers::Search
+
+  before :each do
+    stub_any_search.to_return(body: { "results" => [{ "content_id" => "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" }], "total" => 1 }.to_json)
+  end
+
+  context "count_content_per_level" do
+    it "writes to stdout" do
+      stub_request(:get, "https://draft-content-store.test.gov.uk/content/")
+       .to_return(status: 200, body: "{}", headers: {})
+
+      expect {
+        rake("metrics:taxonomy:count_content_per_level")
+      }.to output(/.+/).to_stdout
+    end
+  end
+
+  context "record_content_coverage_metrics" do
+    it "writes to stdout" do
+      stub_request(:get, "https://draft-content-store.test.gov.uk/content/")
+       .to_return(status: 200, body: "{}", headers: {})
+      stub_request(:get, "https://publishing-api.test.gov.uk/v2/expanded-links/f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a")
+       .to_return(status: 200, body: "{}", headers: {})
+
+      expect {
+        rake("metrics:taxonomy:record_content_coverage_metrics")
+      }.to output(/.+/).to_stdout
+    end
+  end
+
+  context "record_number_of_superfluous_taggings_metrics" do
+    it "writes to stdout" do
+      stub_request(:get, "https://draft-content-store.test.gov.uk/content/")
+       .to_return(status: 200, body: "{}", headers: {})
+
+      stub_request(:get, "https://publishing-api.test.gov.uk/v2/expanded-links/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+       .to_return(status: 200, body: {}.to_json, headers: {})
+
+      expect {
+        rake("metrics:taxonomy:record_number_of_superfluous_taggings_metrics")
+      }.to output(/.+/).to_stdout
+    end
+  end
+end

--- a/spec/services/taxonomy/taxons_with_content_count_spec.rb
+++ b/spec/services/taxonomy/taxons_with_content_count_spec.rb
@@ -131,6 +131,10 @@ RSpec.describe Taxonomy::TaxonsWithContentCount do
       allow(size).to receive(:nested_tree).and_return(tree)
 
       expect(size.max_size).to eq(300)
+
+      taxonomy_size = Taxonomy::TaxonsWithContentCountPresenter.new(size)
+      expect(taxonomy_size.bar_width_percentage(100)).to be(10)
+      expect(taxonomy_size.bar_width_percentage(300)).to be(30)
     end
 
     it "returns the max size of the tree for no children" do
@@ -145,6 +149,13 @@ RSpec.describe Taxonomy::TaxonsWithContentCount do
       allow(size).to receive(:nested_tree).and_return(tree)
 
       expect(size.max_size).to eq(100)
+    end
+
+    it "returns 0% bar width when max_size is 0" do
+      size = Taxonomy::TaxonsWithContentCount.new(content_item)
+      allow(size).to receive(:max_size).and_return(0)
+
+      expect(size.max_size).to eq(0)
     end
   end
 end

--- a/spec/support/rake_task_helper.rb
+++ b/spec/support/rake_task_helper.rb
@@ -1,32 +1,6 @@
 module RakeTaskHelper
   def rake(task, args = [])
-    with_rake_env { invoke(task, args) }
-  end
-
-private
-
-  def application_tasks
-    Rails.application.paths["lib/tasks"].to_a
-  end
-
-  def invoke(task, args)
     Rake::Task[task].invoke(*args)
-  end
-
-  def with_rake_env
-    new_rake = Rake::Application.new
-    old_rake = Rake.application
-    Rake.application = new_rake
-
-    # The Rails enviroment is already loaded so we define an
-    # empty environment task to fufill the prerequisites.
-    Rake::Task.define_task(:environment)
-
-    # Load just the application tasks defined in `lib/tasks`
-    application_tasks.each { |task| load(task) }
-
-    yield
-  ensure
-    Rake.application = old_rake
+    Rake::Task[task].reenable
   end
 end


### PR DESCRIPTION
A lot of these are for rake tasks; ideally the logic should probably be moved out of the take task entirely but for the most part I've tested them as-is (mainly just testing that the library functions are called as appropriate, because most of the logic is already tested).

Other changes:

- RakeTaskHelper was breaking test coverage by reinitialising the rake environment for every test, this has now been simplified;
- One of the rake tasks was calling `return`, which is invalid since a rake task is not a function. It did have the desired effect of aborting the task early, but only because it was throwing an exception about the invalid `return`. This is now fixed to use `abort`.

https://trello.com/c/3xZQq6rw/499-enable-continuous-deployment-for-content-tagger