### PR TITLE
Dockerfile fixes and cleanup.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,14 @@
 .dockerignore
 .git
-.gitignore
 .github
+.gitignore
 Dockerfile
 Jenkinsfile
+Procfile
 README.md
+coverage
 docs
+log
+node_modules
+spec
 tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,26 @@
-ARG base_image=ghcr.io/alphagov/govuk-ruby-base:3.1.2
-ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:3.1.2
+ARG ruby_version=3.1.2
+ARG base_image=ghcr.io/alphagov/govuk-ruby-base:$ruby_version
+ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:$ruby_version
+
 
 FROM $builder_image AS builder
 
-WORKDIR /app
-
-COPY Gemfile* .ruby-version /app/
-
+WORKDIR $APP_HOME
+COPY Gemfile* .ruby-version ./
 RUN bundle install
-
-COPY . /app
-
-RUN bundle exec rails assets:precompile && \
-    rm -fr /app/log
+COPY . .
+RUN bootsnap precompile --gemfile .
+RUN rails assets:precompile && rm -fr log
 
 
 FROM $base_image
 
 ENV GOVUK_APP_NAME=content-tagger
 
-WORKDIR /app
-
-COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
-COPY --from=builder /app /app/
+WORKDIR $APP_HOME
+COPY --from=builder $BUNDLE_PATH $BUNDLE_PATH
+COPY --from=builder $BOOTSNAP_CACHE_DIR $BOOTSNAP_CACHE_DIR
+COPY --from=builder $APP_HOME .
 
 USER app
-
-CMD ["bundle", "exec", "puma"]
+CMD ["puma"]

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gem "rails", "7.0.4"
 
+gem "bootsnap", require: false
 gem "bootstrap-kaminari-views"
 gem "govuk_app_config"
 gem "hashdiff"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,8 @@ GEM
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
     bindex (0.8.1)
+    bootsnap (1.15.0)
+      msgpack (~> 1.2)
     bootstrap-kaminari-views (0.0.5)
       kaminari (>= 0.13)
       rails (>= 3.1)
@@ -211,6 +213,7 @@ GEM
     mini_mime (1.1.2)
     mini_portile2 (2.8.1)
     minitest (5.17.0)
+    msgpack (1.6.0)
     multi_xml (0.6.0)
     net-imap (0.3.1)
       net-protocol
@@ -453,6 +456,7 @@ PLATFORMS
 DEPENDENCIES
   awesome_print
   better_errors
+  bootsnap
   bootstrap-kaminari-views
   factory_bot_rails
   fakefs

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,5 +20,9 @@ module ContentTagger
     config.denylisted_tag_types = config_for(:denylisted_tag_types)
 
     config.active_record.belongs_to_required_by_default = false
+
+    # Set asset path to be application specific so that we can put all GOV.UK
+    # assets into an S3 bucket and distinguish app by path.
+    config.assets.prefix = "/assets/content-tagger"
   end
 end

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,3 +1,4 @@
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
 require "bundler/setup" # Set up gems listed in the Gemfile.
+require "bootsnap"


### PR DESCRIPTION
- Fix Rails assets deployment to S3 by including the app name in the Rails assets path.
- Parameterise the Ruby version.
- Enable [bootsnap](https://github.com/Shopify/bootsnap#bootsnap-).
- Remove some hard-coded paths.
- Clean up `.dockerignore`.
- Make better use of `WORKDIR`.
- Remove the now-redundant `bundle exec` from the default command.

Tested: builds and comes up healthy on the integration Kubernetes cluster.