### PR TITLE
Erb lint update

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -1,0 +1,40 @@
+---
+EnableDefaultLinters: false
+glob: "**/*.{html,text,js}{+*,}.erb"
+exclude:
+  - '**/vendor/**/*'
+  - '**/node_modules/**/*'
+linters:
+  SpaceAroundErbTag:
+    enabled: true
+  Rubocop:
+    enabled: true
+    exclude:
+      - "**/vendor/**/*"
+      - "**/vendor/**/.*"
+      - "bin/**"
+      - "db/**/*"
+      - "spec/**/*"
+      - "config/**/*"
+      - "node_modules/**/*"
+    rubocop_config:
+      inherit_from:
+        - .rubocop.yml
+      AllCops:
+        DisabledByDefault: true
+      Layout/InitialIndentation:
+        Enabled: false
+      Layout/TrailingEmptyLines:
+        Enabled: false
+      Layout/TrailingWhitespace:
+        Enabled: false
+      Naming/FileName:
+        Enabled: false
+      Style/FrozenStringLiteralComment:
+        Enabled: false
+      Layout/LineLength:
+        Enabled: false
+      Lint/UselessAssignment:
+        Enabled: false
+      Layout/FirstHashElementIndentation:
+        Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem "rails", "7.1.3.4"
 gem "bootsnap", require: false
 gem "bootstrap-kaminari-views"
 gem "dartsass-rails"
-gem "erb_lint"
+gem "erb_lint", require: false
 gem "govuk_app_config"
 gem "hashdiff"
 gem "jquery-ui-rails"

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gem "rails", "7.1.3.4"
 gem "bootsnap", require: false
 gem "bootstrap-kaminari-views"
 gem "dartsass-rails"
+gem "erb_lint"
 gem "govuk_app_config"
 gem "hashdiff"
 gem "jquery-ui-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,13 @@ GEM
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
       rouge (>= 1.0.0)
+    better_html (2.1.1)
+      actionview (>= 6.0)
+      activesupport (>= 6.0)
+      ast (~> 2.0)
+      erubi (~> 1.4)
+      parser (>= 2.4)
+      smart_properties
     bigdecimal (3.1.8)
     bindex (0.8.1)
     bootsnap (1.18.4)
@@ -125,6 +132,13 @@ GEM
     docile (1.4.0)
     domain_name (0.6.20240107)
     drb (2.2.1)
+    erb_lint (0.6.0)
+      activesupport
+      better_html (>= 2.0.1)
+      parser (>= 2.7.1.4)
+      rainbow
+      rubocop (>= 1)
+      smart_properties
     erubi (1.13.0)
     execjs (2.9.1)
     factory_bot (6.4.6)
@@ -692,6 +706,7 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    smart_properties (1.17.0)
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
@@ -748,6 +763,7 @@ DEPENDENCIES
   bootsnap
   bootstrap-kaminari-views
   dartsass-rails
+  erb_lint
   factory_bot_rails
   fakefs
   gds-api-adapters

--- a/app/views/application/_aggregated_tag_mappings.html.erb
+++ b/app/views/application/_aggregated_tag_mappings.html.erb
@@ -7,7 +7,7 @@
       <% aggregated_tagging.links.each do |tag_link| %>
         <%= link_to tag_link.link_title, taxon_path(tag_link.link_content_id) %> (<%= tag_link.link_type %>)
         <br />
-      <% end%>
+      <% end %>
 
       <% if aggregated_tagging.errored? %>
         <hr />

--- a/app/views/application/_tag_update_preview.html.erb
+++ b/app/views/application/_tag_update_preview.html.erb
@@ -7,7 +7,7 @@
         locals: {
           completed_tag_mappings: completed_tag_mappings,
           total_tag_mappings: total_tag_mappings,
-          progress_path: progress_path
+          progress_path: progress_path,
         } %>
     <% end %>
   </div>
@@ -21,11 +21,11 @@
         <th></th>
       </tr>
 
-      <%= render partial: 'shared/table_filter' %>
+      <%= render partial: "shared/table_filter" %>
     </thead>
 
     <tbody>
-      <%= render partial: 'aggregated_tag_mappings',
+      <%= render partial: "aggregated_tag_mappings",
         locals: { aggregated_tag_mappings: aggregated_tag_mappings } %>
     </tbody>
   </table>

--- a/app/views/application/_tag_update_progress_bar.html.erb
+++ b/app/views/application/_tag_update_progress_bar.html.erb
@@ -2,7 +2,7 @@
 <div class="js-tag-update-progress" data-progress-path="<%= progress_path %>">
 
   <div class="progress">
-    <div class="progress-bar <%= 'progress-bar-striped active' unless percentage_complete == 100 %>"
+    <div class="progress-bar <%= "progress-bar-striped active" unless percentage_complete == 100 %>"
       role="progressbar"
       aria-valuenow="<%= completed_tag_mappings %>"
       aria-valuemin="0"
@@ -14,7 +14,7 @@
 
   <div class="progress-counter">
     <p>
-      <%= I18n.t('views.tag_update_progress_bar', completed: completed_tag_mappings, total: total_tag_mappings)%>
+      <%= I18n.t("views.tag_update_progress_bar", completed: completed_tag_mappings, total: total_tag_mappings) %>
     </p>
   </div>
 

--- a/app/views/bulk_tags/new.html.erb
+++ b/app/views/bulk_tags/new.html.erb
@@ -1,6 +1,6 @@
-<%= display_header title: t('bulk_tagging.title'), breadcrumbs: [t('navigation.bulk_tag')] do %>
-  <%= link_to t('navigation.tag_importer'), tagging_spreadsheets_path, class: 'btn btn-default' %>
-  <%= link_to t('navigation.tag_migration'), tag_migrations_path, class: 'btn btn-default' %>
+<%= display_header title: t("bulk_tagging.title"), breadcrumbs: [t("navigation.bulk_tag")] do %>
+  <%= link_to t("navigation.tag_importer"), tagging_spreadsheets_path, class: "btn btn-default" %>
+  <%= link_to t("navigation.tag_migration"), tag_migrations_path, class: "btn btn-default" %>
 <% end %>
 
 <div class="lead">
@@ -11,17 +11,17 @@
 <%= simple_form_for :bulk_tag, url: search_results_for_bulk_tag_path, method: :get do |f| %>
   <div class="form-group">
     <%= f.input :query, label: false,
-      input_html: { class: 'form-control', value: query }
+      input_html: { class: "form-control", value: query }
     %>
 
-    <%= f.submit t('bulk_tag.search_button'), class: "btn btn-md btn-success" %>
+    <%= f.submit t("bulk_tag.search_button"), class: "btn btn-md btn-success" %>
   </div>
 <% end %>
 
 <% if search_results.results.any? %>
-  <%= render 'search_results', results: search_results.results %>
+  <%= render "search_results", results: search_results.results %>
 <% elsif query.present? %>
   <p class="no-content no-content-bordered">No search results for '<%= query %>'</p>
 <% end %>
 
-<%= paginate search_results, theme: 'twitter-bootstrap-3' %>
+<%= paginate search_results, theme: "twitter-bootstrap-3" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,46 +4,46 @@
   <%= javascript_include_tag "govuk_publishing_components/load-analytics" %>
 
   <%= stylesheet_link_tag "application", media: "all" %>
-  <%= javascript_include_tag 'application' %>
+  <%= javascript_include_tag "application" %>
   <%= csrf_meta_tags %>
 <% end %>
 
 <% content_for :navbar_items do %>
   <% if user_can_administer_taxonomy? %>
-    <li class='<%= active_navigation_item == 'taggings' ? 'active' : nil %>'>
-      <%= link_to t('navigation.tagging_content'), lookup_taggings_path %>
+    <li class='<%= active_navigation_item == "taggings" ? "active" : nil %>'>
+      <%= link_to t("navigation.tagging_content"), lookup_taggings_path %>
     </li>
   <% end %>
 
   <% if user_can_administer_taxonomy? %>
-    <li class='<%= active_navigation_item.in?(%w[bulk_tags tag_migrations tagging_spreadsheets]) ? 'active' : nil %>'>
-      <%= link_to t('navigation.bulk_tag'), new_bulk_tag_path %>
+    <li class='<%= active_navigation_item.in?(%w[bulk_tags tag_migrations tagging_spreadsheets]) ? "active" : nil %>'>
+      <%= link_to t("navigation.bulk_tag"), new_bulk_tag_path %>
     </li>
   <% end %>
 
   <% if user_can_administer_taxonomy? %>
-    <li class='<%= active_navigation_item.in?(%w[taxons taxon_migrations branches]) ? 'active' : nil %>'>
-      <%= link_to t('navigation.taxons'), taxons_path %>
+    <li class='<%= active_navigation_item.in?(%w[taxons taxon_migrations branches]) ? "active" : nil %>'>
+      <%= link_to t("navigation.taxons"), taxons_path %>
     </li>
   <% end %>
 
   <% if user_can_administer_taxonomy? %>
-    <li class='<%= active_navigation_item.in?(%w[tagging_history]) ? 'active' : nil %>'>
-      <%= link_to t('navigation.tagging_history'), tagging_history_index_path %>
+    <li class='<%= active_navigation_item.in?(%w[tagging_history]) ? "active" : nil %>'>
+      <%= link_to t("navigation.tagging_history"), tagging_history_index_path %>
     </li>
   <% end %>
 
   <% if user_can_administer_taxonomy? %>
-    <li class='<%= active_navigation_item.in?(%w[health_warnings]) ? 'active' : nil %>'>
-      <%= link_to t('navigation.taxonomy_health'), taxonomy_health_warnings_path %>
+    <li class='<%= active_navigation_item.in?(%w[health_warnings]) ? "active" : nil %>'>
+      <%= link_to t("navigation.taxonomy_health"), taxonomy_health_warnings_path %>
     </li>
   <% end %>
 
   <% if user_can_access_tagathon_tools? %>
-    <li class='<%= active_navigation_item.in?(%w[projects project_content_items]) ? 'active' : nil %>'>
-      <%= link_to t('navigation.projects'), projects_path %>
+    <li class='<%= active_navigation_item.in?(%w[projects project_content_items]) ? "active" : nil %>'>
+      <%= link_to t("navigation.projects"), projects_path %>
     </li>
   <% end %>
 <% end %>
 
-<%= render template: 'layouts/govuk_admin_template' %>
+<%= render template: "layouts/govuk_admin_template" %>

--- a/app/views/project_content_items/_flags.html.erb
+++ b/app/views/project_content_items/_flags.html.erb
@@ -4,36 +4,36 @@
       <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
       <h4 class="modal-title">Flag '<%= content_item.title %>' for review</h4>
     </div>
-    <%= form_for content_item, url: update_flags_project_content_item_path(project, content_item), method: :post, remote: true, html: { data: { module: 'radio-toggle' } } do |f| %>
+    <%= form_for content_item, url: update_flags_project_content_item_path(project, content_item), method: :post, remote: true, html: { data: { module: "radio-toggle" } } do |f| %>
 
     <div class="modal-body flag-for-review">
       <div class='radio'>
         <label>
-          <%= f.radio_button :flag, "needs_help", required: true, data: { target: 'need-help-comment' } %>
+          <%= f.radio_button :flag, "needs_help", required: true, data: { target: "need-help-comment" } %>
           I need help tagging this
         </label>
       </div>
 
       <div id='need-help-comment' class='form-group add-top-margin add-left-border'>
         <%= f.label :need_help_comment, "Comment (optional)" %>
-        <%= f.text_field :need_help_comment, class: 'form-control input-md-4' %>
+        <%= f.text_field :need_help_comment, class: "form-control input-md-4" %>
       </div>
 
       <div class='radio'>
         <label>
-          <%= f.radio_button :flag, "missing_topic", data: { target: 'suggested-tags' } %>
+          <%= f.radio_button :flag, "missing_topic", data: { target: "suggested-tags" } %>
           There's no relevant topic for this
         </label>
       </div>
 
       <div id='suggested-tags' class='form-group add-top-margin add-left-border'>
         <%= f.label :suggested_tags, "Suggest a new topic (optional)" %>
-        <%= f.text_field :suggested_tags, class: 'form-control input-md-4' %>
+        <%= f.text_field :suggested_tags, class: "form-control input-md-4" %>
       </div>
     </div>
 
     <div class='modal-footer'>
-      <%= f.submit "Continue", class: 'btn btn-success add-right-margin' %>
+      <%= f.submit "Continue", class: "btn btn-success add-right-margin" %>
       <button type="button" class="btn btn-link" data-dismiss="modal">Cancel</button>
     </div>
     <% end %>

--- a/app/views/project_content_items/flags.js.erb
+++ b/app/views/project_content_items/flags.js.erb
@@ -1,5 +1,5 @@
 $('#flags-modal')
-  .html("<%= escape_javascript(render partial: 'flags', locals: local_assigns) %>")
+  .html("<%= escape_javascript(render partial: "flags", locals: local_assigns) %>")
   .promise()
   .done(function () {
     var radioToggle = new GOVUKAdmin.Modules.RadioToggle;

--- a/app/views/projects/_bulk_tagging.html.erb
+++ b/app/views/projects/_bulk_tagging.html.erb
@@ -6,13 +6,13 @@
     <li class='active'><a href='#'>Edit selected</a></li>
   </ul>
 
-  <%= simple_form_for :bulk_tagging, url: project_bulk_update_path(project), remote: true, html: { class: 'js-bulk-tagger-form' } do |f| %>
+  <%= simple_form_for :bulk_tagging, url: project_bulk_update_path(project), remote: true, html: { class: "js-bulk-tagger-form" } do |f| %>
     <div><span class='js-selected-count'>None</span> selected</div>
 
     <%= f.input :taxons,
-      placeholder: 'Tags',
+      placeholder: "Tags",
       label: false,
-      input_html: { class: [:select2, :bulk_tagger, :js_bulk_tagger_input], autocomplete: 'off' }
+      input_html: { class: [:select2, :bulk_tagger, :js_bulk_tagger_input], autocomplete: "off" }
     %>
 
     <div class='bulk-selectors'>
@@ -20,10 +20,10 @@
         collection: content_items,
         as: :check_boxes,
         include_hidden: false,
-        class: 'content-selector js-content-selector'
+        class: "content-selector js-content-selector"
       %>
     </div>
 
-    <%= f.submit 'Apply' %>
+    <%= f.submit "Apply" %>
   <% end %>
 </div>

--- a/app/views/projects/_content_item.html.erb
+++ b/app/views/projects/_content_item.html.erb
@@ -1,16 +1,16 @@
 <div class='content-item'>
-  <%= simple_form_for content_item, url: project_content_item_path(content_item.project, content_item), remote: true, html: { data: { ref: content_item.id }, class: 'js-content-item-form content-item-form' } do |f| %>
+  <%= simple_form_for content_item, url: project_content_item_path(content_item.project, content_item), remote: true, html: { data: { ref: content_item.id }, class: "js-content-item-form content-item-form" } do |f| %>
     <%= token_tag %>
 
     <% if content_item.needs_help? %>
       <%= render partial: "danger_label_with_text", locals: {
-        label_text: I18n.t('views.projects.flags.help-needed'),
+        label_text: I18n.t("views.projects.flags.help-needed"),
         additional_text_label: "Comment",
         additional_text: content_item.need_help_comment,
       } %>
     <% elsif content_item.missing_topic? %>
       <%= render partial: "danger_label_with_text", locals: {
-        label_text: I18n.t('views.projects.flags.missing-topic'),
+        label_text: I18n.t("views.projects.flags.missing-topic"),
         additional_text_label: "Suggested topic",
         additional_text: content_item.suggested_tags,
       } %>
@@ -19,7 +19,7 @@
     <% end %>
 
     <h4>
-      <%= link_to content_item.title, content_item.url, data: {proxy_iframe: 'enabled', modal_url: content_item.proxied_url, toggle: 'modal', target: '#iframe_modal_id'} %>
+      <%= link_to content_item.title, content_item.url, data: {proxy_iframe: "enabled", modal_url: content_item.proxied_url, toggle: "modal", target: "#iframe_modal_id"} %>
     </h4>
 
     <p><%= content_item.description %></p>
@@ -28,10 +28,10 @@
       label: false,
       input_html: {
         class: [:select2, :tagging_project, :js_bulk_tagger_input],
-        autocomplete: 'off',
+        autocomplete: "off",
         data: { taxons: content_item.taxons },
-        value: '',
-        disabled: 'disabled'
+        value: "",
+        disabled: "disabled",
       } %>
   <% end %>
 
@@ -40,9 +40,9 @@
       &nbsp;
     </p>
     <div class='actions actions-inline'>
-      <%= button_to 'Done', mark_done_project_content_item_path(content_item.project, content_item), class: 'btn btn-primary', form_class: 'js-mark-as-done', remote: true %>
+      <%= button_to "Done", mark_done_project_content_item_path(content_item.project, content_item), class: "btn btn-primary", form_class: "js-mark-as-done", remote: true %>
       <% unless content_item.flag? %>
-        <%= link_to I18n.t('views.projects.flag_for_review'), flags_project_content_item_path(content_item.project, content_item), class: 'btn btn-link', remote: true, data: { toggle: "modal", target: '#flags-modal' } %>
+        <%= link_to I18n.t("views.projects.flag_for_review"), flags_project_content_item_path(content_item.project, content_item), class: "btn btn-link", remote: true, data: { toggle: "modal", target: "#flags-modal" } %>
       <% end %>
     </div>
   <% end %>

--- a/app/views/projects/confirm_delete.html.erb
+++ b/app/views/projects/confirm_delete.html.erb
@@ -11,7 +11,7 @@
   <%= button_to "Confirm delete",
     project_path(project),
     method: :delete,
-    class: 'btn btn-danger add-right-margin' %>
+    class: "btn btn-danger add-right-margin" %>
 
   <%= link_to "Cancel", :back, class: "cancel-link" %>
 </div>

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -1,5 +1,5 @@
-<%= display_header title: "Tagging Projects", breadcrumbs: ["Projects"] do %>
-  <%= link_to new_project_path, class: 'btn btn-default' do %>
+<%= display_header title: "Tagging Projects", breadcrumbs: %w[Projects] do %>
+  <%= link_to new_project_path, class: "btn btn-default" do %>
     <i class="glyphicon glyphicon-plus"></i>Add new project
   <% end %>
 <% end %>
@@ -27,7 +27,7 @@
     </thead>
 
     <tbody>
-      <%= render partial: 'project', collection: branch_projects, cached: true %>
+      <%= render partial: "project", collection: branch_projects, cached: true %>
     </tbody>
   </table>
 <% end %>
@@ -57,7 +57,7 @@
 
 </form>
 
-<% if percentage_by_organisation.present?%>
+<% if percentage_by_organisation.present? %>
   <table class="table queries-list table-bordered table-striped" id="tagging-progress">
     <thead>
       <tr class="table-header">

--- a/app/views/projects/new.html.erb
+++ b/app/views/projects/new.html.erb
@@ -21,29 +21,29 @@
         </div>
       <% end %>
 
-      <%= f.input :name, input_html: { class: 'form-control' },
-                  label: 'Name',
-                  hint: 'Name of the new project.' %>
+      <%= f.input :name, input_html: { class: "form-control" },
+                  label: "Name",
+                  hint: "Name of the new project." %>
 
-      <%= f.input :taxonomy_branch, input_html: { class: 'form-control' },
-                  label: 'Branch of GOV.UK taxonomy',
+      <%= f.input :taxonomy_branch, input_html: { class: "form-control" },
+                  label: "Branch of GOV.UK taxonomy",
                   collection: form.taxonomy_branches_for_select %>
 
-      <%= f.input :remote_url, input_html: { class: 'form-control' },
-                  label: 'Spreadsheet URL',
-                  hint: 'Spreadsheet URL with the contents of the project. Required columns: url, title and description.' %>
+      <%= f.input :remote_url, input_html: { class: "form-control" },
+                  label: "Spreadsheet URL",
+                  hint: "Spreadsheet URL with the contents of the project. Required columns: url, title and description." %>
 
-      <%= f.input :bulk_tagging_enabled, input_html: { class: 'form-control' },
-                  label: 'Bulk tagging',
-                  hint: 'Enable the bulk tagging interface for this project?',
+      <%= f.input :bulk_tagging_enabled, input_html: { class: "form-control" },
+                  label: "Bulk tagging",
+                  hint: "Enable the bulk tagging interface for this project?",
                   as: :boolean,
                   checked_value: true %>
 
-      <%= f.submit 'New Project', class: "btn btn-lg btn-success" %>
+      <%= f.submit "New Project", class: "btn btn-lg btn-success" %>
     <% end %>
   </div>
   <div class="col-md-4">
-    <%= render 'shared/help',
+    <%= render "shared/help",
       example_spreadsheet: "https://docs.google.com/spreadsheets/d/1R9Qkg4CmvnQ1WDmT6mqZm7_5kIOstRsnhIDmv0Eop40/pub?gid=0" %>
   </div>
 </div>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -1,10 +1,10 @@
 <%= display_header title: project.name, breadcrumbs: [:projects, project.name] do %>
   <% if user_can_administer_taxonomy? %>
-    <%= link_to 'Delete', project_confirm_delete_path(project), class: 'btn btn-danger' %>
+    <%= link_to "Delete", project_confirm_delete_path(project), class: "btn btn-danger" %>
   <% end %>
 <% end %>
 
-<%= render partial: 'shared/iframe_proxy_modal' %>
+<%= render partial: "shared/iframe_proxy_modal" %>
 <div id="flags-modal" class="modal" tabindex="-1" role="dialog"></div>
 
 <div class="row tagathon-project">
@@ -19,7 +19,7 @@
              value="<%= query.params[:title_search] %>"
              placeholder="Filter by title...">
 
-      <% filters.each do |filter_option|  %>
+      <% filters.each do |filter_option| %>
         <div class="radio">
           <label>
             <input type="radio"
@@ -45,7 +45,7 @@
       <% end %>
 
       <div class='content-list'>
-        <%= render partial: 'content_item', collection: content_items, cached: true %>
+        <%= render partial: "content_item", collection: content_items, cached: true %>
       </div>
     <% else %>
       <p class="no-content">No pages found!</p>

--- a/app/views/shared/_tag_migration_form.html.erb
+++ b/app/views/shared/_tag_migration_form.html.erb
@@ -8,7 +8,7 @@
 
 <div class="form-group">
   <h4>Tag selected pages to taxon:</h4>
-  <%= select_tag :taxons, options_for_select(taxons), multiple: true, class: 'select2' %>
+  <%= select_tag :taxons, options_for_select(taxons), multiple: true, class: "select2" %>
 </div>
 
 <div class="panel panel-default add-top-margin">
@@ -21,9 +21,9 @@
 </div>
 
 <% if expanded_links.any? %>
-  <%= render 'tag_migrations/items_tagged_to_item', expanded_links: expanded_links %>
+  <%= render "tag_migrations/items_tagged_to_item", expanded_links: expanded_links %>
 <% else %>
   <p class="no-content no-content-bordered">No content tagged to this item</p>
 <% end %>
 
-<%= f.submit t("bulk_tagging.preview"), class: 'btn btn-md btn-default' %>
+<%= f.submit t("bulk_tagging.preview"), class: "btn btn-md btn-default" %>

--- a/app/views/tag_migrations/_bulk_tagging_history_table.html.erb
+++ b/app/views/tag_migrations/_bulk_tagging_history_table.html.erb
@@ -7,7 +7,7 @@
       <th></th>
       <th></th>
     </tr>
-    <%= render partial: 'shared/table_filter' %>
+    <%= render partial: "shared/table_filter" %>
   </thead>
   <tbody>
     <% tag_migrations.each do |tag_migration| %>

--- a/app/views/tag_migrations/_items_tagged_to_item.html.erb
+++ b/app/views/tag_migrations/_items_tagged_to_item.html.erb
@@ -3,26 +3,26 @@
     <tr class="table-header">
       <th data-module="select-all">
         Select all
-        <%= check_box_tag 'select_all', nil, false %>
+        <%= check_box_tag "select_all", nil, false %>
       </th>
       <th>Page</th>
       <th></th>
     </tr>
 
-    <%= render partial: 'shared/table_filter' %>
+    <%= render partial: "shared/table_filter" %>
   </thead>
   <tbody>
     <% expanded_links.each do |expanded_link| %>
       <tr>
         <td>
-          <%= check_box_tag 'content_base_paths[]',
-            expanded_link.base_path, false, class: 'select-content-item' %>
+          <%= check_box_tag "content_base_paths[]",
+            expanded_link.base_path, false, class: "select-content-item" %>
         </td>
         <td>
           <%= expanded_link.title %>
           <%- if expanded_link.draft? %><%= expanded_link_label(expanded_link) %><%- end %>
         </td>
-        <td><%= link_to 'View on site', website_url(expanded_link.base_path, draft: expanded_link.draft?) %></td>
+        <td><%= link_to "View on site", website_url(expanded_link.base_path, draft: expanded_link.draft?) %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/tag_migrations/index.html.erb
+++ b/app/views/tag_migrations/index.html.erb
@@ -1,8 +1,8 @@
-<%= display_header title: t('navigation.tag_migration'), breadcrumbs: [
-  link_to(t('navigation.bulk_tag'), new_bulk_tag_path), t('navigation.tag_migration')] %>
+<%= display_header title: t("navigation.tag_migration"), breadcrumbs: [
+      link_to(t("navigation.bulk_tag"), new_bulk_tag_path), t("navigation.tag_migration")] %>
 
 <% if tag_migrations.any? %>
-  <%= render 'bulk_tagging_history_table', tag_migrations: tag_migrations %>
+  <%= render "bulk_tagging_history_table", tag_migrations: tag_migrations %>
 <% else %>
   <p class="no-content no-content-bordered">Nothing to see here yet.</p>
 <% end %>

--- a/app/views/tag_migrations/new.html.erb
+++ b/app/views/tag_migrations/new.html.erb
@@ -1,18 +1,18 @@
 <%= display_header(
-  title: t('views.tag_migrations.new.title',
+  title: t("views.tag_migrations.new.title",
            taxon: source_content_item.title,
            type: source_content_item.document_type.humanize.downcase),
   breadcrumbs: [
-    link_to(t('navigation.bulk_tag'), new_bulk_tag_path),
-    "Retag content from '#{source_content_item.title}'"
-  ]
+    link_to(t("navigation.bulk_tag"), new_bulk_tag_path),
+    "Retag content from '#{source_content_item.title}'",
+  ],
 ) %>
 
 <%= simple_form_for tag_migration, url: tag_migrations_path, method: :post do |f| %>
   <%= render(
-    'shared/tag_migration_form',
+    "shared/tag_migration_form",
     f: f,
     taxons: taxons,
-    expanded_links: expanded_links
+    expanded_links: expanded_links,
   ) %>
 <% end %>

--- a/app/views/tag_migrations/show.html.erb
+++ b/app/views/tag_migrations/show.html.erb
@@ -1,8 +1,9 @@
 <%= display_header title: t("views.tag_migrations.show.title", taxon: source_content_item.title, type: source_content_item.document_type.humanize.downcase),
     breadcrumbs: [
       link_to(t("navigation.bulk_tag"), new_bulk_tag_path),
-    link_to(t("navigation.tag_migration"), tag_migrations_path),
-    tag_migration.source_description ] do %>
+      link_to(t("navigation.tag_migration"), tag_migrations_path),
+      tag_migration.source_description,
+    ] do %>
 <% end %>
 
 <% if tag_migration.should_delete_source_link? %>

--- a/app/views/tag_migrations/show.html.erb
+++ b/app/views/tag_migrations/show.html.erb
@@ -1,20 +1,20 @@
-<%= display_header title: t('views.tag_migrations.show.title', taxon: source_content_item.title, type: source_content_item.document_type.humanize.downcase),
+<%= display_header title: t("views.tag_migrations.show.title", taxon: source_content_item.title, type: source_content_item.document_type.humanize.downcase),
     breadcrumbs: [
-    link_to(t('navigation.bulk_tag'), new_bulk_tag_path),
-    link_to(t('navigation.tag_migration'), tag_migrations_path),
+      link_to(t("navigation.bulk_tag"), new_bulk_tag_path),
+    link_to(t("navigation.tag_migration"), tag_migrations_path),
     tag_migration.source_description ] do %>
 <% end %>
 
 <% if tag_migration.should_delete_source_link? %>
   <%= content_tag(
     :p,
-    I18n.t('views.tag_migrations.move_message', taxon_name: current_tagged_taxon),
-    class: 'alert alert-danger'
+    I18n.t("views.tag_migrations.move_message", taxon_name: current_tagged_taxon),
+    class: "alert alert-danger",
   ) %>
 <% end %>
 
 <% if tag_migration.ready_to_import? %>
-  <%= link_to t('bulk_tagging.start_tagging'),
+  <%= link_to t("bulk_tagging.start_tagging"),
     tag_migration_publish_tags_path(tag_migration),
     method: :post,
     class: "btn btn-lg btn-success" %>

--- a/app/views/tagging_history/_user_filter.html.erb
+++ b/app/views/tagging_history/_user_filter.html.erb
@@ -1,12 +1,12 @@
 <%= form_tag(tagging_history_index_path, method: "get") do %>
   <div class="input-group add-top-margin" style="min-width: 30em;">
     <%= select_tag :users,
-                   options_from_collection_for_select(User.all, 'uid', 'name', params[:users]),
+                   options_from_collection_for_select(User.all, "uid", "name", params[:users]),
                    multiple: true,
                    placeholder: "Filter by user",
-                   class: ['select2', 'form-control'] %>
+                   class: %w[select2 form-control] %>
     <span class="input-group-btn">
-      <%= submit_tag "Filter", class: 'btn btn-default' %>
+      <%= submit_tag "Filter", class: "btn btn-default" %>
     </span>
   </div>
 <% end %>

--- a/app/views/tagging_history/index.html.erb
+++ b/app/views/tagging_history/index.html.erb
@@ -13,7 +13,7 @@
       <th>User</th>
     </tr>
 
-    <%= render partial: 'shared/table_filter' %>
+    <%= render partial: "shared/table_filter" %>
     </thead>
 
     <tbody>

--- a/app/views/tagging_history/show.html.erb
+++ b/app/views/tagging_history/show.html.erb
@@ -16,14 +16,14 @@
       <th>User</th>
     </tr>
 
-    <%= render partial: 'shared/table_filter' %>
+    <%= render partial: "shared/table_filter" %>
     </thead>
 
     <tbody>
     <% link_changes.changes.each do |link_change| %>
       <tr>
         <td><%= time_ago_in_words(link_change[:created_at]) %> ago</td>
-        <td class="<%= link_change[:change] == 'remove' ? 'bg-danger' : 'bg-success' %>">
+        <td class="<%= link_change[:change] == "remove" ? "bg-danger" : "bg-success" %>">
           <% if link_change[:change] == 'remove' %>
             Untagged
           <% else %>

--- a/app/views/tagging_spreadsheets/index.html.erb
+++ b/app/views/tagging_spreadsheets/index.html.erb
@@ -1,12 +1,12 @@
 <%= display_header(
-      title: t('navigation.tag_importer'),
+      title: t("navigation.tag_importer"),
       breadcrumbs: [
-        link_to(I18n.t('navigation.bulk_tag'), new_bulk_tag_path),
-        t('navigation.tag_importer')
-      ]
+        link_to(I18n.t("navigation.bulk_tag"), new_bulk_tag_path),
+        t("navigation.tag_importer"),
+      ],
     ) do %>
 
-  <%= link_to I18n.t('tag_import.upload_sheet'), new_tagging_spreadsheet_path, class: 'btn btn-default' %>
+  <%= link_to I18n.t("tag_import.upload_sheet"), new_tagging_spreadsheet_path, class: "btn btn-default" %>
 <% end %>
 
 <table class="table queries-list table-bordered table-striped" data-module="filterable-table">
@@ -19,7 +19,7 @@
       <th></th>
       <th></th>
     </tr>
-    <%= render partial: 'shared/table_filter' %>
+    <%= render partial: "shared/table_filter" %>
   </thead>
   <tbody>
     <% page.spreadsheets.each do |spreadsheet| %>
@@ -28,7 +28,7 @@
           <%=
             state_label_for(
               label_type: spreadsheet.label_type,
-              title: spreadsheet.state_title
+              title: spreadsheet.state_title,
             )
           %>
         </td>
@@ -39,13 +39,13 @@
           <%= time_tag_for(spreadsheet.created_at) %>
         </td>
         <td>
-          <%= spreadsheet.added_by.present? ? spreadsheet.added_by.name : "unknown user"  %>
+          <%= spreadsheet.added_by.present? ? spreadsheet.added_by.name : "unknown user" %>
         </td>
         <td>
           <%= link_to "View", tagging_spreadsheet_path(spreadsheet) %>
         </td>
         <td>
-          <%= link_to I18n.t('tag_import.delete'),
+          <%= link_to I18n.t("tag_import.delete"),
             tagging_spreadsheet_path(spreadsheet),
             method: :delete,
             class: "btn btn-danger btn-sm" %>

--- a/app/views/tagging_spreadsheets/new.html.erb
+++ b/app/views/tagging_spreadsheets/new.html.erb
@@ -1,8 +1,8 @@
-<%= display_header title: I18n.t('tag_import.upload_sheet'),
+<%= display_header title: I18n.t("tag_import.upload_sheet"),
   breadcrumbs: [
-    link_to(I18n.t('navigation.bulk_tag'), new_bulk_tag_path),
-    link_to(I18n.t('navigation.tag_importer'), tagging_spreadsheets_path),
-    I18n.t('tag_import.upload_sheet')
+    link_to(I18n.t("navigation.bulk_tag"), new_bulk_tag_path),
+    link_to(I18n.t("navigation.tag_importer"), tagging_spreadsheets_path),
+    I18n.t("tag_import.upload_sheet"),
   ] %>
 
 <div class="row">
@@ -10,15 +10,15 @@
     <%= simple_form_for tagging_spreadsheet, url: tagging_spreadsheets_path do |f| %>
       <div class="form-group">
         <%= f.input :url,
-          input_html: { type: :text, class: 'form-control' },
-          label: I18n.t('tag_import.sheet_url') %>
-        <%= f.input :description, input_html: { class: 'form-control' } %>
+          input_html: { type: :text, class: "form-control" },
+          label: I18n.t("tag_import.sheet_url") %>
+        <%= f.input :description, input_html: { class: "form-control" } %>
 
-        <%= f.submit I18n.t('tag_import.upload'), class: "btn btn-lg btn-success" %>
+        <%= f.submit I18n.t("tag_import.upload"), class: "btn btn-lg btn-success" %>
       </div>
     <% end %>
   </div>
   <div class="col-md-4">
-    <%= render 'shared/help', example_spreadsheet: "https://docs.google.com/spreadsheets/d/1CkmNClwusFBfhMRcE2wEO96RgAi85WrukdQKRDlVuos/pub" %>
+    <%= render "shared/help", example_spreadsheet: "https://docs.google.com/spreadsheets/d/1CkmNClwusFBfhMRcE2wEO96RgAi85WrukdQKRDlVuos/pub" %>
   </div>
 </div>

--- a/app/views/tagging_spreadsheets/show.html.erb
+++ b/app/views/tagging_spreadsheets/show.html.erb
@@ -1,9 +1,9 @@
 <%= display_header title: tagging_spreadsheet.description, breadcrumbs: [:tagging_spreadsheets, "Preview"] do %>
-  <%= link_to I18n.t('tag_import.refresh'), tagging_spreadsheet_refetch_path(tagging_spreadsheet), method: :post, class: "btn btn-md btn-default" %>
+  <%= link_to I18n.t("tag_import.refresh"), tagging_spreadsheet_refetch_path(tagging_spreadsheet), method: :post, class: "btn btn-md btn-default" %>
 <% end %>
 
   <p>
-    <%= link_to I18n.t('tag_import.start_tagging'), tagging_spreadsheet_publish_tags_path(tagging_spreadsheet), method: :post, class: "btn btn-lg btn-success" %>
+    <%= link_to I18n.t("tag_import.start_tagging"), tagging_spreadsheet_publish_tags_path(tagging_spreadsheet), method: :post, class: "btn btn-lg btn-success" %>
   </p>
 
 <% if tagging_spreadsheet.state == "errored" %>
@@ -13,7 +13,7 @@
   </p>
 <% end %>
 <div class='view-on-site'>
-  <%= link_to "View on Google Docs", tagging_spreadsheet.url, target: "_blank" %>
+  <%= link_to "View on Google Docs", tagging_spreadsheet.url, target: "_blank", rel: "noopener" %>
 </div>
 
 <%= render "tag_update_preview",

--- a/app/views/taggings/_form_for_ordered_related_items.html.erb
+++ b/app/views/taggings/_form_for_ordered_related_items.html.erb
@@ -5,7 +5,7 @@
             data-module="related-content-tagger">
     <ul class="sortable-list select2-choices ui-sortable sortable-inputs">
       <% tagging_update.ordered_related_items.each do |base_path| %>
-        <%= render 'tagging_entry',
+        <%= render "tagging_entry",
           base_path: base_path,
           is_template: false,
           link_type: :ordered_related_items,
@@ -15,8 +15,8 @@
 
     <% # Hidden, empty tag used by JS to asynchronously render the related item template %>
     <div class="related-item-template hide">
-      <%= render 'tagging_entry',
-        base_path: '',
+      <%= render "tagging_entry",
+        base_path: "",
         is_template: true,
         link_type: :ordered_related_items,
         tagging_update: tagging_update

--- a/app/views/taggings/_form_for_ordered_related_items_overrides.html.erb
+++ b/app/views/taggings/_form_for_ordered_related_items_overrides.html.erb
@@ -5,7 +5,7 @@
             data-module="related-content-tagger">
     <ul class="sortable-list select2-choices ui-sortable sortable-inputs">
       <% tagging_update.ordered_related_items_overrides.each do |base_path| %>
-        <%= render 'tagging_entry',
+        <%= render "tagging_entry",
           base_path: base_path,
           is_template: false,
           link_type: :ordered_related_items_overrides,
@@ -15,8 +15,8 @@
 
     <% # Hidden, empty tag used by JS to asynchronously render the related item template %>
     <div class="related-item-template hide">
-      <%= render 'tagging_entry',
-        base_path: '',
+      <%= render "tagging_entry",
+        base_path: "",
         is_template: true,
         link_type: :ordered_related_items_overrides,
         tagging_update: tagging_update

--- a/app/views/taggings/_form_for_suggested_ordered_related_items.html.erb
+++ b/app/views/taggings/_form_for_suggested_ordered_related_items.html.erb
@@ -5,7 +5,7 @@
             data-module="related-content-tagger">
     <ul class="sortable-list select2-choices ui-sortable sortable-inputs">
       <% tagging_update.suggested_ordered_related_items.each do |base_path| %>
-        <%= render 'tagging_entry',
+        <%= render "tagging_entry",
                    base_path: base_path,
                    is_template: false,
                    link_type: :suggested_ordered_related_items,

--- a/app/views/taggings/_tagging_entry.html.erb
+++ b/app/views/taggings/_tagging_entry.html.erb
@@ -19,7 +19,7 @@
     </div>
   <% end %>
 
-  <div class="related-item value <%= tagging_update.get_errors_for(link_type)[base_path] ? 'has-error' : '' %>">
+  <div class="related-item value <%= tagging_update.get_errors_for(link_type)[base_path] ? "has-error" : "" %>">
     <%= text_field_tag "tagging_tagging_update_form[#{link_type.to_s}][]",
                        base_path,
                        class: "form-control related-item-path" %>

--- a/app/views/taggings/_tagging_form.html.erb
+++ b/app/views/taggings/_tagging_form.html.erb
@@ -1,4 +1,4 @@
-<%= simple_form_for tagging_update, url: tagging_path, method: 'put' do |f| %>
+<%= simple_form_for tagging_update, url: tagging_path, method: "put" do |f| %>
   <%= f.hidden_field :content_id %>
   <%= f.hidden_field :previous_version %>
 
@@ -7,12 +7,12 @@
       <%= render "form_for_#{tag_type}", {
         f: f,
         linkables: tagging_update.linkables,
-        tagging_update: tagging_update
+        tagging_update: tagging_update,
       } %>
     </div>
   <% end %>
 
   <hr/>
 
-  <%= f.submit I18n.t('taggings.update_tags'), class: "btn btn-lg btn-success" %>
+  <%= f.submit I18n.t("taggings.update_tags"), class: "btn btn-lg btn-success" %>
 <% end %>

--- a/app/views/taggings/item_not_found.html.erb
+++ b/app/views/taggings/item_not_found.html.erb
@@ -1,4 +1,4 @@
-<%= display_header title: "Page not found", breadcrumbs: ["Tagging"] %>
+<%= display_header title: "Page not found", breadcrumbs: %w[Tagging] %>
 
 <p class='lead'>
   Sorry, that content item wasn't found. <%= link_to "Try searching again", lookup_taggings_path %>.

--- a/app/views/taggings/lookup.html.erb
+++ b/app/views/taggings/lookup.html.erb
@@ -1,5 +1,5 @@
-<%= display_header title: t('navigation.tagging_title'),
-  breadcrumbs: [t('navigation.tagging_content')] %>
+<%= display_header title: t("navigation.tagging_title"),
+  breadcrumbs: [t("navigation.tagging_content")] %>
 
 <div class="lead">
   Enter the URL or path of a GOV.UK page to edit its tagging or related links.
@@ -10,12 +10,12 @@
     <%= f.input :base_path,
       label: false,
       required: false,
-      input_html: { class: 'form-control' }
+      input_html: { class: "form-control" }
     %>
 
     For example: <%= link_to "https://www.gov.uk/pay-vat", "/taggings/lookup/pay-vat" %>
     or <%= link_to "/bank-holidays", "/taggings/lookup/bank-holidays" %>
   </div>
 
-  <%= submit_tag I18n.t('taggings.search'), class: 'btn btn-success btn-md' %>
+  <%= submit_tag I18n.t("taggings.search"), class: "btn btn-success btn-md" %>
 <% end %>

--- a/app/views/taggings/show.html.erb
+++ b/app/views/taggings/show.html.erb
@@ -1,16 +1,16 @@
 <%= display_header title: "Add or remove tags from #{tagging_update.content_item.title}",
-  breadcrumbs: [link_to(t('navigation.tagging_content'), lookup_taggings_path), tagging_update.content_item] %>
+  breadcrumbs: [link_to(t("navigation.tagging_content"), lookup_taggings_path), tagging_update.content_item] %>
 
 <div class='view-on-site'>
-  View on site: <%= link_to tagging_update.content_item.base_path, website_url(tagging_update.content_item.base_path), target: "_blank" %>
+  View on site: <%= link_to tagging_update.content_item.base_path, website_url(tagging_update.content_item.base_path), target: "_blank", rel: "noopener" %>
 </div>
 
 <hr/>
 
 <%= render(
-  partial: 'tagging_form',
+  partial: "tagging_form",
   locals: {
     tagging_update: tagging_update,
-  }
+  },
 )
 %>

--- a/app/views/taxon_migrations/new.html.erb
+++ b/app/views/taxon_migrations/new.html.erb
@@ -2,15 +2,15 @@
   title: "Move content from #{source_content_item.document_type.humanize.downcase} '#{source_content_item.title}'",
   breadcrumbs: [
     link_to(source_content_item.title, taxon_path(source_content_item.content_id)),
-    "Move content from '#{source_content_item.title}'"
-  ]
+    "Move content from '#{source_content_item.title}'",
+  ],
 ) %>
 
 <%= simple_form_for tag_migration, url: taxon_migrations_path, method: :post do |f| %>
   <%= render(
-    'shared/tag_migration_form',
+    "shared/tag_migration_form",
     f: f,
     taxons: taxons,
-    expanded_links: expanded_links
+    expanded_links: expanded_links,
   ) %>
 <% end %>

--- a/app/views/taxonomy/health_warnings/index.html.erb
+++ b/app/views/taxonomy/health_warnings/index.html.erb
@@ -41,7 +41,7 @@
       <th>Warning message</th>
     </tr>
 
-    <%= render partial: 'shared/table_filter' %>
+    <%= render partial: "shared/table_filter" %>
     </thead>
 
     <tbody>

--- a/app/views/taxons/_form_fields.html.erb
+++ b/app/views/taxons/_form_fields.html.erb
@@ -1,51 +1,51 @@
 <div data-module="parent-taxon-prefix-preview">
-  <%= f.input :parent_content_id, collection: page.taxons_for_select, label: 'Parent',
-    input_html: { class: 'js-parent-taxon form-control', include_blank: true } %>
+  <%= f.input :parent_content_id, collection: page.taxons_for_select, label: "Parent",
+    input_html: { class: "js-parent-taxon form-control", include_blank: true } %>
 
   <% if page.show_url_override_input_field? %>
-    <%= f.input :url_override, input_html: { class: 'form-control' },
-      label: I18n.t('views.taxons.url_override'),
-      hint: I18n.t('views.taxons.url_override_hint') %>
+    <%= f.input :url_override, input_html: { class: "form-control" },
+      label: I18n.t("views.taxons.url_override"),
+      hint: I18n.t("views.taxons.url_override_hint") %>
   <% end %>
   <% if page.show_url_override? %>
     <label>URL override</label>
     <p class="help-block"><%= page.url_override %></p>
   <% end %>
 
-  <%= f.input :base_path, input_html: { class: 'form-control' },
-    placeholder: 'e.g. /highest-level-taxon-name/taxon-name' %>
+  <%= f.input :base_path, input_html: { class: "form-control" },
+    placeholder: "e.g. /highest-level-taxon-name/taxon-name" %>
 
   <div class="alert alert-warning js-path-prefix-hint hidden"></div>
 </div>
 
-<%= f.input :internal_name, input_html: { class: 'form-control' },
-  label: I18n.t('views.taxons.internal_name'),
-  hint: I18n.t('views.taxons.internal_name_hint') %>
+<%= f.input :internal_name, input_html: { class: "form-control" },
+  label: I18n.t("views.taxons.internal_name"),
+  hint: I18n.t("views.taxons.internal_name_hint") %>
 
-<%= f.input :title, input_html: { class: 'form-control' },
-  label: I18n.t('views.taxons.external_name'),
-  hint: I18n.t('views.taxons.displayed_on_govuk') %>
+<%= f.input :title, input_html: { class: "form-control" },
+  label: I18n.t("views.taxons.external_name"),
+  hint: I18n.t("views.taxons.displayed_on_govuk") %>
 
 <%= f.input :description,
   as: :text,
-  hint: I18n.t('views.taxons.displayed_on_govuk'),
-  input_html: { class: 'form-control' } %>
+  hint: I18n.t("views.taxons.displayed_on_govuk"),
+  input_html: { class: "form-control" } %>
 
 <% if page.show_visibilty_checkbox? %>
   <%= f.input :visible_to_departmental_editors,
     as: :boolean,
-    input_html: { class: 'form-control' },
-    checked_value: 'true',
-    label: I18n.t('views.taxons.visible_to_departmental_editors'),
-    hint: I18n.t('views.taxons.visible_to_departmental_editors_hint')  %>
+    input_html: { class: "form-control" },
+    checked_value: "true",
+    label: I18n.t("views.taxons.visible_to_departmental_editors"),
+    hint: I18n.t("views.taxons.visible_to_departmental_editors_hint") %>
 <% end %>
 
 <%= f.input :phase,
       collection: %w[alpha beta live],
-      selected: page.taxon.phase || 'live',
-      input_html: { class: 'form-control' } %>
+      selected: page.taxon.phase || "live",
+      input_html: { class: "form-control" } %>
 
-<%= f.input :notes_for_editors, as: :text, input_html: { class: 'form-control' } %>
+<%= f.input :notes_for_editors, as: :text, input_html: { class: "form-control" } %>
 
 <%= f.input :associated_taxons,
     collection: page.taxons_for_select,
@@ -57,6 +57,6 @@
 
 <div class="form-group">
   <label class="control-label" for="version_note">Internal change note</label>
-  <%= text_area_tag :internal_change_note, nil, class: 'form-control' %>
+  <%= text_area_tag :internal_change_note, nil, class: "form-control" %>
   <p class="help-block">Displayed in Content Tagger</p>
 </div>

--- a/app/views/taxons/_list.html.erb
+++ b/app/views/taxons/_list.html.erb
@@ -24,7 +24,7 @@
   <%= render partial: "list_children",
              locals: {
                page: page,
-               children: [page.taxonomy_size.nested_tree]
+               children: [page.taxonomy_size.nested_tree],
              }
   %>
 </ul>

--- a/app/views/taxons/_tagged_content.html.erb
+++ b/app/views/taxons/_tagged_content.html.erb
@@ -8,7 +8,7 @@
         <th></th>
       </tr>
 
-      <%= render partial: 'shared/table_filter' %>
+      <%= render partial: "shared/table_filter" %>
     </thead>
 
     <tbody>
@@ -20,8 +20,8 @@
             <td>
               <%=
               link_to(
-                t('views.taxons.edit_tagging'),
-                tagging_url(content_item["content_id"])
+                t("views.taxons.edit_tagging"),
+                tagging_url(content_item["content_id"]),
               )
               %>
             </td>
@@ -29,9 +29,9 @@
           <td>
             <%=
               link_to(
-                t('views.taxons.view_similar'),
-                similar_search_results_url(content_item['base_path']),
-                target: 'blank'
+                t("views.taxons.view_similar"),
+                similar_search_results_url(content_item["base_path"]),
+                target: "blank",
               )
             %>
           </td>

--- a/app/views/taxons/confirm_bulk_publish.html.erb
+++ b/app/views/taxons/confirm_bulk_publish.html.erb
@@ -7,12 +7,12 @@
   topics appear to everyone on GOV.UK.
 </div>
 
-<%= render 'taxonomy_tree', page: page %>
+<%= render "taxonomy_tree", page: page %>
 
 <div class="confirmation-box">
   <%= button_to "Confirm publish",
   taxon_bulk_publish_path(page.taxon_content_id),
-  class: 'btn btn-lg btn-success' %>
+  class: "btn btn-lg btn-success" %>
 
 
   <%= link_to "Cancel", taxon_path(page.taxon_content_id), class: "cancel-link" %>

--- a/app/views/taxons/confirm_bulk_update.html.erb
+++ b/app/views/taxons/confirm_bulk_update.html.erb
@@ -1,4 +1,4 @@
-<%= form_tag(taxon_bulk_update_path, class: 'form-inline confirmation-box') do %>
+<%= form_tag(taxon_bulk_update_path, class: "form-inline confirmation-box") do %>
   <header class="heading-with-actions">
     <h1><%= page.title %></h1>
   </header>
@@ -6,7 +6,7 @@
   <div class="lead">
     <p>
       You are about to update the phase of this taxon and its children to
-      <%= select_tag 'taxon_phase', options_for_select(%w[alpha beta live], page.taxon.phase), class: 'form-control' %>.
+      <%= select_tag "taxon_phase", options_for_select(%w[alpha beta live], page.taxon.phase), class: "form-control" %>.
     </p>
 
     <p>
@@ -14,8 +14,8 @@
     </p>
   </div>
 
-  <%= submit_tag "Confirm bulk update", class: 'btn btn-lg btn-success' %>
+  <%= submit_tag "Confirm bulk update", class: "btn btn-lg btn-success" %>
   <%= link_to "Cancel", taxon_path(page.taxon_content_id), class: "cancel-link" %>
 
-  <%= render 'taxonomy_tree', page: page, hide_parents: true %>
+  <%= render "taxonomy_tree", page: page, hide_parents: true %>
 <% end %>

--- a/app/views/taxons/confirm_delete.html.erb
+++ b/app/views/taxons/confirm_delete.html.erb
@@ -1,14 +1,14 @@
-<h1><%= t('views.taxons.confirm_deletion_title') %> "<%= page.taxon.title %>"</h1>
+<h1><%= t("views.taxons.confirm_deletion_title") %> "<%= page.taxon.title %>"</h1>
 
-<div class="lead"><%= t('views.taxons.confirm_deletion_restore') %></div>
+<div class="lead"><%= t("views.taxons.confirm_deletion_restore") %></div>
 
 <% if page.tagged.any? || page.children.any? %>
 <div class="alert alert-warning clearfix" role="warning">
   <p>
-    <%= t('views.taxons.delete_warning_1') %>
+    <%= t("views.taxons.delete_warning_1") %>
     <ul>
-      <li><%= t('views.taxons.delete_warning_2') %></li>
-      <li><%= t('views.taxons.delete_warning_3') %></li>
+      <li><%= t("views.taxons.delete_warning_2") %></li>
+      <li><%= t("views.taxons.delete_warning_3") %></li>
     </ul>
   </p>
 </div>
@@ -17,15 +17,15 @@
 <%= simple_form_for page, url: taxon_path(page.taxon.content_id), method: :delete do |f| %>
   <%= f.input :redirect_to, collection: page.taxons_for_select,
     input_html: { class: :select2, multiple: false, include_blank: true } %>
-  <%= f.input :do_tag, as: :boolean, value: true, label: 'Tag content to parent?' %>
-  <%= f.button :button, class: 'btn btn-md btn-danger' do %>
+  <%= f.input :do_tag, as: :boolean, value: true, label: "Tag content to parent?" %>
+  <%= f.button :button, class: "btn btn-md btn-danger" do %>
     <span class="glyphicon glyphicon-trash"></span>
-    <span><%= t('views.taxons.confirm_deletion') %></span>
+    <span><%= t("views.taxons.confirm_deletion") %></span>
   <% end %>
 
-  <%= link_to taxon_path(page.taxon.content_id), class: 'btn btn-md btn-default' do %>
+  <%= link_to taxon_path(page.taxon.content_id), class: "btn btn-md btn-default" do %>
     <span>
-      <%= t('views.taxons.cancel_button') %>
+      <%= t("views.taxons.cancel_button") %>
     </span>
   <% end %>
 <% end %>
@@ -38,7 +38,7 @@
        <th>Taxon</th>
      </tr>
 
-     <%= render 'shared/table_filter' %>
+     <%= render "shared/table_filter" %>
    </thead>
 
    <tbody>
@@ -53,5 +53,5 @@
 
 <% if page.tagged.any? %>
   <h2>Tagged content</h2>
-  <%= render 'tagged_content', tagged: page.tagged %>
+  <%= render "tagged_content", tagged: page.tagged %>
 <% end %>

--- a/app/views/taxons/confirm_discard.html.erb
+++ b/app/views/taxons/confirm_discard.html.erb
@@ -10,7 +10,7 @@
   <%= button_to "Confirm delete",
   taxon_discard_draft_path(taxon.content_id),
   method: :delete,
-  class: 'btn btn-lg btn-success' %>
+  class: "btn btn-lg btn-success" %>
 
   <%= link_to "Cancel", taxon_path(taxon.content_id), class: "cancel-link" %>
 </div>

--- a/app/views/taxons/confirm_publish.html.erb
+++ b/app/views/taxons/confirm_publish.html.erb
@@ -10,7 +10,7 @@
 <div class="confirmation-box">
   <%= button_to "Confirm publish",
   taxon_publish_path(taxon.content_id),
-  class: 'btn btn-lg btn-success' %>
+  class: "btn btn-lg btn-success" %>
 
   <%= link_to "Cancel", taxon_path(taxon.content_id), class: "cancel-link" %>
 </div>

--- a/app/views/taxons/confirm_restore.html.erb
+++ b/app/views/taxons/confirm_restore.html.erb
@@ -1,11 +1,11 @@
-<h1><%= t('views.taxons.confirm_restore_title') %> "<%= page.title %>"</h1>
+<h1><%= t("views.taxons.confirm_restore_title") %> "<%= page.title %>"</h1>
 
-<div class="lead"><%= t('views.taxons.confirm_restore_redirect') %></div>
+<div class="lead"><%= t("views.taxons.confirm_restore_redirect") %></div>
 
 <div class="confirmation-box">
   <%= button_to "Confirm restore",
   taxon_restore_path(page.taxon_content_id),
-  class: 'btn btn-lg btn-success' %>
+  class: "btn btn-lg btn-success" %>
 
   <%= link_to "Cancel", taxon_path(page.taxon_content_id), class: "cancel-link" %>
 </div>

--- a/app/views/taxons/edit.html.erb
+++ b/app/views/taxons/edit.html.erb
@@ -4,7 +4,7 @@
 <%= simple_form_for page.taxon, url: taxon_path(page.taxon_content_id), method: :patch do |f| %>
   <%= f.hidden_field :content_id, value: page.taxon_content_id %>
 
-  <%= render 'form_fields', f: f, page: page %>
+  <%= render "form_fields", f: f, page: page %>
 
   <%= f.submit "Save draft", class: "btn btn-lg btn-success submit-button" %>
 <% end %>

--- a/app/views/taxons/history.html.erb
+++ b/app/views/taxons/history.html.erb
@@ -1,5 +1,5 @@
 <%= display_header title: page.title,
-      breadcrumbs: [:taxons, link_to(page.taxon.title, taxon_path(page.taxon.content_id)), 'History'] %>
+      breadcrumbs: [:taxons, link_to(page.taxon.title, taxon_path(page.taxon.content_id)), "History"] %>
 
 <% page.version_history.each do |version| %>
   <div class="well well-sm">

--- a/app/views/taxons/index.html.erb
+++ b/app/views/taxons/index.html.erb
@@ -1,37 +1,37 @@
-<%= display_header title: t("views.taxons.#{params[:action]}.title"), breadcrumbs: ['Taxons'] do %>
-  <%= link_to taxon_path(GovukTaxonomy::ROOT_CONTENT_ID), class: 'btn btn-md btn-default' do %>
+<%= display_header title: t("views.taxons.#{params[:action]}.title"), breadcrumbs: %w[Taxons] do %>
+  <%= link_to taxon_path(GovukTaxonomy::ROOT_CONTENT_ID), class: "btn btn-md btn-default" do %>
     View homepage taxon
   <% end %>
 
   <% if user_can_administer_taxonomy? %>
-    <%= link_to new_taxon_path, class: 'btn btn-default' do %>
+    <%= link_to new_taxon_path, class: "btn btn-default" do %>
       <i class="glyphicon glyphicon-plus"></i>
-        <%= I18n.t('views.taxons.add_taxon') %>
+        <%= I18n.t("views.taxons.add_taxon") %>
       </i>
     <% end %>
   <% end %>
 
-  <%= link_to download_taxons_path, class: 'btn btn-md btn-default' do %>
+  <%= link_to download_taxons_path, class: "btn btn-md btn-default" do %>
     <i class="glyphicon glyphicon-download-alt"></i>
     Download published taxons as CSV
   <% end %>
 <% end %>
 
 <ul class="nav nav-tabs">
-  <li role="presentation" class="<%= current_page?(taxons_path) ? "active" : nil%>"><%= link_to "Published", taxons_path(q: page.query) %></li>
-  <li role="presentation" class="<%= current_page?(drafts_taxons_path) ? "active" : nil%>"><%= link_to "Draft", drafts_taxons_path(q: page.query) %></li>
-  <li role="presentation" class="<%= current_page?(trash_taxons_path) ? "active" : nil%>"><%= link_to "Deleted", trash_taxons_path(q: page.query) %></li>
+  <li role="presentation" class="<%= current_page?(taxons_path) ? "active" : nil %>"><%= link_to "Published", taxons_path(q: page.query) %></li>
+  <li role="presentation" class="<%= current_page?(drafts_taxons_path) ? "active" : nil %>"><%= link_to "Draft", drafts_taxons_path(q: page.query) %></li>
+  <li role="presentation" class="<%= current_page?(trash_taxons_path) ? "active" : nil %>"><%= link_to "Deleted", trash_taxons_path(q: page.query) %></li>
 </ul>
 
-<%= simple_form_for :taxon_search, url: '', method: :get do |f| %>
+<%= simple_form_for :taxon_search, url: "", method: :get do |f| %>
   <div class="form-group">
     <%= f.input :query,
       input_html: {
         type: :text,
-        class: 'form-control input-lg',
+        class: "form-control input-lg",
         value: page.query,
-        name: 'q',
-        placeholder: t("views.taxons.index.search_placeholder")
+        name: "q",
+        placeholder: t("views.taxons.index.search_placeholder"),
       },
       label: false %>
     <%= f.submit "Search", class: "btn btn-lg btn-success" %>
@@ -55,11 +55,11 @@
           <span class="text-muted"><%= taxon.base_path %></span>
         </td>
         <td>
-          <%= link_to I18n.t('views.taxons.view'), taxon_path(taxon.content_id) %>
+          <%= link_to I18n.t("views.taxons.view"), taxon_path(taxon.content_id) %>
         </td>
       </tr>
     <% end %>
   </tbody>
 </table>
 
-<%= paginate page.search_results, theme: 'twitter-bootstrap-3' %>
+<%= paginate page.search_results, theme: "twitter-bootstrap-3" %>

--- a/app/views/taxons/new.html.erb
+++ b/app/views/taxons/new.html.erb
@@ -1,7 +1,7 @@
-<%= display_header title: I18n.t('views.taxons.new_title'),
-  breadcrumbs: [:taxons, I18n.t('views.taxons.new_breadcrumb')] %>
+<%= display_header title: I18n.t("views.taxons.new_title"),
+  breadcrumbs: [:taxons, I18n.t("views.taxons.new_breadcrumb")] %>
 
 <%= simple_form_for page.taxon, url: taxons_path do |f| %>
-  <%= render 'form_fields', f: f, page: page %>
-  <%= f.submit I18n.t('views.taxons.new_button'), class: "btn btn-lg btn-success" %>
+  <%= render "form_fields", f: f, page: page %>
+  <%= f.submit I18n.t("views.taxons.new_button"), class: "btn btn-lg btn-success" %>
 <% end %>

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -61,19 +61,19 @@
 
 <% unless page.unpublished? %>
   <p>
-    <%= link_to I18n.t('views.taxons.tagged_content'),
+    <%= link_to I18n.t("views.taxons.tagged_content"),
                 taxon_tagged_content_path(page.taxon_content_id) %>
   </p>
 <% end %>
 
 <p>
-  <%= link_to 'View taxon change history', taxon_history_path(page.taxon_content_id) %>
+  <%= link_to "View taxon change history", taxon_history_path(page.taxon_content_id) %>
 </p>
 
 <p>
   <%= link_to taxonomy_path(page.taxon_content_id, format: :csv), class: "btn btn-default" do %>
     <i class="glyphicon glyphicon-download-alt"></i>
-    <%= I18n.t('views.taxons.download_csv') %>
+    <%= I18n.t("views.taxons.download_csv") %>
   <% end %>
 </p>
 
@@ -92,14 +92,14 @@
 
         <% unless page.unpublished? %>
           <p>
-            <%= link_to I18n.t('views.taxons.edit'),
+            <%= link_to I18n.t("views.taxons.edit"),
                         edit_taxon_path(page.taxon_content_id),
                         class: "btn btn-default" %>
           </p>
         <% end %>
 
         <p>
-          <%= link_to I18n.t('views.taxons.add_child'),
+          <%= link_to I18n.t("views.taxons.add_child"),
           new_taxon_path(taxon: { parent_content_id: page.content_id }),
           class: "btn btn-default" %>
         </p>
@@ -108,25 +108,25 @@
           <p>
             <%= link_to "Unpublish",
                         taxon_confirm_delete_path(page.taxon_content_id),
-                        class: 'btn btn-danger add-top-margin' %>
+                        class: "btn btn-danger add-top-margin" %>
           </p>
         <% elsif page.draft? %>
           <p>
             <%= link_to "Publish",
                         taxon_confirm_publish_path(page.taxon_content_id),
-                        class: 'btn btn-default' %>
+                        class: "btn btn-default" %>
           </p>
 
           <p>
             <%= link_to "Discard draft",
                         taxon_confirm_discard_path(page.taxon_content_id),
-                        class: 'btn btn-danger add-top-margin' %>
+                        class: "btn btn-danger add-top-margin" %>
           </p>
         <% elsif page.unpublished? %>
           <p>
             <%= link_to "Restore to draft",
                         taxon_confirm_restore_path(page.taxon_content_id),
-                        class: 'btn btn-warning' %>
+                        class: "btn btn-warning" %>
           </p>
         <% end %>
       </li>
@@ -141,14 +141,14 @@
           <p>
             <%= link_to "Change phase for this taxon and its children",
                         taxon_confirm_bulk_update_path(page.taxon_content_id),
-                        class: 'btn btn-default' %>
+                        class: "btn btn-default" %>
           </p>
         <% end %>
 
         <p>
           <%= link_to "Publish tree",
                       taxon_confirm_bulk_publish_path(page.taxon_content_id),
-                      class: 'btn btn-default' %>
+                      class: "btn btn-default" %>
         </p>
       </li>
       <% end %>
@@ -161,7 +161,7 @@
     <div class="panel panel-default">
       <div class="panel-heading">
         <h2 class="panel-title">
-          <%= t('views.taxons.associated_taxons') %>
+          <%= t("views.taxons.associated_taxons") %>
         </h2>
       </div>
 
@@ -186,7 +186,7 @@
        aria-label="Taxonomy visualisations">
     <% TaxonsController::VISUALISATIONS.each do |viz| %>
       <a href="<%= taxon_path(params[:id], viz: viz) %>"
-         class="btn <%= viz == page.visualisation ? 'btn-primary' : 'btn-default' %>"
+         class="btn <%= viz == page.visualisation ? "btn-primary" : "btn-default" %>"
          role="button">
         <%= viz.titlecase %>
       </a>

--- a/app/views/taxons/tagged_content_page.html.erb
+++ b/app/views/taxons/tagged_content_page.html.erb
@@ -5,7 +5,7 @@
 
 <% unless page.unpublished? %>
   <% if user_can_administer_taxonomy? %>
-    <%= link_to taxon_download_tagged_path(page.taxon_content_id), class: 'btn btn-default' do %>
+    <%= link_to taxon_download_tagged_path(page.taxon_content_id), class: "btn btn-default" do %>
       <i class="glyphicon glyphicon-download-alt"></i>
       Download as CSV
     <% end %>
@@ -14,12 +14,12 @@
   <% if user_can_manage_taxonomy? %>
     <%= link_to "Move content",
                 new_taxon_migration_path(source_content_id: page.taxon_content_id),
-                class: 'btn btn-md btn-default' %>
+                class: "btn btn-md btn-default" %>
   <% end %>
 
-  <%= link_to I18n.t('views.taxons.tagging_history'),
+  <%= link_to I18n.t("views.taxons.tagging_history"),
               tagging_history_path(page.taxon_content_id),
-              class: "btn btn-default"%>
+              class: "btn btn-default" %>
 
   <div class="panel panel-default add-top-margin">
     <div class="panel-body">
@@ -31,7 +31,7 @@
   </div>
 
   <% if page.tagged.any? %>
-    <%= render 'tagged_content', tagged: page.tagged %>
+    <%= render "tagged_content", tagged: page.tagged %>
   <% else %>
     <p class="no-content no-content-bordered add-top-margin">
       No content tagged to this taxon

--- a/app/views/taxons/taxon_not_found.html.erb
+++ b/app/views/taxons/taxon_not_found.html.erb
@@ -1,4 +1,4 @@
-<%= display_header title: "Page not found", breadcrumbs: [t('navigation.taxons')] %>
+<%= display_header title: "Page not found", breadcrumbs: [t("navigation.taxons")] %>
 
 <p class='lead'>
   Sorry, that taxon wasn't found. <%= link_to "Try searching again", taxons_path %>.

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -53,6 +53,6 @@
       "note": "Safe because we control the URLs in the database."
     }
   ],
-  "updated": "2024-09-03 15:02:07 +0000",
+  "updated": "2024-09-04 10:33:57 +0000",
   "brakeman_version": "6.1.2"
 }

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -24,21 +24,35 @@
       "warning_code": 4,
       "fingerprint": "cebddc2d284fc2066c8b68b5212906cea4b93c9e015826350b21ef0417918c60",
       "check_name": "LinkToHref",
-      "message": "Potentially unsafe model attribute in link_to href",
+      "message": "Potentially unsafe model attribute in `link_to` href",
       "file": "app/views/projects/_content_item.html.erb",
       "line": 22,
       "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
       "code": "link_to((Unresolved Model).new.title, (Unresolved Model).new.url, :data => ({ :proxy_iframe => \"enabled\", :modal_url => (Unresolved Model).new.proxied_url, :toggle => \"modal\", :target => \"#iframe_modal_id\" }))",
-      "render_path": [{"type":"template","name":"projects/show","line":48,"file":"app/views/projects/show.html.erb"}],
+      "render_path": [
+        {
+          "type": "template",
+          "name": "projects/show",
+          "line": 48,
+          "file": "app/views/projects/show.html.erb",
+          "rendered": {
+            "name": "projects/_content_item",
+            "file": "app/views/projects/_content_item.html.erb"
+          }
+        }
+      ],
       "location": {
         "type": "template",
         "template": "projects/_content_item"
       },
       "user_input": "(Unresolved Model).new.url",
       "confidence": "Weak",
+      "cwe_id": [
+        79
+      ],
       "note": "Safe because we control the URLs in the database."
     }
   ],
-  "updated": "2018-08-02 08:11:26 +0100",
-  "brakeman_version": "4.3.1"
+  "updated": "2024-09-03 15:02:07 +0000",
+  "brakeman_version": "6.1.2"
 }

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,5 +1,6 @@
 desc "Run all linters"
 task lint: :environment do
+  sh "bundle exec erblint --lint-all"
   sh "bundle exec rubocop"
   sh "yarn run lint"
 end


### PR DESCRIPTION
Currently in most(may be all) of our app there is no linting mechanism for erb files. We want some way of linting erb files and hence we have introduced [erb_lint](https://rubygems.org/gems/erb_lint/versions/0.5.0?locale=en) gem for the same.

The changes in this PR allows us to have a workflow to run erb lint.
All the files that have been linted after running erblint.

When we run the command 'erblint --lint-all' it uses the default '.erb_lint.yml' file inside the project to apply any custom rules.

https://trello.com/c/NPZL0Ibg