### PR TITLE
Configure hosts for application

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -83,4 +83,12 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  # Enable DNS rebinding protection and other `Host` header attacks.
+  config.hosts = [
+    /content-tagger\..*gov.uk?/,
+  ]
+
+  # Skip DNS rebinding protection for the default health check endpoint.
+  config.host_authorization = { exclude: ->(request) { request.path.match?("^\/healthcheck") } }
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -86,7 +86,7 @@ Rails.application.configure do
 
   # Enable DNS rebinding protection and other `Host` header attacks.
   config.hosts = [
-    /content-tagger\..*gov.uk?/,
+    /content-tagger\..*\.gov.uk/,
   ]
 
   # Skip DNS rebinding protection for the default health check endpoint.


### PR DESCRIPTION
Note: the healthcheck endpoints are requested by IP, not domain, so we need to specifically exclude them from the protection.<br><br>[Trello card](https://trello.com/c/frqFN7D8)