### PR TITLE
Add world_location_news to document types excluded from the topic taxonomy

### DIFF
--- a/config/document_types_excluded_from_the_topic_taxonomy.yml
+++ b/config/document_types_excluded_from_the_topic_taxonomy.yml
@@ -57,4 +57,5 @@ document_types:
   - travel_advice_index
   - working_group
   - world_location
+  - world_location_news
   - worldwide_organisation


### PR DESCRIPTION
We are adding a new document type of world location news, as part of migrating rendering of these documents away from whitehall. This is intended to replace the document type of `placeholder_world_location_news_page`, which will be removed in a separate PR once we've fully switched to the new document type.

[Related govuk-content-schemas change](https://github.com/alphagov/govuk-content-schemas/pull/1116)

[Trello](https://trello.com/c/5vpV1JUu/194-update-world-news-location-document-type)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
