### PR TITLE
Switch from Uglifier to Terser

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem "select2-rails", "< 4" # There are unresolved visual and HTML changes with s
 gem "sentry-sidekiq"
 gem "simple_form"
 gem "sprockets-rails"
-gem "uglifier"
+gem "terser"
 
 gem "gds-api-adapters"
 gem "gds-sso"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -699,13 +699,13 @@ GEM
     statsd-ruby (1.5.0)
     stringio (3.1.1)
     strscan (3.1.0)
+    terser (1.2.3)
+      execjs (>= 0.3.0, < 3)
     thor (1.3.1)
     tilt (2.0.10)
     timeout (0.4.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    uglifier (4.2.0)
-      execjs (>= 0.3.0, < 3)
     unicode-display_width (2.5.0)
     uri (0.13.0)
     version_gem (1.1.4)
@@ -770,7 +770,7 @@ DEPENDENCIES
   simple_form
   simplecov
   sprockets-rails
-  uglifier
+  terser
   web-console
   webmock
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -25,7 +25,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = :terser
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Use Terser instead of Uglifier to compile JavaScript.

## Why

This change is preparation for upgrading to V5 of govuk-frontend in the govuk-publishing-components gem.

govuk-frontend v5 now targets browsers that support ES6. This means that the UMD modules used in govuk_publsihing_components from govuk-frontend use features of ES6 and so it means that Uglifier can't be used anymore because it only supports ES5.
