### PR TITLE
Updating to meet Replatforming standards

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.dockerignore
+.git
+.gitignore
+.github
+Dockerfile
+Jenkinsfile
+README.md
+docs
+tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,29 @@
-FROM ruby:2.7.6
-RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y build-essential nodejs && apt-get clean
-RUN gem install foreman
+ARG base_image=ghcr.io/alphagov/govuk-ruby-base:2.7.6
+ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:2.7.6
+ 
+FROM $builder_image AS builder
 
-# This image is only intended to be able to run this app in a production RAILS_ENV
-ENV RAILS_ENV production
+WORKDIR /app
 
-ENV DATABASE_URL postgresql://postgres@postgres/content-tagger
-ENV GOVUK_APP_NAME content-tagger
-ENV PORT 3116
+COPY Gemfile* .ruby-version /app/
 
-ENV APP_HOME /app
-RUN mkdir $APP_HOME
+RUN bundle install
 
-WORKDIR $APP_HOME
-ADD Gemfile* $APP_HOME/
-RUN bundle config set deployment 'true'
-RUN bundle config set without 'development test'
-RUN bundle install --jobs 4
-ADD . $APP_HOME
+COPY . /app
 
-RUN GOVUK_APP_DOMAIN=www.gov.uk GOVUK_APP_DOMAIN_EXTERNAL=www.gov.uk bundle exec rails assets:precompile
+RUN bundle exec rails assets:precompile && \
+    rm -fr /app/log
 
-HEALTHCHECK CMD curl --silent --fail localhost:$PORT || exit 1
 
-CMD foreman run web
+FROM $base_image
+
+ENV GOVUK_APP_NAME=content-tagger
+
+WORKDIR /app
+
+COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
+COPY --from=builder /app /app/
+
+USER app
+
+CMD bundle exec puma

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,0 +1,2 @@
+require "govuk_app_config/govuk_puma"
+GovukPuma.configure_rails(self)


### PR DESCRIPTION
  Updated Dockerfile to match replatforming standards
  Added .dockerignore
  Adds Puma via govuk_app_config

https://trello.com/c/44ebF691/1026-publishing-journey-apps-migrations

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
