### PR TITLE
Fully qualify an exception reference

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -50,7 +50,7 @@ private
   end
 
   def deny_access_to(subject)
-    raise PermissionDeniedError, "Sorry, you are not authorised to access this #{subject}."
+    raise GDS::SSO::PermissionDeniedError, "Sorry, you are not authorised to access this #{subject}."
   end
 
   def permission_checker


### PR DESCRIPTION
The `PermissionDeniedError` exists in the `GDS::SSO` namespace, not within the `ApplicationController `, so the reference to it needs to be fully qualified.

This is to resolve an unhandled exception:

```
uninitialized constant ApplicationController::PermissionDeniedError (NameError)
```

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
