### PR TITLE
Fix broken icons

### DIFF
--- a/app/assets/javascripts/views/related-content-tagger.js
+++ b/app/assets/javascripts/views/related-content-tagger.js
@@ -10,7 +10,7 @@
       var $templateTag = $fieldset.find('.related-item-template > li').first()
       var $fieldErrors = $fieldset.find('.related-item-error-message')
 
-      $fieldset.on('click', '.select2-search-choice-close', removeItem)
+      $fieldset.on('click', '.js-remove-related', removeItem)
       $basePathInput.on('keypress', lookUpBasePathOnEnterPress)
       $lookupButton.on('click', lookUpBasePath)
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -86,3 +86,9 @@
 .nav.nav-tabs {
   margin-bottom: 20px;
 }
+
+@font-face {
+  font-family: "Glyphicons Halflings";
+  src: url("bootstrap/glyphicons-halflings-regular.eot");
+  src: url("bootstrap/glyphicons-halflings-regular.eot?#iefix") format("embedded-opentype"),url("bootstrap/glyphicons-halflings-regular.woff2") format("woff2"),url("bootstrap/glyphicons-halflings-regular.woff") format("woff"),url("bootstrap/glyphicons-halflings-regular.ttf") format("truetype"),url("bootstrap/glyphicons-halflings-regular.svg#glyphicons_halflingsregular") format("svg")
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -92,3 +92,18 @@
   src: url("bootstrap/glyphicons-halflings-regular.eot");
   src: url("bootstrap/glyphicons-halflings-regular.eot?#iefix") format("embedded-opentype"),url("bootstrap/glyphicons-halflings-regular.woff2") format("woff2"),url("bootstrap/glyphicons-halflings-regular.woff") format("woff"),url("bootstrap/glyphicons-halflings-regular.ttf") format("truetype"),url("bootstrap/glyphicons-halflings-regular.svg#glyphicons_halflingsregular") format("svg")
 }
+
+.sortable-list .glyphicon.remove-icon {
+  float: left;
+  margin-left: -20px;
+  margin-right: 10px;
+}
+
+// overrides for select2 as it doesn't compile properly in dart-sass, uses image-url
+.select2-container .select2-choice .select2-arrow {
+  background: url("select2.png") no-repeat 0 1px;
+}
+
+.select2-search-choice-close {
+    background: url("select2.png") right top no-repeat;
+}

--- a/app/views/taggings/_tagging_entry.html.erb
+++ b/app/views/taggings/_tagging_entry.html.erb
@@ -7,7 +7,7 @@
         <%= tagging_update.title_for_related_link(base_path) %> (<%= base_path %>)
       </a>
 
-      <a href="#" class="select2-search-choice-close" tabindex="-1"></a>
+      <a href="#" class="js-remove-related glyphicon glyphicon-remove remove-icon" tabindex="-1" title="Remove <%= base_path %>"></a>
 
       <span class="glyphicon glyphicon-resize-vertical" aria-hidden="true"></span>
 


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / why
- fixes broken icons across the site
- icons are glyphicons from bootstrap, which are included as part of that dependency and can't be directly modified
- problem is caused by the compiled Sass not being able to find and download the icon font files e.g. https://content-tagger.publishing.service.gov.uk/assets/content-tagger/bootstrap/glyphicons-halflings-regular.eot
- this appears to be because the syntax in bootstrap for defining these files uses `url(font-path(path))` which doesn't seem to work anymore, could be related to the recent dart-sass migration but unclear
- as a workaround have copied the font-face declaration from the bootstrap CSS into our own, and replaced the above with `url(path)`, which works
- this occurs after the bootstrap declaration, overriding it and allowing the icon font file to be found and loaded correctly

## Visual changes

Before
![Screenshot 2024-08-08 at 16 12 33](https://github.com/user-attachments/assets/6a547e86-7151-4a54-8521-67dbaace925a)

After
![Screenshot 2024-08-08 at 16 12 40](https://github.com/user-attachments/assets/4c7eea3c-f849-4eea-863e-45c288c70278)

Trello card: https://trello.com/c/gW2NW1sB/239-fix-sass-compilation-warnings