### PR TITLE
Revert "Bump pg from 1.5.3 to 1.5.4"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -455,7 +455,7 @@ GEM
     parser (3.2.2.3)
       ast (~> 2.4.1)
       racc
-    pg (1.5.4)
+    pg (1.5.3)
     plek (5.0.0)
     prometheus-client (4.2.1)
     prometheus_exporter (2.0.8)


### PR DESCRIPTION
Reverts alphagov/content-tagger#1560
Seems to not be passing checks when merging.