### PR TITLE
Mount /component-guide

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -78,9 +78,10 @@ Rails.application.routes.draw do
 
   resources :tagging_history, only: %i[index show]
 
-  if Rails.env.development?
-    mount GovukAdminTemplate::Engine, at: "/style-guide"
+  mount GovukAdminTemplate::Engine, at: "/style-guide"
+  mount GovukPublishingComponents::Engine, at: "/component-guide"
 
+  if Rails.env.development?
     require "sidekiq/web"
     mount Sidekiq::Web => "/sidekiq"
   end


### PR DESCRIPTION
This should be enabled on every app which pulls in govuk_publishing_components.

Similarly, moves the (deprecated) govuk_admin_template `/style-guide` route out of the dev block so that it's available on production. It was decided in https://trello.com/c/ITcz5b1G/3417-enable-component-guide-on-non-dev-environments that there's no reason we need to lock this down to dev env only.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
