### PR TITLE
Update example spreadsheet for bulk tagging

### DIFF
--- a/app/views/tagging_spreadsheets/new.html.erb
+++ b/app/views/tagging_spreadsheets/new.html.erb
@@ -19,6 +19,6 @@
     <% end %>
   </div>
   <div class="col-md-4">
-    <%= render 'shared/help', example_spreadsheet: "https://docs.google.com/spreadsheets/d/1qUajhROscOjcPzuDc9tpEnVsBZCJSfO6Ctkcwh9EgvY/pub?gid=0" %>
+    <%= render 'shared/help', example_spreadsheet: "https://docs.google.com/spreadsheets/d/1CkmNClwusFBfhMRcE2wEO96RgAi85WrukdQKRDlVuos/pub" %>
   </div>
 </div>


### PR DESCRIPTION
The original example spreadsheet was deleted from Google Drive, so it was 404 erroring when users clicked the link.

We've updated the link to use a new example spreadsheet. This new Google Sheet is held in a Shared Drive, so it should persist beyond the life of any one individual's Google account.

This was reported to us via Zendesk:
https://govuk.zendesk.com/agent/tickets/5188849

Trello:
https://trello.com/c/gowpUa2c/1117-update-content-tagger-with-an-example-spreadsheet-gds

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
