### PR TITLE
Remove Mailer from the Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,6 @@ gem "govuk_app_config"
 gem "hashdiff"
 gem "jquery-ui-rails"
 gem "kaminari"
-gem "mail", "~> 2.7.1"  # TODO: remove once https://github.com/mikel/mail/issues/1489 is fixed.
 gem "pg"
 gem "rack-proxy"
 gem "sassc-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -470,7 +470,6 @@ DEPENDENCIES
   hashdiff
   jquery-ui-rails
   kaminari
-  mail (~> 2.7.1)
   pg
   plek
   pry-byebug


### PR DESCRIPTION
Previously, there was an issue with the mailer gem in release 2.8.0 mikel/mail#1489.

To circumvent this we added it to the Gemfile and pinned it on the 2.7.0 release. Since this has been fixed we can remove it as a direct dependency.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
