### PR TITLE
Fix Javascript error on page load

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -8,10 +8,11 @@
 //= require jquery.waypoints.min.js
 
 //= require govuk_publishing_components/dependencies
+//= require govuk_publishing_components/lib/cookie-functions
 
 $(document).ready(function () {
   $('.select2:not(.tagging_project):not(.bulk_tagger)').select2({ allowClear: true })
-})
 
-window.GOVUK.approveAllCookieTypes()
-window.GOVUK.cookie('cookies_preferences_set', 'true', { days: 365 })
+  window.GOVUK.approveAllCookieTypes()
+  window.GOVUK.cookie('cookies_preferences_set', 'true', { days: 365 })
+})


### PR DESCRIPTION
With the update to the publishing components gem the call to
 `window.GOVUK.approveAllCookieTypes()` in
 `app/assets/javascripts/application.js` is failing. Move the call
 inside a `$(document).ready` handler and add a require for the cookie
 functions code.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
