### PR TITLE
This sets the asset path to include the application name.

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -19,6 +19,10 @@ module ContentTagger
     # Configure denylisted tag types by publishing app
     config.denylisted_tag_types = config_for(:denylisted_tag_types)
 
+    # Set asset path to be application specific so that we can put all GOV.UK
+    # assets into an S3 bucket and distinguish app by path.
+    config.assets.prefix = "/assets/content-tagger"
+
     config.active_record.belongs_to_required_by_default = false
   end
 end


### PR DESCRIPTION
Background to this change can be found here:
alphagov/manuals-publisher#2004

Have tested by deploying branch into integration and checking assets on pages.
https://content-tagger.integration.publishing.service.gov.uk/taxons

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
