### PR TITLE
Prevent rails from being upgraded automatically

### DIFF
--- a/.govuk_dependabot_merger.yml
+++ b/.govuk_dependabot_merger.yml
@@ -2,3 +2,6 @@ api_version: 2
 defaults:
   auto_merge: true
   update_external_dependencies: false # TODO: enable after verifying that this repo meets the conditions
+overrides:
+  - dependency: rails # should be upgraded manually, see https://docs.publishing.service.gov.uk/manual/keeping-software-current.html#rails
+    auto_merge: false


### PR DESCRIPTION
Rails upgrades should always be done manually:
https://docs.publishing.service.gov.uk/manual/keeping-software-current.html#rails

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
