### PR TITLE
Fix incomplete regex escape function.

### DIFF
--- a/app/assets/javascripts/filter-table.js
+++ b/app/assets/javascripts/filter-table.js
@@ -50,11 +50,9 @@
         GOVUKAdmin.redirect(link.attr('href'))
       }
 
-      // http://stackoverflow.com/questions/3446170/escape-string-for-use-in-javascript-regex
-      // https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/regexp
-      // Escape ~!@#$%^&*(){}[]`/=?+\|-_;:'",<.>
       function escapeStringForRegexp (str) {
-        return str.replace(/[-[\]/{}()*+?.^$|]/g, '\\$&')
+        // https://github.com/tc39/proposal-regex-escaping
+        return str.replace(/[\\^$*+?.()|[\]{}]/g, '\\$&')
       }
     }
   }


### PR DESCRIPTION
Use the regex from the TC39 [regex escaping proposal](https://github.com/tc39/proposal-regex-escaping) instead of our own, which didn't handle backslashes properly.

The code taken from the proposal is public domain (CC0 1.0 declaration), so the attribution link is simply for maintainability rather than legal reasons.

Fixes https://github.com/alphagov/content-tagger/security/code-scanning/1.