### PR TITLE
Add rake task to update related links on all Travel Advice

### DIFF
--- a/lib/tasks/travel_advice/tmp_swap_travel_advice_link.rake
+++ b/lib/tasks/travel_advice/tmp_swap_travel_advice_link.rake
@@ -1,0 +1,29 @@
+namespace :travel_advice do
+  desc ""
+  task crisis_support: :environment do
+    take_out = "5dc09a0e-7631-11e4-a3cb-005056011aef" # /guidance/how-to-deal-with-a-crisis-overseas
+    swap_in = "aad65646-964d-4f68-ac22-5bc6c8281336" # /government/collections/support-for-british-nationals-abroad
+
+    response = Services.publishing_api.get_editions(
+      per_page: 300,
+      publishing_app: "travel-advice-publisher",
+      document_types: %w[travel_advice],
+      states: %w[published],
+    )
+
+    response["results"].each do |edition|
+      links = Services.publishing_api.get_links(edition["content_id"])["links"]
+      next unless links && links["ordered_related_items"]
+
+      index_of_link = links["ordered_related_items"].index(take_out)
+
+      links["ordered_related_items"][index_of_link] = swap_in if index_of_link
+
+      Services.publishing_api.patch_links(
+        edition["content_id"],
+        links: links,
+        bulk_publishing: true,
+      )
+    end
+  end
+end

--- a/spec/lib/tasks/tmp_swap_travel_advice_link_spec.rb
+++ b/spec/lib/tasks/tmp_swap_travel_advice_link_spec.rb
@@ -1,0 +1,74 @@
+require "rails_helper"
+
+RSpec.describe "travel_advice:crisis_support" do
+  include PublishingApiHelper
+  include RakeTaskHelper
+
+  let(:edition) do
+    {
+      content_id: SecureRandom.uuid,
+      document_type: "travel_advice",
+      publishing_app: "travel-advice-publisher",
+      links: {
+        ordered_related_items: %w[
+          850ce029-b884-4c1f-8410-7f8fe7e49426
+          98c68202-8c31-405c-b2dc-ad3c00eda687
+          5dc09a0e-7631-11e4-a3cb-005056011aef
+        ],
+      },
+    }
+  end
+
+  before do
+    stub_publishing_api_get_editions(
+      [edition],
+      per_page: 300,
+      publishing_app: "travel-advice-publisher",
+      document_types: %w[travel_advice],
+      states: %w[published],
+    )
+
+    stub_publishing_api_has_links(
+      {
+        content_id: edition[:content_id],
+        links: edition[:links],
+      },
+    )
+
+    stub_any_publishing_api_patch_links
+  end
+
+  it "swaps /guidance/how-to-deal-with-a-crisis-overseas for /government/collections/support-for-british-nationals-abroad" do
+    rake "travel_advice:crisis_support"
+
+    assert_publishing_api_patch_links(
+      edition[:content_id],
+      links: {
+        "ordered_related_items" => %w[
+          850ce029-b884-4c1f-8410-7f8fe7e49426
+          98c68202-8c31-405c-b2dc-ad3c00eda687
+          aad65646-964d-4f68-ac22-5bc6c8281336
+        ],
+      },
+      bulk_publishing: true,
+    )
+  end
+
+  it "doesn't swap in that link for other content types" do
+    edition[:document_type] = "publication"
+
+    rake "travel_advice:crisis_support"
+
+    refute(assert_publishing_api_patch_links(
+             edition[:content_id],
+             links: {
+               "ordered_related_items" => %w[
+                 850ce029-b884-4c1f-8410-7f8fe7e49426
+                 98c68202-8c31-405c-b2dc-ad3c00eda687
+                 aad65646-964d-4f68-ac22-5bc6c8281336
+               ],
+             },
+             bulk_publishing: true,
+           ))
+  end
+end


### PR DESCRIPTION
FCDO wants this link replaced on all their Travel Advice pages. This is a one off change, so we're making this a rake task to be deleted.

Followed the conventions set in https://github.com/alphagov/content-tagger/pull/1186

[Trello](https://trello.com/c/g5f4cHoe/1348-related-content-link-change-in-travel-advice-s)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
