### PR TITLE
Revert  "Bump mail from 2.7.1 to 2.8.0"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem "govuk_app_config"
 gem "hashdiff"
 gem "jquery-ui-rails"
 gem "kaminari"
-gem "mail", "~> 2.8.0"  # TODO: remove once https://github.com/mikel/mail/issues/1489 is fixed.
+gem "mail", "~> 2.7.1"  # TODO: remove once https://github.com/mikel/mail/issues/1489 is fixed.
 gem "pg"
 gem "rack-proxy"
 gem "sassc-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -201,11 +201,8 @@ GEM
     loofah (2.19.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.8.0)
+    mail (2.7.1)
       mini_mime (>= 0.1.1)
-      net-imap
-      net-pop
-      net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
@@ -470,7 +467,7 @@ DEPENDENCIES
   hashdiff
   jquery-ui-rails
   kaminari
-  mail (~> 2.8.0)
+  mail (~> 2.7.1)
   pg
   plek
   pry-byebug


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
