### PR TITLE
Update dependency to solve security alert with `js-yaml`

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2177,13 +2177,13 @@ __metadata:
   linkType: hard
 
 "js-yaml@npm:^4.1.0":
-  version: 4.1.1
-  resolution: "js-yaml@npm:4.1.1"
+  version: 4.3.0
+  resolution: "js-yaml@npm:4.3.0"
   dependencies:
     argparse: ^2.0.1
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: ea2339c6930fe048ec31b007b3c90be2714ab3e7defcc2c27ebf30c74fd940358f29070b4345af0019ef151875bf3bc3f8644bea1bab0372652b5044813ac02d
+  checksum: 1268fb22ae8504646cedc0823c18816d4af056029578e855b9a4d3e19bcafc3e9ba9e391f70dea4a29b023bb09f23639766071199cb89e853266b90a6ec25f9a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Unlike other tools where we have been able to solve the dependency
by running a blanket update of `stylelint` and `standardx`, the
move to a much newer version of `yarn` means we have to be
more targeted in our approach.

This commit updates the problematic package directly with
`yarn up js-yaml -R`.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
