### PR TITLE
Log number of taxons updated when country name is removed

### DIFF
--- a/lib/world_taxon_update_helper.rb
+++ b/lib/world_taxon_update_helper.rb
@@ -76,6 +76,7 @@ class WorldTaxonUpdateHelper
 
     log_rake_progress("Publishing all updated taxons")
     Taxonomy::BulkPublishTaxon.call(WORLD_ROOT_CONTENT_ID)
+    log_rake_progress("Total number of taxons updated - #{total_taxon_updates}")
   rescue StandardError => e
     log_rake_error("An error occurred while publishing taxons: #{e.full_message}")
   end


### PR DESCRIPTION
Improved logging for the clean up (`remove_country_names`)  method in order for us to monitor how many taxons are updated by the rake task which calls it. 

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
