### PR TITLE
Rework test for taxonomy:untag to avoid intermittent failure

### DIFF
--- a/lib/tasks/taxonomy/untag.rake
+++ b/lib/tasks/taxonomy/untag.rake
@@ -4,7 +4,8 @@ namespace :taxonomy do
   task :untag, %i[content_id untag] => :environment do |_, args|
     taxon_content_id = args[:content_id]
     if taxon_content_id.nil?
-      abort "Please supply the content id of the taxon to untag."
+      warn "Please supply the content id of the taxon to untag."
+      next
     end
 
     GdsApi::Base.default_options = { timeout: 30 }

--- a/spec/lib/tasks/taxonomy/untag_spec.rb
+++ b/spec/lib/tasks/taxonomy/untag_spec.rb
@@ -19,9 +19,10 @@ RSpec.describe "taxonomy:untag", type: :task do
     expect(untagger).not_to receive(:call)
     stub_const("Tagging::Untagger", untagger)
 
-    begin
-      expect { rake("taxonomy:untag") }.to raise_exception(SystemExit)
-    rescue SystemExit # rubocop:disable Lint/SuppressedException
-    end
+    untagger = double(Tagging::Untagger)
+    expect(untagger).not_to receive(:call)
+    stub_const("Tagging::Untagger", untagger)
+
+    rake("taxonomy:untag")
   end
 end


### PR DESCRIPTION
This task exits early which works oddly in Rake. Previously used `return` which is not valid (but worked by accident, because it caused a runtime error). `abort` appeared to work but fails intermittently in CI, perhaps due to test ordering? Stack Overflow recommends `next` instead. Then the test can just ensure that the untagger is never called rather than checking for a `SystemExit`.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
