### PR TITLE
Port govuk_taxonomy_helpers gem into codebase

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,6 @@ gem "gds-api-adapters"
 gem "gds-sso"
 gem "govuk_admin_template"
 gem "govuk_sidekiq"
-gem "govuk_taxonomy_helpers"
 gem "plek"
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -160,7 +160,6 @@ GEM
       sidekiq (>= 5, < 6)
       sidekiq-logging-json (~> 0.0)
       sidekiq-statsd (>= 2.1)
-    govuk_taxonomy_helpers (1.0.0)
     govuk_test (3.0.1)
       brakeman (>= 5.0.2)
       capybara (>= 3.36)
@@ -468,7 +467,6 @@ DEPENDENCIES
   govuk_app_config
   govuk_schemas
   govuk_sidekiq
-  govuk_taxonomy_helpers
   govuk_test
   hashdiff
   jquery-ui-rails

--- a/app/models/taxonomy/expanded_taxonomy.rb
+++ b/app/models/taxonomy/expanded_taxonomy.rb
@@ -86,7 +86,7 @@ module Taxonomy
       if content_item["content_id"] == GovukTaxonomy::ROOT_CONTENT_ID
         home_page_linked_content_item
       else
-        GovukTaxonomyHelpers::LinkedContentItem.new(
+        LinkedContentItem.new(
           internal_name: content_item.dig("details", "internal_name"),
           title: content_item.fetch("title"),
           base_path: content_item.fetch("base_path"),
@@ -96,7 +96,7 @@ module Taxonomy
     end
 
     def home_page_linked_content_item
-      GovukTaxonomyHelpers::LinkedContentItem.new(
+      LinkedContentItem.new(
         internal_name: GovukTaxonomy::TITLE,
         title: GovukTaxonomy::TITLE,
         base_path: "/",
@@ -119,7 +119,7 @@ module Taxonomy
     end
 
     def build_child_expansion
-      @child_expansion = GovukTaxonomyHelpers::LinkedContentItem.from_content_id(
+      @child_expansion = LinkedContentItem.from_content_id(
         content_id: @content_id,
         publishing_api: Services.publishing_api,
       )
@@ -134,7 +134,7 @@ module Taxonomy
     def build_child_expansion_for_home_page
       @child_expansion = home_page_linked_content_item.tap do |node|
         LevelOneTaxonsRetrieval.new.get.each do |level_one_taxon|
-          node << GovukTaxonomyHelpers::LinkedContentItem.from_content_id(
+          node << LinkedContentItem.from_content_id(
             content_id: level_one_taxon["content_id"],
             publishing_api: Services.publishing_api,
           )

--- a/app/models/taxonomy/linked_content_item.rb
+++ b/app/models/taxonomy/linked_content_item.rb
@@ -1,0 +1,119 @@
+module Taxonomy
+  # A LinkedContentItem can be anything that has a content store representation
+  # on GOV.UK.
+  #
+  # It can be used with "taxon" content items (a topic in the taxonomy) or
+  # other document types that link to taxons.
+  #
+  # Taxon instances can have an optional parent and any number of child taxons.
+  class LinkedContentItem
+    extend Forwardable
+    attr_reader :title, :content_id, :base_path, :children, :internal_name, :taxons
+    attr_accessor :parent
+
+    def_delegators :tree, :map, :each, :count
+
+    # Use the publishing API service to fetch and extract a LinkedContentItem
+    #
+    # @param content_id [String] id of the content
+    # @param publishing_api [GdsApi::PublishingApi] Publishing API service
+    # @return [LinkedContentItem]
+    def self.from_content_id(content_id:, publishing_api:)
+      PublishingApiResponse.new(
+        content_item: publishing_api.get_content(content_id).to_h,
+        expanded_links: publishing_api.get_expanded_links(content_id).to_h,
+        publishing_api:,
+      ).linked_content_item
+    end
+
+    # @param title [String] the user facing name for the content item
+    # @param base_path [String] the relative URL, starting with a leading "/"
+    # @param content_id [UUID] unique identifier of the content item
+    # @param internal_name [String] an internal name for the content item
+    def initialize(title:, base_path:, content_id:, internal_name: nil)
+      @title = title
+      @internal_name = internal_name
+      @content_id = content_id
+      @base_path = base_path
+      @children = []
+      @taxons = []
+    end
+
+    # Add a LinkedContentItem as a child of this one
+    def <<(child_node)
+      child_node.parent = self
+      @children << child_node
+    end
+
+    # Get taxons in the taxon's branch of the taxonomy.
+    #
+    # @return [Array] all taxons in this branch of the taxonomy, including the content item itself
+    def tree
+      return [self] if @children.empty?
+
+      @children.each_with_object([self]) do |child, tree|
+        tree.concat(child.tree)
+      end
+    end
+
+    # Get descendants of a taxon
+    #
+    # @return [Array] all taxons in this branch of the taxonomy, excluding the content item itself
+    def descendants
+      tree.tap(&:shift)
+    end
+
+    # Get ancestors of a taxon
+    #
+    # @return [Array] all taxons in the path from the root of the taxonomy to the parent taxon
+    def ancestors
+      if parent.nil?
+        []
+      else
+        parent.ancestors + [parent]
+      end
+    end
+
+    # Get a breadcrumb trail for a taxon
+    #
+    # @return [Array] all taxons in the path from the root of the taxonomy to this taxon
+    def breadcrumb_trail
+      ancestors + [self]
+    end
+
+    # Get all linked taxons and their ancestors
+    #
+    # @return [Array] all taxons that this content item can be found in
+    def taxons_with_ancestors
+      taxons.flat_map(&:breadcrumb_trail)
+    end
+
+    # @return [Boolean] whether this taxon is the root of its taxonomy
+    def root?
+      parent.nil?
+    end
+
+    # @return [Integer] the number of taxons between this taxon and the taxonomy root
+    def depth
+      return 0 if root?
+
+      1 + parent.depth
+    end
+
+    # Link this content item to a taxon
+    #
+    # @param taxon_node [LinkedContentItem] A taxon content item
+    def add_taxon(taxon_node)
+      taxons << taxon_node
+    end
+
+    # @return [String] the string representation of the content item
+    def inspect
+      if internal_name.nil?
+        "LinkedContentItem(title: '#{title}', content_id: '#{content_id}', base_path: '#{base_path}')"
+      else
+        "LinkedContentItem(title: '#{title}', internal_name: '#{internal_name}', content_id: '#{content_id}', base_path: '#{base_path}')"
+      end
+    end
+  end
+end

--- a/app/models/taxonomy/linked_content_item/publishing_api_response.rb
+++ b/app/models/taxonomy/linked_content_item/publishing_api_response.rb
@@ -1,0 +1,101 @@
+module Taxonomy
+  class LinkedContentItem::PublishingApiResponse
+    attr_accessor :linked_content_item
+
+    # @param content_item [Hash] Publishing API `get_content` response hash
+    # @param expanded_links [Hash] Publishing API `get_expanded_links` response hash
+    # @param publishing_api [GdsApi::PublishingApi] Publishing API service
+    def initialize(content_item:, expanded_links:, publishing_api:)
+      details = content_item["details"] || {}
+
+      @linked_content_item = LinkedContentItem.new(
+        title: content_item["title"],
+        internal_name: details["internal_name"],
+        content_id: content_item["content_id"],
+        base_path: content_item["base_path"],
+      )
+
+      add_expanded_links(expanded_links, publishing_api)
+    end
+
+  private
+
+    def add_expanded_links(expanded_links_response, publishing_api)
+      level_one_taxons = expanded_links_response["expanded_links"]["level_one_taxons"]
+      child_taxons = expanded_links_response["expanded_links"]["child_taxons"]
+      parent_taxons = expanded_links_response["expanded_links"]["parent_taxons"]
+      taxons = expanded_links_response["expanded_links"]["taxons"]
+
+      if level_one_taxons
+        level_one_taxons.each do |taxon|
+          expanded = publishing_api.get_expanded_links(taxon["content_id"])
+          taxon["links"] = expanded["expanded_links"]
+          linked_content_item << parse_nested_child(taxon)
+        end
+      end
+
+      if child_taxons
+        child_taxons.each do |child|
+          linked_content_item << parse_nested_child(child)
+        end
+      end
+
+      if parent_taxons
+        # Assume no taxon has multiple parents
+        single_parent = parent_taxons.first
+
+        parse_nested_parent(single_parent) << linked_content_item
+      end
+
+      if taxons
+        taxons.each do |taxon|
+          taxon_node = parse_nested_parent(taxon)
+          linked_content_item.add_taxon(taxon_node)
+        end
+      end
+    end
+
+    def parse_nested_child(nested_item)
+      details = nested_item["details"] || {}
+      links = nested_item["links"] || {}
+
+      nested_linked_content_item = LinkedContentItem.new(
+        title: nested_item["title"],
+        internal_name: details["internal_name"],
+        content_id: nested_item["content_id"],
+        base_path: nested_item["base_path"],
+      )
+
+      child_taxons = links["child_taxons"]
+
+      unless child_taxons.nil?
+        child_taxons.each do |child|
+          nested_linked_content_item << parse_nested_child(child)
+        end
+      end
+
+      nested_linked_content_item
+    end
+
+    def parse_nested_parent(nested_item)
+      details = nested_item["details"] || {}
+      links = nested_item["links"] || {}
+
+      nested_linked_content_item = LinkedContentItem.new(
+        title: nested_item["title"],
+        internal_name: details["internal_name"],
+        content_id: nested_item["content_id"],
+        base_path: nested_item["base_path"],
+      )
+
+      parent_taxons = links["parent_taxons"]
+
+      unless parent_taxons.nil?
+        single_parent = parent_taxons.first
+        parse_nested_parent(single_parent) << nested_linked_content_item
+      end
+
+      nested_linked_content_item
+    end
+  end
+end

--- a/app/services/taxonomy/bulk_publish_taxon.rb
+++ b/app/services/taxonomy/bulk_publish_taxon.rb
@@ -9,7 +9,7 @@ module Taxonomy
     end
 
     def bulk_publish
-      linked_content_item = GovukTaxonomyHelpers::LinkedContentItem.from_content_id(
+      linked_content_item = LinkedContentItem.from_content_id(
         content_id: @root_taxon_content_id,
         publishing_api: Services.publishing_api,
       )

--- a/app/services/taxonomy/bulk_update_taxon.rb
+++ b/app/services/taxonomy/bulk_update_taxon.rb
@@ -14,11 +14,10 @@ module Taxonomy
   private
 
     def nested_tree
-      GovukTaxonomyHelpers::LinkedContentItem
-        .from_content_id(
-          content_id: @root_taxon_content_id,
-          publishing_api: Services.publishing_api,
-        )
+      LinkedContentItem.from_content_id(
+        content_id: @root_taxon_content_id,
+        publishing_api: Services.publishing_api,
+      )
     end
   end
 end

--- a/app/services/taxonomy/taxons_with_content_count.rb
+++ b/app/services/taxonomy/taxons_with_content_count.rb
@@ -6,7 +6,7 @@ module Taxonomy
 
     def nested_tree
       @nested_tree ||= process_linked_content_item_tree(
-        GovukTaxonomyHelpers::LinkedContentItem.from_content_id(
+        LinkedContentItem.from_content_id(
           content_id: @root_taxon.content_id,
           publishing_api: Services.publishing_api,
         ),

--- a/spec/models/taxonomy/linked_content_item/publishing_api_response_spec.rb
+++ b/spec/models/taxonomy/linked_content_item/publishing_api_response_spec.rb
@@ -1,0 +1,501 @@
+module Taxonomy
+  RSpec.describe LinkedContentItem::PublishingApiResponse do
+    let(:content_item) do
+      {
+        "content_id" => "64aadc14-9bca-40d9-abb4-4f21f9792a05",
+        "base_path" => "/taxon",
+        "title" => "Taxon",
+        "details" => {
+          "internal_name" => "My lovely taxon",
+        },
+      }
+    end
+    let(:linked_content_item) do
+      LinkedContentItem.from_content_id(
+        content_id: content_item["content_id"],
+        publishing_api:,
+      )
+    end
+
+    let(:expanded_links) do
+      child = {
+        "content_id" => "74aadc14-9bca-40d9-abb4-4f21f9792a05",
+        "base_path" => "/child",
+        "title" => "Child",
+        "details" => {
+          "internal_name" => "C",
+        },
+        "links" => {},
+      }
+
+      {
+        "content_id" => "64aadc14-9bca-40d9-abb4-4f21f9792a05",
+        "expanded_links" => {
+          "child_taxons" => [child],
+        },
+      }
+    end
+
+    let(:publishing_api) { instance_double("GdsApi::PublishingApi") }
+
+    before do
+      allow(publishing_api).to receive(:get_content).with("64aadc14-9bca-40d9-abb4-4f21f9792a05").and_return(content_item)
+      allow(publishing_api).to receive(:get_expanded_links).with("64aadc14-9bca-40d9-abb4-4f21f9792a05").and_return(expanded_links)
+    end
+
+    describe "#from_content_id - simple one child case" do
+      it "loads the taxon" do
+        expect(linked_content_item.title).to eq("Taxon")
+        expect(linked_content_item.children.map(&:title)).to eq(%w[Child])
+        expect(linked_content_item.children.map(&:children)).to all(be_empty)
+      end
+    end
+
+    context "when content item contain multiple levels of descendants" do
+      let(:expanded_links) do
+        grandchild1 = {
+          "content_id" => "84aadc14-9bca-40d9-abb4-4f21f9792a05",
+          "base_path" => "/grandchild-1",
+          "title" => "Grandchild 1",
+          "details" => {
+            "internal_name" => "GC 1",
+          },
+          "links" => {},
+        }
+
+        grandchild2 = {
+          "content_id" => "94aadc14-9bca-40d9-abb4-4f21f9792a05",
+          "base_path" => "/grandchild-2",
+          "title" => "Grandchild 2",
+          "details" => {
+            "internal_name" => "GC 2",
+          },
+          "links" => {},
+        }
+
+        child1 = {
+          "content_id" => "74aadc14-9bca-40d9-abb4-4f21f9792a05",
+          "base_path" => "/child-1",
+          "title" => "Child 1",
+          "details" => {
+            "internal_name" => "C 1",
+          },
+          "links" => {
+            "child_taxons" => [
+              grandchild1,
+              grandchild2,
+            ],
+          },
+        }
+
+        {
+          "content_id" => "64aadc14-9bca-40d9-abb4-4f21f9792a05",
+          "expanded_links" => {
+            "child_taxons" => [child1],
+          },
+        }
+      end
+
+      it "parses titles" do
+        expect(linked_content_item.title).to eq("Taxon")
+        expect(linked_content_item.children.map(&:title)).to eq(["Child 1"])
+        expect(linked_content_item.children.first.children.map(&:title)).to eq(["Grandchild 1", "Grandchild 2"])
+      end
+
+      it "parses internal names" do
+        expect(linked_content_item.internal_name).to eq("My lovely taxon")
+        expect(linked_content_item.children.map(&:internal_name)).to eq(["C 1"])
+        expect(linked_content_item.children.first.children.map(&:internal_name)).to eq(["GC 1", "GC 2"])
+      end
+    end
+
+    context "when a content item has no descendants" do
+      let(:expanded_links) do
+        {
+          "content_id" => "64aadc14-9bca-40d9-abb4-4f21f9792a05",
+          "expanded_links" => {},
+        }
+      end
+
+      it "parses each level of taxons" do
+        expect(linked_content_item.title).to eq("Taxon")
+        expect(linked_content_item.children).to be_empty
+      end
+    end
+
+    context "when a content item has children but no grandchildren" do
+      let(:expanded_links) do
+        child1 = {
+          "content_id" => "74aadc14-9bca-40d9-abb4-4f21f9792a05",
+          "base_path" => "/child-1",
+          "title" => "Child 1",
+          "details" => {
+            "internal_name" => "C 1",
+          },
+          "links" => {},
+        }
+
+        child2 = {
+          "content_id" => "84aadc14-9bca-40d9-abb4-4f21f9792a05",
+          "base_path" => "/child-2",
+          "title" => "Child 2",
+          "details" => {
+            "internal_name" => "C 2",
+          },
+          "links" => {},
+        }
+
+        {
+          "content_id" => "64aadc14-9bca-40d9-abb4-4f21f9792a05",
+          "expanded_links" => {
+            "child_taxons" => [child1, child2],
+          },
+        }
+      end
+
+      it "parses each level of taxons" do
+        expect(linked_content_item.title).to eq("Taxon")
+        expect(linked_content_item.children.map(&:title)).to eq(["Child 1", "Child 2"])
+        expect(linked_content_item.children.map(&:children)).to all(be_empty)
+      end
+    end
+
+    context "when a content item has parents and grandparents" do
+      let(:expanded_links) do
+        grandparent1 = {
+          "content_id" => "84aadc14-9bca-40d9-abb4-4f21f9792a05",
+          "base_path" => "/grandparent-1",
+          "title" => "Grandparent 1",
+          "details" => {
+            "internal_name" => "GP 1",
+          },
+          "links" => {},
+        }
+
+        parent1 = {
+          "content_id" => "74aadc14-9bca-40d9-abb4-4f21f9792a05",
+          "base_path" => "/parent-1",
+          "title" => "Parent 1",
+          "details" => {
+            "internal_name" => "P 1",
+          },
+          "links" => {
+            "parent_taxons" => [
+              grandparent1,
+            ],
+          },
+        }
+
+        {
+          "content_id" => "64aadc14-9bca-40d9-abb4-4f21f9792a05",
+          "expanded_links" => {
+            "parent_taxons" => [parent1],
+          },
+        }
+      end
+
+      it "parses the ancestors" do
+        expect(linked_content_item.title).to eq("Taxon")
+        expect(linked_content_item.parent.title).to eq("Parent 1")
+        expect(linked_content_item.ancestors.map(&:title)).to eq(["Grandparent 1", "Parent 1"])
+      end
+    end
+
+    context "when a content item has parents but no grandparents" do
+      let(:expanded_links) do
+        parent1 = {
+          "content_id" => "74aadc14-9bca-40d9-abb4-4f21f9792a05",
+          "base_path" => "/parent-1",
+          "title" => "Parent 1",
+          "details" => {
+            "internal_name" => "P 1",
+          },
+          "links" => {},
+        }
+
+        {
+          "content_id" => "64aadc14-9bca-40d9-abb4-4f21f9792a05",
+          "expanded_links" => {
+            "parent_taxons" => [parent1],
+          },
+        }
+      end
+
+      it "parses the ancestors" do
+        expect(linked_content_item.title).to eq("Taxon")
+        expect(linked_content_item.parent.title).to eq("Parent 1")
+        expect(linked_content_item.ancestors.map(&:title)).to eq(["Parent 1"])
+      end
+    end
+
+    context "when a content item has no parents" do
+      let(:expanded_links) do
+        {
+          "content_id" => "64aadc14-9bca-40d9-abb4-4f21f9792a05",
+          "expanded_links" => {},
+        }
+      end
+
+      it "parses the ancestors" do
+        expect(linked_content_item.title).to eq("Taxon")
+        expect(linked_content_item.parent).to be_nil
+        expect(linked_content_item.ancestors.map(&:title)).to be_empty
+      end
+    end
+
+    context "when a content item has multiple parents" do
+      let(:expanded_links) do
+        parent1 = {
+          "content_id" => "74aadc14-9bca-40d9-abb4-4f21f9792a05",
+          "base_path" => "/parent-1",
+          "title" => "Parent 1",
+          "details" => {
+            "internal_name" => "P 1",
+          },
+          "links" => {},
+        }
+
+        parent2 = {
+          "content_id" => "84aadc14-9bca-40d9-abb4-4f21f9792a05",
+          "base_path" => "/parent-2",
+          "title" => "Parent 2",
+          "details" => {
+            "internal_name" => "P 2",
+          },
+          "links" => {},
+        }
+
+        {
+          "content_id" => "64aadc14-9bca-40d9-abb4-4f21f9792a05",
+          "expanded_links" => {
+            "parent_taxons" => [parent1, parent2],
+          },
+        }
+      end
+
+      it "uses only the first parent" do
+        expect(linked_content_item.title).to eq("Taxon")
+        expect(linked_content_item.parent.title).to eq("Parent 1")
+        expect(linked_content_item.ancestors.map(&:title)).to eq(["Parent 1"])
+      end
+    end
+
+    context "when a content item tagged to multiple taxons" do
+      let(:expanded_links) do
+        grandparent1 = {
+          "content_id" => "22aadc14-9bca-40d9-abb4-4f21f9792a05",
+          "base_path" => "/grandparent-1",
+          "title" => "Grandparent 1",
+          "details" => {
+            "internal_name" => "GP 1",
+          },
+          "links" => {},
+        }
+
+        parent1 = {
+          "content_id" => "11aadc14-9bca-40d9-abb4-4f21f9792a05",
+          "base_path" => "/parent-1",
+          "title" => "Parent 1",
+          "details" => {
+            "internal_name" => "P 1",
+          },
+          "links" => {
+            "parent_taxons" => [grandparent1],
+          },
+        }
+
+        taxon1 = {
+          "content_id" => "00aadc14-9bca-40d9-abb4-4f21f9792a05",
+          "base_path" => "/this-is-a-taxon",
+          "title" => "Taxon 1",
+          "details" => {
+            "internal_name" => "T 1",
+          },
+          "links" => {
+            "parent_taxons" => [parent1],
+          },
+        }
+
+        grandparent2 = {
+          "content_id" => "03aadc14-9bca-40d9-abb4-4f21f9792a05",
+          "base_path" => "/grandparent-2",
+          "title" => "Grandparent 2",
+          "details" => {
+            "internal_name" => "GP 2",
+          },
+          "links" => {},
+        }
+
+        parent2 = {
+          "content_id" => "02aadc14-9bca-40d9-abb4-4f21f9792a05",
+          "base_path" => "/parent-2",
+          "title" => "Parent 2",
+          "details" => {
+            "internal_name" => "P 2",
+          },
+          "links" => {
+            "parent_taxons" => [grandparent2],
+          },
+        }
+
+        taxon2 = {
+          "content_id" => "01aadc14-9bca-40d9-abb4-4f21f9792a05",
+          "base_path" => "/this-is-also-a-taxon",
+          "title" => "Taxon 2",
+          "details" => {
+            "internal_name" => "T 2",
+          },
+          "links" => {
+            "parent_taxons" => [parent2],
+          },
+        }
+
+        {
+          "content_id" => "64aadc14-9bca-40d9-abb4-4f21f9792a05",
+          "expanded_links" => {
+            "taxons" => [taxon1, taxon2],
+          },
+        }
+      end
+
+      it "parses the taxons and their ancestors" do
+        expect(linked_content_item.parent).to be_nil
+        expect(linked_content_item.taxons.map(&:title)).to eq(["Taxon 1", "Taxon 2"])
+        expect(linked_content_item.taxons_with_ancestors.map(&:title).sort).to eq(
+          [
+            "Grandparent 1",
+            "Grandparent 2",
+            "Parent 1",
+            "Parent 2",
+            "Taxon 1",
+            "Taxon 2",
+          ],
+        )
+      end
+    end
+
+    context "when there is a homepage content item with a level_one_taxon and a child" do
+      it "parses each level of taxons from home page" do
+        root_taxon = {
+          "content_id" => "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a",
+          "base_path" => "/",
+          "title" => "GOV.UK homepage",
+          "details" => {},
+        }
+
+        child_for_level_one_taxon = {
+          "content_id" => "84aadc14-9bca-40d9-abb4-4f21f9792a05",
+          "base_path" => "/transport_child",
+          "title" => "Transport child",
+          "details" => {
+            "internal_name" => "TC 1",
+          },
+          "links" => {},
+        }
+
+        level_one_taxon = {
+          "content_id" => "a4038b29-b332-4f13-98b1-1c9709e216bc",
+          "base_path" => "/transport/all",
+          "title" => "Transport",
+          "details" => {
+            "internal_name" => "Transport",
+          },
+          "links" => {
+            "child_taxons" => [child_for_level_one_taxon],
+            "root_taxon" => [root_taxon],
+          },
+        }
+
+        expanded_links = {
+          "expanded_links" => {
+            "level_one_taxons" => [level_one_taxon],
+          },
+        }
+
+        expanded_links2 = {
+          "expanded_links" => {
+            "child_taxons" => [child_for_level_one_taxon],
+          },
+        }
+
+        allow(publishing_api).to receive(:get_content).with("f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a").and_return(root_taxon)
+        allow(publishing_api).to receive(:get_expanded_links).with("f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a").and_return(expanded_links)
+        allow(publishing_api).to receive(:get_expanded_links).with("a4038b29-b332-4f13-98b1-1c9709e216bc").and_return(expanded_links2)
+
+        homepage_taxon = LinkedContentItem.from_content_id(
+          content_id: root_taxon["content_id"],
+          publishing_api:,
+        )
+
+        expect(homepage_taxon.title).to eq("GOV.UK homepage")
+        expect(homepage_taxon.parent).to eq(nil)
+        expect(homepage_taxon.children.map(&:title)).to eq(%w[Transport])
+        expect(homepage_taxon.descendants.map(&:title)).to eq(["Transport", "Transport child"])
+        expect(homepage_taxon.children.first.children.first.title).to eq("Transport child")
+      end
+    end
+
+    context "when there are minimal responses with missing links and details hashes" do
+      it "parses taxons with nil internal names" do
+        grandchild1 = {
+          "content_id" => "84aadc14-9bca-40d9-abb4-4f21f9792a05",
+          "base_path" => "/grandchild-1",
+          "title" => "Grandchild 1",
+        }
+
+        grandchild2 = {
+          "content_id" => "94aadc14-9bca-40d9-abb4-4f21f9792a05",
+          "base_path" => "/grandchild-2",
+          "title" => "Grandchild 2",
+        }
+
+        child1 = {
+          "content_id" => "74aadc14-9bca-40d9-abb4-4f21f9792a05",
+          "base_path" => "/child-1",
+          "title" => "Child 1",
+          "links" => {
+            "child_taxons" => [
+              grandchild1,
+              grandchild2,
+            ],
+          },
+        }
+
+        content_item = {
+          "content_id" => "aaaaaa14-9bca-40d9-abb4-4f21f9792a05",
+          "base_path" => "/minimal-taxon",
+          "title" => "Minimal Taxon",
+        }
+
+        expanded_links = {
+          "content_id" => "64aadc14-9bca-40d9-abb4-4f21f9792a05",
+          "expanded_links" => {
+            "child_taxons" => [child1],
+            "parent_taxons" => [
+              {
+                "content_id" => "ffaadc14-9bca-40d9-abb4-4f21f9792aff",
+                "title" => "Parent Taxon",
+                "base_path" => "/parent",
+              },
+            ],
+          },
+        }
+
+        allow(publishing_api).to receive(:get_content).with("aaaaaa14-9bca-40d9-abb4-4f21f9792a05").and_return(content_item)
+        allow(publishing_api).to receive(:get_expanded_links).with("aaaaaa14-9bca-40d9-abb4-4f21f9792a05").and_return(expanded_links)
+
+        minimal_taxon = LinkedContentItem.from_content_id(
+          content_id: content_item["content_id"],
+          publishing_api:,
+        )
+
+        expect(minimal_taxon.title).to eq("Minimal Taxon")
+        expect(minimal_taxon.internal_name).to be_nil
+        expect(minimal_taxon.parent.title).to eq("Parent Taxon")
+        expect(minimal_taxon.parent.internal_name).to be_nil
+        expect(minimal_taxon.descendants.map(&:title)).to eq(["Child 1", "Grandchild 1", "Grandchild 2"])
+        expect(minimal_taxon.descendants.map(&:internal_name)).to all(be_nil)
+      end
+    end
+  end
+end

--- a/spec/models/taxonomy/linked_content_item_spec.rb
+++ b/spec/models/taxonomy/linked_content_item_spec.rb
@@ -1,0 +1,147 @@
+RSpec.describe Taxonomy::LinkedContentItem do
+  let(:root_node) { described_class.new(title: "root-id", content_id: "abc", base_path: "/root-id") }
+  let(:child_node_1) { described_class.new(title: "child-1-id", content_id: "abc", base_path: "/child-1-id") }
+
+  describe "#<<(child_node)" do
+    it "makes one node the child of another node" do
+      root_node << child_node_1
+
+      expect(root_node.tree).to include child_node_1
+      expect(child_node_1.parent).to eq root_node
+    end
+  end
+
+  describe "#tree" do
+    context "when given a node with a tree of successors" do
+      it "returns an array representing a pre-order traversal of the tree" do
+        child_node_2 = described_class.new(title: "child-2-id", content_id: "abc", base_path: "/child-2-id")
+        child_node_3 = described_class.new(title: "child-3-id", content_id: "abc", base_path: "/child-3-id")
+
+        root_node << child_node_1
+        child_node_1 << child_node_3
+        child_node_1 << child_node_2
+
+        expect(root_node.tree.count).to eq 4
+        expect(root_node.tree.first).to eq root_node
+        expect(root_node.tree.map(&:title)).to eq %w[root-id child-1-id child-3-id child-2-id]
+        expect(child_node_1.tree.map(&:title)).to eq %w[child-1-id child-3-id child-2-id]
+      end
+    end
+
+    context "when given a single node" do
+      it "returns an array containing only that node" do
+        expect(root_node.tree.map(&:title)).to eq %w[root-id]
+      end
+    end
+  end
+
+  describe "#root?" do
+    before do
+      root_node << child_node_1
+    end
+
+    it "returns true when a node is the root" do
+      expect(root_node.root?).to be(true)
+    end
+
+    it "returns false when a node is not the root" do
+      expect(child_node_1.root?).to be(false)
+    end
+  end
+
+  describe "#depth" do
+    it "returns the depth of the node in its tree" do
+      child_node_2 = described_class.new(title: "child-2-id", content_id: "abc", base_path: "/child-2-id")
+      root_node << child_node_1
+      child_node_1 << child_node_2
+
+      expect(root_node.depth).to eq 0
+      expect(child_node_1.depth).to eq 1
+      expect(child_node_2.depth).to eq 2
+    end
+  end
+
+  context "when there is a taxon with ancestors" do
+    let(:child_node_2) do
+      described_class.new(
+        title: "child-2-id",
+        content_id: "abc",
+        base_path: "/child-2-id",
+      )
+    end
+
+    before do
+      root_node << child_node_1
+      child_node_1 << child_node_2
+    end
+
+    describe "#breadcrumb_trail" do
+      it "includes the ancestors plus the content item itself" do
+        expect(child_node_2.breadcrumb_trail.map(&:title)).to eq %w[root-id child-1-id child-2-id]
+      end
+
+      it "is just contains itself for the root node" do
+        expect(root_node.breadcrumb_trail.map(&:title)).to eq %w[root-id]
+      end
+    end
+
+    describe "#ancestors" do
+      it "includes the ancestors but not the content item itself" do
+        expect(child_node_2.ancestors.map(&:title)).to eq %w[root-id child-1-id]
+      end
+
+      it "is the reverse of #descendants" do
+        have_descendant_node = lambda do |ancestor|
+          ancestor.descendants.include?(child_node_2)
+        end
+
+        expect(child_node_2.ancestors).to all(satisfy(&have_descendant_node))
+      end
+
+      it "is an empty array for the root node" do
+        expect(root_node.ancestors).to be_empty
+      end
+    end
+
+    describe "#taxons" do
+      let(:content_item) do
+        described_class.new(
+          title: "content",
+          content_id: "abc",
+          base_path: "/content",
+        )
+      end
+
+      it "includes only the directly linked taxons" do
+        content_item.add_taxon(child_node_2)
+
+        expect(content_item.taxons.map(&:title)).to eq ["child-2-id"]
+      end
+    end
+
+    describe "#taxons_with_ancestors" do
+      let(:another_taxon) do
+        described_class.new(
+          title: "another-taxon",
+          content_id: "abc",
+          base_path: "/another-taxon",
+        )
+      end
+
+      let(:content_item) do
+        described_class.new(
+          title: "content",
+          content_id: "abc",
+          base_path: "/content",
+        )
+      end
+
+      it "includes all of the taxons and all of their anscestors" do
+        content_item.add_taxon(child_node_2)
+        content_item.add_taxon(another_taxon)
+
+        expect(content_item.taxons_with_ancestors.map(&:title).sort).to eq %w[another-taxon child-1-id child-2-id root-id]
+      end
+    end
+  end
+end

--- a/spec/presenters/taxonomy/csv_tree_presenter_spec.rb
+++ b/spec/presenters/taxonomy/csv_tree_presenter_spec.rb
@@ -4,19 +4,19 @@ module Taxonomy
 
     describe "#present" do
       let(:root_node) do
-        GovukTaxonomyHelpers::LinkedContentItem.new(internal_name: "root", base_path: "/root", content_id: "Root", title: "Root")
+        LinkedContentItem.new(internal_name: "root", base_path: "/root", content_id: "Root", title: "Root")
       end
 
       let(:child_node_1) do
-        GovukTaxonomyHelpers::LinkedContentItem.new(internal_name: "child-1", base_path: "/Child-1", content_id: "Child-1", title: "Child-1")
+        LinkedContentItem.new(internal_name: "child-1", base_path: "/Child-1", content_id: "Child-1", title: "Child-1")
       end
 
       let(:child_node_2) do
-        GovukTaxonomyHelpers::LinkedContentItem.new(internal_name: "child-2", base_path: "/Child-2", content_id: "Child-2", title: "Child-2")
+        LinkedContentItem.new(internal_name: "child-2", base_path: "/Child-2", content_id: "Child-2", title: "Child-2")
       end
 
       let(:child_node_3) do
-        GovukTaxonomyHelpers::LinkedContentItem.new(internal_name: "child-3", base_path: "/Child-3", content_id: "Child-3", title: "Child-3")
+        LinkedContentItem.new(internal_name: "child-3", base_path: "/Child-3", content_id: "Child-3", title: "Child-3")
       end
 
       before do

--- a/spec/services/taxonomy/bulk_publish_taxon_spec.rb
+++ b/spec/services/taxonomy/bulk_publish_taxon_spec.rb
@@ -2,10 +2,10 @@ RSpec.describe Taxonomy::BulkPublishTaxon do
   let(:root_taxon_id) { 123 }
 
   before do
-    item = GovukTaxonomyHelpers::LinkedContentItem.new(title: "item1", base_path: "/item1", content_id: "id1")
-    item << GovukTaxonomyHelpers::LinkedContentItem.new(title: "item2", base_path: "/item2", content_id: "id2")
+    item = Taxonomy::LinkedContentItem.new(title: "item1", base_path: "/item1", content_id: "id1")
+    item << Taxonomy::LinkedContentItem.new(title: "item2", base_path: "/item2", content_id: "id2")
 
-    allow(GovukTaxonomyHelpers::LinkedContentItem)
+    allow(Taxonomy::LinkedContentItem)
       .to receive(:from_content_id)
       .with(content_id: root_taxon_id, publishing_api: Services.publishing_api)
       .and_return(item)


### PR DESCRIPTION
Trello: https://trello.com/c/QrxjshEm/270-move-ruby-gems-from-jenkins-to-github-actions

The govuk_taxonomy_helpers [1] gem is only used by this application and has had very little development since it was created in 2017.

It seems unlikely that this tool will be used by other GOV.UK applications, so I'm merging into this application.

Once this PR is merged I'm going to go ahead and archive the gem. This will reduce the amount of things GOV.UK will have to maintain.

[1]: https://github.com/alphagov/govuk_taxonomy_helpers

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
