### PR TITLE
Ensure Sidekiq is 7.0.0 compliant

### DIFF
--- a/app/services/taxonomy/bulk_update_taxon.rb
+++ b/app/services/taxonomy/bulk_update_taxon.rb
@@ -7,7 +7,7 @@ module Taxonomy
 
     def bulk_update
       nested_tree.each do |taxon|
-        UpdateTaxonWorker.perform_async(taxon.content_id, @attributes)
+        UpdateTaxonWorker.perform_async(taxon.content_id, @attributes.stringify_keys)
       end
     end
 

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,2 @@
+# Use Sidekiq strict args to force Sidekiq 6 deprecations to error ahead of upgrade to Sidekiq 7
+Sidekiq.strict_args!

--- a/lib/tasks/taxonomy/health_checks.rake
+++ b/lib/tasks/taxonomy/health_checks.rake
@@ -7,7 +7,7 @@ namespace :taxonomy do
     ContentTagger::Application.config_for(:health_checks)["metrics"].each do |metric|
       puts %(Name: #{metric[:name]}; Arguments: #{(metric[:arguments] || []).map { |k, v| "#{k}: #{v}" }.join(', ')})
       klazz = "TaxonomyHealth::#{metric[:class]}".constantize
-      klazz.perform_async(metric[:arguments])
+      klazz.perform_async(metric[:arguments].stringify_keys)
     end
   end
 end


### PR DESCRIPTION
## Description 

We recently merged the bump of the GOV.UK Sidekiq gem to 6.0.0 in https://github.com/alphagov/content-tagger/pull/1439

We're going through our repos that use Sidekiq, enforcing strict args and applying fixes to that they're 7.0.0 compliant.

## Trello card 

https://trello.com/c/JXAvbpOX/1103-upgrade-apps-to-sidekiq-v6

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
